### PR TITLE
feat: Test the GTFS Schedule sources uniqueness

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,13 @@ import os
 from jsonschema import validate
 from tools.helpers import from_json
 from tools.operations import get_sources
-from tools.constants import GTFS, GTFS_SCHEDULES_SOURCE_SCHEMA_PATH_FROM_ROOT
+from tools.constants import (
+    GTFS,
+    GTFS_SCHEDULES_SOURCE_SCHEMA_PATH_FROM_ROOT,
+    MDB_SOURCE_ID,
+    URLS,
+    AUTO_DISCOVERY,
+)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 
@@ -14,3 +20,15 @@ def test_catalogs_static_gtfs_json_schema():
     schema = from_json(static_source_schema_path)
     for source in get_sources(data_type=GTFS):
         validate(instance=source, schema=schema)
+
+
+def test_catalogs_static_gtfs_source_ids_uniqueness():
+    source_ids = [source[MDB_SOURCE_ID] for source in get_sources(data_type=GTFS)]
+    assert len(set(source_ids)) == len(source_ids)
+
+
+def test_catalogs_static_gtfs_auto_discovery_urls_uniqueness():
+    auto_discovery_urls = [
+        source[URLS][AUTO_DISCOVERY] for source in get_sources(data_type=GTFS)
+    ]
+    assert len(set(auto_discovery_urls)) == len(auto_discovery_urls)


### PR DESCRIPTION
**Summary:**

Fixes #34: Integration tests to verify the uniqueness of the source id and the auto-discovery url across the sources

This PR updates the integration tests to check that the `mdb_source_id` and the `url.auto_discovery` properties are unique for each GTFS Schedule source.

Changes:

- `test_integration.py` is updated

**Expected behavior:** 

Same as before but with additional tests.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~