### PR TITLE
Fixes #4: adds workflow to verify source stable URL

### DIFF
--- a/.github/workflows/verify-source-url.yml
+++ b/.github/workflows/verify-source-url.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python CI
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ labeled ]
+
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'new-gtfs-source' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
+          sudo apt-get update
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Verify source url
+        uses: jitterbit/get-changed-files@v1
+        run: |
+          # stop the build if the source url submitted already exists on the database
+          for changed_file in ${{ steps.files.outputs.added_modified }}; do
+            python ./scripts/verify_source_url.py -f "$changed_file"
+          done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+backoff==1.11.1
+certifi==2021.5.30
+charset-normalizer==2.0.1
+idna==3.2
+mwoauth==0.3.7
+numpy==1.21.0
+oauthlib==3.1.1
+pandas==1.3.0
+PyJWT==1.7.1
+python-dateutil==2.8.2
+pytz==2021.1
+requests==2.26.0
+requests-oauthlib==1.3.0
+simplejson==3.17.3
+six==1.16.0
+urllib3==1.26.6
+wikibaseintegrator==0.10.0

--- a/scripts/verify_source_url.py
+++ b/scripts/verify_source_url.py
@@ -1,0 +1,85 @@
+from wikibaseintegrator import wbi_core
+from wikibaseintegrator.wbi_config import config as wbi_config
+from wikibaseintegrator.wbi_core import (
+    CorePropIntegrityException,
+    ManualInterventionReqException,
+)
+import os
+import argparse
+import json
+
+###############################################################################
+# This script verifies if a submitted source is using a stable URL already
+# present on the Mobility Database.
+# Made for Python 3.9. Requires the modules listed in requirements.txt.
+###############################################################################
+
+# Mobility Database constants
+SPARQL_BIGDATA_URL = "http://mobilitydatabase.org:8989/bigdata/sparql"
+API_URL = "http://mobilitydatabase.org/w/api.php"
+SVC_URL = "http://wikibase.svc"
+STABLE_URL = "stable_url"
+SOURCE_NAME = "source_name"
+STABLE_URL_PROPERTY = "P13"
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Script to verify source URL. Python 3.9.")
+    parser.add_argument(
+        "-f",
+        "--file-path",
+        action="store",
+        help="Path to the source file to read.",
+    )
+    args = parser.parse_args()
+
+    # Load Wikibase Integrator config
+    wbi_config["MEDIAWIKI_API_URL"] = API_URL
+    wbi_config["SPARQL_ENDPOINT_URL"] = SPARQL_BIGDATA_URL
+    wbi_config["WIKIBASE_URL"] = SVC_URL
+
+    with open(args.file_path, "r") as f:
+        source_json = json.load(f)
+
+    stable_url = source_json[STABLE_URL]
+    source_name = source_json[SOURCE_NAME]
+
+    try:
+        source_stable_url = wbi_core.Url(value=stable_url, prop_nr=STABLE_URL_PROPERTY)
+    except ValueError as ve:
+        print(f"url {stable_url} for source name {source_name} raised {ve}")
+        raise ve
+
+    core_props_data = [source_stable_url]
+
+    # An existing source entity is considered the same as the one processed
+    # if and only if their stable URLs are matching
+    # so the core properties threshold is 100%
+    core_props_threshold = 1.0
+
+    try:
+        source_entity = wbi_core.ItemEngine(
+            data=core_props_data,
+            core_props={
+                os.environ[STABLE_URL_PROPERTY],
+            },
+            core_prop_match_thresh=core_props_threshold,
+        )
+    except ManualInterventionReqException as mi:
+        print(
+            f"ManualInterventionReqException : a core property value exists for multiple source entities."
+        )
+        raise mi
+    except CorePropIntegrityException as cp:
+        print(
+            f"CorePropIntegrityException: a source entity exists with 1 of the core props value."
+        )
+        raise cp
+    except Exception as e:
+        print(f"Stable url : {stable_url} as core property raised {e}")
+        raise e
+
+    # If the source entity retrieved as already an item_id (entity id) value,
+    # then we raise an exception because a source already exists with the stable URL
+    if source_entity.item_id != "":
+        raise Exception(f"{source_entity.item_id} already exist with stable URL {stable_url}")


### PR DESCRIPTION
**Summary:**

Fixes #4: adds `verify_source_url.py`, `verify-source-url.yml` and `requirements.txt`

Implement
- the script `verify_source_url.py`
- the workflow `verify-source-url.yml`
- the file `requirements.txt`

**Expected behavior:** 

A PR made with the label `new-gtfs-source` should trigger the workflow, which will pass if the submitted source have an URL different from those on the Mobility Database, fail otherwise.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~