### PR TITLE
feat: Protect the sources from being overwritten

### DIFF
--- a/tools/operations.py
+++ b/tools/operations.py
@@ -67,6 +67,22 @@ def add_source(
             country_code=country_code,
             data_type=data_type,
         )
+
+        # Stop the process if adding the source will overwrite another one
+        source_path = os.path.join(
+            PROJECT_ROOT, data_type_map[PATH_FROM_ROOT], f"{mdb_source_id}.{JSON}"
+        )
+        if os.path.exists(source_path):
+            raise FileExistsError(
+                f"Exception occurred while adding the source. "
+                f"Impossible to add the source without overwriting an existing source.\n"
+                f'Another source exists with a MDB Source ID created from provider "{provider}", '
+                f'subdivision name "{subdivision_name}", country code "{country_code}" and '
+                f'data type "{data_type}".\n'
+                f"Please contact emma@mobilitydata.org for assistance.\n"
+            )
+
+        # Continue the process otherwise
         (
             minimum_latitude,
             maximum_latitude,


### PR DESCRIPTION
**Summary:**

Fixes #40: Protect sources from being overwritten by new sources.

This PR updates the `add_source` operation to raise an exception if a source already exists with the same MDB Source Id, which is used to name a source JSON file.

Changes:

- `operations.py` is updated

**Expected behavior:** 

If the MDB source ID generated for a new source is the same as that of another source, an exception will be thrown so that the JSON file of the latter is not overwritten (the MDB source ID is used as the file name). 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~