### PR TITLE
feat: Adds GTFS Realtime JSON schema

### DIFF
--- a/schemas/gtfs_realtime_source_schema.json
+++ b/schemas/gtfs_realtime_source_schema.json
@@ -4,8 +4,8 @@
   "type": "object",
   "properties": {
     "mdb_source_id": {
-      "type": "string",
-      "description": "Unique identifier following the structure: mdbsrc-datatype-provider-subdivision-name-country-code."
+      "type": "number",
+      "description": "Unique numerical identifier."
     },
     "data_type": {
       "type": "string",

--- a/schemas/gtfs_realtime_source_schema.json
+++ b/schemas/gtfs_realtime_source_schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "The GTFS Realtime source schema of the Mobility Catalogs.",
+  "type": "object",
+  "properties": {
+    "mdb_source_id": {
+      "type": "string",
+      "description": "Unique identifier following the structure: mdbsrc-datatype-provider-subdivision-name-country-code."
+    },
+    "data_type": {
+      "type": "string",
+      "description": "The data format that the source uses, e.g gtfs, gtfs-rt.",
+      "enum": ["gtfs-rt"]
+    },
+    "provider": {
+      "type": "string",
+      "description": "Name of the transit provider."
+    },
+    "name": {
+      "type": "string",
+      "description": "An optional description of the data source, e.g to specify if the data source is an aggregate of multiple providers, or which network is represented by the source."
+    },
+    "static_reference": {
+      "type": "string",
+      "description": "The unique identifier (mdb_source_id) of the GTFS Schedule static reference for this GTFS Realtime source. Although optional, if not provided, the location of this source will be set to unknown."
+    },
+    "urls": {
+      "type": "object",
+      "properties": {
+        "realtime_vehicle_positions": {
+          "type": "string",
+          "description": "URL that serves the Vehicle Positions entities for this GTFS Realtime source.",
+          "pattern": "^(http|https|ftp):\/\/[a-zA-Z0-9.,~#{}():&/%='?_/-]+$"
+        },
+        "realtime_trip_updates": {
+          "type": "string",
+          "description": "URL that serves the Trip Updates entities for this GTFS Realtime source.",
+          "pattern": "^(http|https|ftp):\/\/[a-zA-Z0-9.,~#{}():&/%='?_/-]+$"
+        },
+        "realtime_alerts": {
+          "type": "string",
+          "description": "URL that serves the Service Alerts entities for this GTFS Realtime source.",
+          "pattern": "^(http|https|ftp):\/\/[a-zA-Z0-9.,~#{}():&/%='?_/-]+$"
+        }
+      },
+      "anyOf": [{
+        "required" : ["realtime_vehicle_positions"]
+      }, {
+        "required" : ["realtime_trip_updates"]
+      }, {
+        "required" : ["realtime_alerts"]
+      }]
+    }
+  },
+  "required": ["mdb_source_id", "data_type", "provider", "urls"]
+}

--- a/schemas/gtfs_schedules_source_schema.json
+++ b/schemas/gtfs_schedules_source_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "The Mobility Catalogs static source schema.",
+  "title": "The GTFS Schedules source schema of the Mobility Catalogs.",
   "type": "object",
   "properties": {
     "mdb_source_id": {


### PR DESCRIPTION
**Summary:**

Fixes #38: Creating GTFS Realtime JSON schema

This PR adds the GTFS Realtime JSON schema as presented [here](https://docs.google.com/document/d/1Mlz3AXHItInitsOEAKKi8hZV9d3t3gpFbyIZGm67ESU/edit#heading=h.88f252jw0urf). It also updates the title of the GTFS Schedules JSON schema.

Implements:
- `gtfs_realtime_source_schema.json` with one URL per entity type and a static reference field to identify the GTFS Schedules source that the GTFS Realtime source references.

Changes:

- `gtfs_schedules_source_schema.json` title is updates to improve accuracy with the behavior.

**Expected behavior:** 

A GTFS Realtime source validated against the schema needs at least one of the 3 possible realtime URLs (`realtime_vehicle_positions`, `realtime_trip_updates`, `realtime_alerts`) and can have a static reference (optional).

Both examples are valid:
```
{
    "mdb_source_id": 1,
    "data_type": "gtfs-rt",
    "provider": "test",
    "name": "test",
    "static_reference": "test",
    "urls": {
      "realtime_vehicle_positions": "http://test.com",
      "realtime_trip_updates": "http://test.com",
      "realtime_alerts": "http://test.com",
    }
}
```
```
{
    "mdb_source_id": 1,
    "data_type": "gtfs-rt",
    "provider": "test",
    "name": "test",
    "urls": {
      "realtime_vehicle_positions": "http://test.com",
    }
}
```

Once flatten in the exported CSV, the `static_reference` could be replaced by the location information of the static reference, so it's easier for discoverability.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~