### PR TITLE
feat: Change providers to agencies

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -44,7 +44,7 @@ jobs:
               'location.country_code',
               'location.subdivision_name',
               'location.municipality',
-              'provider',
+              'agency',
               'name',
               'static_reference',
               'urls.auto_discovery',

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ The easiest way to add a GTFS Schedule source is to use the operation `tools.ope
 
 ```
 >>> add_gtfs_schedule_source(
-        provider=$YOUR_SOURCE_PROVIDER_NAME,
+        agency=$YOUR_SOURCE_AGENCY_NAME,
         country_code=$YOUR_SOURCE_COUNTRY_CODE,
         subdivision_name=$YOUR_SOURCE_SUBDIVISION_NAME,
         municipality=$YOUR_SOURCE_MUNICIPALITY,
@@ -61,7 +61,7 @@ The easiest way to add a GTFS Realtime source is to use the operation `tools.ope
 
 ```
 >>> add_gtfs_realtime_source(
-        provider=$YOUR_SOURCE_PROVIDER_NAME,
+        agency=$YOUR_SOURCE_AGENCY_NAME,
         static_reference=$OPTIONAL_STATIC_REFERENCE_NUMERICAL_ID,
         vehicle_positions_url=$OPTIONAL_VEHICLE_POSITIONS_URL,
         trip_updates_url=$OPTIONAL_TRIP_UPDATES_URL,
@@ -73,12 +73,12 @@ The easiest way to add a GTFS Realtime source is to use the operation `tools.ope
 #### Update a GTFS Schedule source
 The easiest way to update a GTFS Schedule source is to use the operation `tools.operations.update_gtfs_schedule_source` through the Python interpreter or in your scripts.
 
-Note that only the parameters for which the provided value will differ from the default value `None` will be updated. Only the following parameters can be updated: `provider`, `name`, `country_code`, `subdivision_name`, `municipality`, `auto_discovery_url` and `license_url`.
+Note that only the parameters for which the provided value will differ from the default value `None` will be updated. Only the following parameters can be updated: `agency`, `name`, `country_code`, `subdivision_name`, `municipality`, `auto_discovery_url` and `license_url`.
 
 ```
 >>> update_gtfs_schedule_source(
         mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
-        provider=$OPTIONAL_SOURCE_PROVIDER_NAME,
+        agency=$OPTIONAL_SOURCE_AGENCY_NAME,
         name=$OPTIONAL_SOURCE_NAME,
         country_code=$OPTIONAL_SOURCE_COUNTRY_CODE,
         subdivision_name=$OPTIONAL_SOURCE_SUBDIVISION_NAME,
@@ -91,12 +91,12 @@ Note that only the parameters for which the provided value will differ from the 
 #### Update a GTFS Realtime source
 The easiest way to update a GTFS Realtime source is to use the operation `tools.operations.update_gtfs_realtime_source` through the Python interpreter or in your scripts.
 
-Note that only the parameters for which the provided value will differ from the default value `None` will be updated. Only the following parameters can be updated: `provider`, `name`, `static_reference`, `vehicle_positions_url`, `trip_updates_url` and `service_alerts_url`.
+Note that only the parameters for which the provided value will differ from the default value `None` will be updated. Only the following parameters can be updated: `agency`, `name`, `static_reference`, `vehicle_positions_url`, `trip_updates_url` and `service_alerts_url`.
 
 ```
 >>> update_gtfs_realtime_source(
         mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
-        provider=$OPTIONAL_SOURCE_PROVIDER_NAME,
+        agency=$OPTIONAL_SOURCE_AGENCY_NAME,
         static_reference=$OPTIONAL_STATIC_REFERENCE_NUMERICAL_ID,
         vehicle_positions_url=$OPTIONAL_VEHICLE_POSITIONS_URL,
         trip_updates_url=$OPTIONAL_TRIP_UPDATES_URL,

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Contains the JSON schemas used to validate the sources in the integration tests.
 | Country Code       | Yes                   | ISO 3166-1 alpha-2 code designating the country where the system is located. For a list of valid codes [see here](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes).                                                    |   |   |
 | Subdivision name   | Yes                   | ISO 3166-2 subdivision name designating the subdivision (e.g province, state, region) where the system is located. For a list of valid names [see here](https://unece.org/trade/uncefact/unlocode-country-subdivisions-iso-3166-2).              |   |   |
 | Municipality       | Yes                   | Primary municipality in which the transit system is located.                                                                                                        |   |   |
-| Provider           | Yes                   | Name of the transit provider.                                                                                                                                       |   |   |
-| Name               | Optional              | An optional description of the data source, e.g to specify if the data source is an aggregate of multiple providers, or which network is represented by the source. |   |   |
+| Agency           | Yes                   | Name of the transit agency.                                                                                                                                       |   |   |
+| Name               | Optional              | An optional description of the data source, e.g to specify if the data source is an aggregate of information from multiple agencies, or which network is represented by the source. |   |   |
 | Auto-Discovery URL | Yes                   | URL that automatically opens the source.                                                                                                                            |   |   |
 | Latest dataset URL | No - system generated | A stable URL for the latest dataset of a source.                                                                                                                    |   |   |
-| License URL        | Optional              | The transit provider’s license information.                                                                                                                         |   |   |
+| License URL        | Optional              | The transit agency’s license information.                                                                                                                         |   |   |
 | Bounding box       | No - system generated | This is the bounding box of the data source when it was first added to the catalog. It includes the date and timestamp the bounding box was extracted on in UTC.       |   |   |
 
 ## GTFS Realtime Data Structure
@@ -55,13 +55,13 @@ Contains the JSON schemas used to validate the sources in the integration tests.
 |:------------------:|:---------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------:
 | MDB Source ID      | No - system generated | Unique numerical identifier.      |   |   |
 | Data Type          | Yes                   | The data format that the source uses: GTFS_RT.                                                                                                            |   |   |
-| Provider           | Yes                   | Name of the transit provider.                                                                                                                                       |   |   |
-| Name               | Optional              | An optional description of the data source, e.g to specify if the data source is an aggregate of multiple providers, or which network is represented by the source. |   |   |
+| Agency           | Yes                   | Name of the transit agency.                                                                                                                                       |   |   |
+| Name               | Optional              | An optional description of the data source, e.g to specify if the data source is an aggregate of information from multiple agencies, or which network is represented by the source. |   |   |
 | Static Reference | Optional                   | The MDB ID of the GTFS Schedule source associated with the Realtime source. If this is not provided, the country code, subdivision, and municipality will display as "Unknown" in the CSV export. The bounding box will appear blank. If the MDB ID of the GTFS Schedule source is provided, the country code, subdivision, municipality and bounding box fields will match the information in the static reference.                                                                                                                  |   |   |
 | Vehicle Positions URL | Optional | The Vehicle Positions URL.                                                                                                                   |   |   |
 | Trip Updates URL | Optional | The Trip Updates URL.                                                                                                                   |   |   |
 | Service Alerts URL | Optional | The Service Alerts URL.                                                                                                                   |   |   |
-| License URL        | Optional              | The transit provider’s license information.                                                                                                                         |   |   |
+| License URL        | Optional              | The transit agency’s license information.                                                                                                                         |   |   |
 
 ## Installation
 
@@ -157,7 +157,7 @@ To get the sources by bounding box, where `$MINIMUM_LATITUDE` `$MAXIMUM_LATITUDE
 To add a new GTFS Schedule source:
 ```
 >>> add_gtfs_schedule_source(
-        provider=$YOUR_SOURCE_PROVIDER_NAME,
+        agency=$YOUR_SOURCE_AGENCY_NAME,
         country_code=$YOUR_SOURCE_COUNTRY_CODE,
         subdivision_name=$YOUR_SOURCE_SUBDIVISION_NAME,
         municipality=$YOUR_SOURCE_MUNICIPALITY,
@@ -170,7 +170,7 @@ To add a new GTFS Schedule source:
 To add a new GTFS Realtime source:
 ```
 >>> add_gtfs_realtime_source(
-        provider=$YOUR_SOURCE_PROVIDER_NAME,
+        agency=$YOUR_SOURCE_AGENCY_NAME,
         static_reference=$OPTIONAL_STATIC_REFERENCE_NUMERICAL_ID,
         vehicle_positions_url=$OPTIONAL_VEHICLE_POSITIONS_URL,
         trip_updates_url=$OPTIONAL_TRIP_UPDATES_URL,
@@ -183,7 +183,7 @@ To update a GTFS Schedule source:
 ```
 >>> update_gtfs_schedule_source(
         mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
-        provider=$OPTIONAL_SOURCE_PROVIDER_NAME,
+        agency=$OPTIONAL_SOURCE_AGENCY_NAME,
         name=$OPTIONAL_SOURCE_NAME,
         country_code=$OPTIONAL_SOURCE_COUNTRY_CODE,
         subdivision_name=$OPTIONAL_SOURCE_SUBDIVISION_NAME,
@@ -198,7 +198,7 @@ To update a GTFS Realtime source:
 ```
 >>> update_gtfs_realtime_source(
         mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
-        provider=$OPTIONAL_SOURCE_PROVIDER_NAME,
+        agency=$OPTIONAL_SOURCE_AGENCY_NAME,
         static_reference=$OPTIONAL_STATIC_REFERENCE_NUMERICAL_ID,
         vehicle_positions_url=$OPTIONAL_VEHICLE_POSITIONS_URL,
         trip_updates_url=$OPTIONAL_TRIP_UPDATES_URL,
@@ -216,7 +216,7 @@ In order to avoid invalid sources in the Mobility Database Catalogs, any modific
 
 Code licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
 
-Individual transit data sources are subject to the terms & conditions of their own respective data provider. If you are a transit provider and there is a data source that should not be included in the repository, please contact emma@mobilitydata.org and we'll remove it as soon as possible.
+Individual transit data sources are subject to the terms & conditions of their own respective data provider. If you are a transit agency and there is a data source that should not be included in the repository, please contact emma@mobilitydata.org and we'll remove it as soon as possible.
 
 ## Contributing
 

--- a/catalogs/sources/gtfs/realtime/ca-ontario-barrie-transit-gtfs_rt-4.json
+++ b/catalogs/sources/gtfs/realtime/ca-ontario-barrie-transit-gtfs_rt-4.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 4,
     "data_type": "gtfs_rt",
-    "provider": "Barrie Transit",
+    "agency": "Barrie Transit",
     "name": "Barrie Transit GTFS Realtime",
     "static_reference": 3,
     "urls": {

--- a/catalogs/sources/gtfs/schedule/ca-ontario-barrie-transit-gtfs-3.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-barrie-transit-gtfs-3.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 3,
     "data_type": "gtfs",
-    "provider": "Barrie Transit",
+    "agency": "Barrie Transit",
     "name": "Barrie Transit GTFS Schedule source",
     "location": {
         "country_code": "CA",

--- a/catalogs/sources/gtfs/schedule/ca-ontario-london-transit-commission-gtfs-2.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-london-transit-commission-gtfs-2.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 2,
     "data_type": "gtfs",
-    "provider": "London Transit Commission",
+    "agency": "London Transit Commission",
     "name": "London Transit Commission GTFS Source",
     "location": {
         "country_code": "CA",

--- a/catalogs/sources/gtfs/schedule/us-maine-casco-bay-lines-gtfs-1.json
+++ b/catalogs/sources/gtfs/schedule/us-maine-casco-bay-lines-gtfs-1.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 1,
     "data_type": "gtfs",
-    "provider": "Casco Bay Lines",
+    "agency": "Casco Bay Lines",
     "name": "Casco Bay Lines GTFS Schedule source",
     "location": {
         "country_code": "US",

--- a/schemas/gtfs_realtime_source_schema.json
+++ b/schemas/gtfs_realtime_source_schema.json
@@ -12,9 +12,9 @@
       "description": "The data format that the source uses, e.g gtfs, gtfs_rt.",
       "enum": ["gtfs_rt"]
     },
-    "provider": {
+    "agency": {
       "type": "string",
-      "description": "Name of the transit provider."
+      "description": "Name of the transit agency."
     },
     "name": {
       "type": "string",
@@ -52,5 +52,5 @@
       }]
     }
   },
-  "required": ["mdb_source_id", "data_type", "provider", "urls"]
+  "required": ["mdb_source_id", "data_type", "agency", "urls"]
 }

--- a/schemas/gtfs_schedule_source_schema.json
+++ b/schemas/gtfs_schedule_source_schema.json
@@ -12,9 +12,9 @@
       "description": "The data format that the source uses, e.g gtfs, gtfs-rt.",
       "enum": ["gtfs"]
     },
-    "provider": {
+    "agency": {
       "type": "string",
-      "description": "Name of the transit provider."
+      "description": "Name of the transit agency."
     },
     "name": {
       "type": "string",
@@ -116,5 +116,5 @@
       "required": ["auto_discovery", "latest"]
     }
   },
-  "required": ["mdb_source_id", "data_type", "provider", "location", "urls"]
+  "required": ["mdb_source_id", "data_type", "agency", "location", "urls"]
 }

--- a/tools/constants.py
+++ b/tools/constants.py
@@ -7,7 +7,9 @@ STOP_LAT = "stop_lat"
 STOP_LON = "stop_lon"
 
 # FILENAME TEMPLATE
-MDB_SOURCE_FILENAME = "{country_code}-{subdivision_name}-{provider}-{data_type}-{mdb_source_id}.{extension}"
+MDB_SOURCE_FILENAME = (
+    "{country_code}-{subdivision_name}-{agency}-{data_type}-{mdb_source_id}.{extension}"
+)
 
 # ARCHIVES TEMPLATE
 MDB_ARCHIVES_LATEST_URL_TEMPLATE = (
@@ -38,7 +40,7 @@ GTFS_REALTIME_SOURCE_SCHEMA_PATH_FROM_ROOT = "schemas/gtfs_realtime_source_schem
 # GTFS SCHEDULE & REALTIME CONSTANTS
 MDB_SOURCE_ID = "mdb_source_id"
 DATA_TYPE = "data_type"
-PROVIDER = "provider"
+AGENCY = "agency"
 NAME = "name"
 LOCATION = "location"
 COUNTRY_CODE = "country_code"

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -124,11 +124,9 @@ def is_readable(url, load_func):
 #########################
 
 
-def create_latest_url(
-    country_code, subdivision_name, provider, data_type, mdb_source_id
-):
+def create_latest_url(country_code, subdivision_name, agency, data_type, mdb_source_id):
     """Creates the latest url for a MDB Source.
-    :param provider: The name of the entity.
+    :param agency: The agency of the entity.
     :param subdivision_name: The subdivision name of the entity.
     :param country_code: The country code of the entity.
     :param data_type: The data type of the entity.
@@ -139,7 +137,7 @@ def create_latest_url(
         filename=create_filename(
             country_code=country_code,
             subdivision_name=subdivision_name,
-            provider=provider,
+            agency=agency,
             data_type=data_type,
             mdb_source_id=mdb_source_id,
             extension=ZIP,
@@ -148,10 +146,10 @@ def create_latest_url(
 
 
 def create_filename(
-    country_code, subdivision_name, provider, data_type, mdb_source_id, extension
+    country_code, subdivision_name, agency, data_type, mdb_source_id, extension
 ):
     """Creates the latest url for a MDB Source.
-    :param provider: The name of the entity.
+    :param agency: The name of the entity.
     :param subdivision_name: The subdivision name of the entity.
     :param country_code: The country code of the entity.
     :param data_type: The data type of the entity.
@@ -162,7 +160,7 @@ def create_filename(
     return MDB_SOURCE_FILENAME.format(
         country_code=normalize(country_code),
         subdivision_name=normalize(subdivision_name),
-        provider=normalize(provider),
+        agency=normalize(agency),
         data_type=data_type,
         mdb_source_id=mdb_source_id,
         extension=extension,

--- a/tools/operations.py
+++ b/tools/operations.py
@@ -3,7 +3,7 @@ from tools.constants import (
     GTFS,
     GTFS_RT,
     NAME,
-    PROVIDER,
+    AGENCY,
     COUNTRY_CODE,
     SUBDIVISION_NAME,
     MUNICIPALITY,
@@ -29,7 +29,7 @@ ALL_MAP = {CATALOGS: ["GtfsScheduleSourcesCatalog", "GtfsRealtimeSourcesCatalog"
 
 
 def add_gtfs_realtime_source(
-    provider,
+    agency,
     static_reference=None,
     vehicle_positions_url=None,
     trip_updates_url=None,
@@ -39,7 +39,7 @@ def add_gtfs_realtime_source(
     """Add a new GTFS Realtime source to the Mobility Catalogs."""
     catalog = GtfsRealtimeSourcesCatalog()
     data = {
-        PROVIDER: provider,
+        AGENCY: agency,
         STATIC_REFERENCE: static_reference,
         REALTIME_VEHICLE_POSITIONS: vehicle_positions_url,
         REALTIME_TRIP_UPDATES: trip_updates_url,
@@ -52,7 +52,7 @@ def add_gtfs_realtime_source(
 
 def update_gtfs_realtime_source(
     mdb_source_id,
-    provider=None,
+    agency=None,
     static_reference=None,
     vehicle_positions_url=None,
     trip_updates_url=None,
@@ -63,7 +63,7 @@ def update_gtfs_realtime_source(
     catalog = GtfsRealtimeSourcesCatalog()
     data = {
         MDB_SOURCE_ID: mdb_source_id,
-        PROVIDER: provider,
+        AGENCY: agency,
         STATIC_REFERENCE: static_reference,
         REALTIME_VEHICLE_POSITIONS: vehicle_positions_url,
         REALTIME_TRIP_UPDATES: trip_updates_url,
@@ -75,7 +75,7 @@ def update_gtfs_realtime_source(
 
 
 def add_gtfs_schedule_source(
-    provider,
+    agency,
     country_code,
     subdivision_name,
     municipality,
@@ -86,7 +86,7 @@ def add_gtfs_schedule_source(
     """Add a new GTFS Schedule source to the Mobility Catalogs."""
     catalog = GtfsScheduleSourcesCatalog()
     data = {
-        PROVIDER: provider,
+        AGENCY: agency,
         COUNTRY_CODE: country_code,
         SUBDIVISION_NAME: subdivision_name,
         MUNICIPALITY: municipality,
@@ -100,7 +100,7 @@ def add_gtfs_schedule_source(
 
 def update_gtfs_schedule_source(
     mdb_source_id,
-    provider=None,
+    agency=None,
     name=None,
     country_code=None,
     subdivision_name=None,
@@ -112,7 +112,7 @@ def update_gtfs_schedule_source(
     catalog = GtfsScheduleSourcesCatalog()
     data = {
         MDB_SOURCE_ID: mdb_source_id,
-        PROVIDER: provider,
+        AGENCY: agency,
         COUNTRY_CODE: country_code,
         SUBDIVISION_NAME: subdivision_name,
         MUNICIPALITY: municipality,

--- a/tools/representations.py
+++ b/tools/representations.py
@@ -17,7 +17,7 @@ from tools.constants import (
     GTFS_REALTIME_CATALOG_PATH,
     MDB_SOURCE_ID,
     DATA_TYPE,
-    PROVIDER,
+    AGENCY,
     NAME,
     LOCATION,
     COUNTRY_CODE,
@@ -203,7 +203,7 @@ class Source(ABC):
     def __init__(self, **kwargs):
         self.mdb_source_id = kwargs.pop(MDB_SOURCE_ID)
         self.data_type = kwargs.pop(DATA_TYPE)
-        self.provider = kwargs.pop(PROVIDER)
+        self.agency = kwargs.pop(AGENCY)
         self.name = kwargs.pop(NAME, None)
         self.filename = kwargs.pop(FILENAME)
 
@@ -273,7 +273,7 @@ class GtfsScheduleSource(Source):
         attributes = {
             MDB_SOURCE_ID: self.mdb_source_id,
             DATA_TYPE: self.data_type,
-            PROVIDER: self.provider,
+            AGENCY: self.agency,
             NAME: self.name,
             COUNTRY_CODE: self.country_code,
             SUBDIVISION_NAME: self.subdivision_name,
@@ -328,9 +328,9 @@ class GtfsScheduleSource(Source):
                 self.bbox_max_lon,
             ) = extract_gtfs_bounding_box(url=auto_discovery_url)
             self.bbox_extracted_on = get_iso_time()
-        provider = kwargs.get(PROVIDER)
-        if provider is not None:
-            self.provider = provider
+        agency = kwargs.get(AGENCY)
+        if agency is not None:
+            self.agency = agency
         name = kwargs.get(NAME)
         if name is not None:
             self.name = name
@@ -364,7 +364,7 @@ class GtfsScheduleSource(Source):
             filename = create_filename(
                 country_code=kwargs.get(COUNTRY_CODE),
                 subdivision_name=kwargs.get(SUBDIVISION_NAME),
-                provider=kwargs.get(PROVIDER),
+                agency=kwargs.get(AGENCY),
                 data_type=data_type,
                 mdb_source_id=kwargs.get(MDB_SOURCE_ID),
                 extension=JSON,
@@ -372,7 +372,7 @@ class GtfsScheduleSource(Source):
             latest = create_latest_url(
                 country_code=kwargs.get(COUNTRY_CODE),
                 subdivision_name=kwargs.get(SUBDIVISION_NAME),
-                provider=kwargs.get(PROVIDER),
+                agency=kwargs.get(AGENCY),
                 data_type=data_type,
                 mdb_source_id=kwargs.get(MDB_SOURCE_ID),
             )
@@ -394,7 +394,7 @@ class GtfsScheduleSource(Source):
         schema = {
             MDB_SOURCE_ID: kwargs.pop(MDB_SOURCE_ID),
             DATA_TYPE: kwargs.pop(DATA_TYPE),
-            PROVIDER: kwargs.pop(PROVIDER),
+            AGENCY: kwargs.pop(AGENCY),
             NAME: kwargs.pop(NAME, None),
             LOCATION: {
                 COUNTRY_CODE: kwargs.pop(COUNTRY_CODE),
@@ -436,7 +436,7 @@ class GtfsRealtimeSource(Source):
         attributes = {
             MDB_SOURCE_ID: self.mdb_source_id,
             DATA_TYPE: self.data_type,
-            PROVIDER: self.provider,
+            AGENCY: self.agency,
             NAME: self.name,
             STATIC_REFERENCE: self.static_reference,
             REALTIME_VEHICLE_POSITIONS: self.vehicle_positions_url,
@@ -491,9 +491,9 @@ class GtfsRealtimeSource(Source):
         return False
 
     def update(self, **kwargs):
-        provider = kwargs.get(PROVIDER)
-        if provider is not None:
-            self.provider = provider
+        agency = kwargs.get(AGENCY)
+        if agency is not None:
+            self.agency = agency
         name = kwargs.get(NAME)
         if name is not None:
             self.name = name
@@ -529,7 +529,7 @@ class GtfsRealtimeSource(Source):
         filename = create_filename(
             country_code=country_code,
             subdivision_name=subdivision_name,
-            provider=kwargs.get(PROVIDER),
+            agency=kwargs.get(AGENCY),
             data_type=data_type,
             mdb_source_id=kwargs.get(MDB_SOURCE_ID),
             extension=JSON,
@@ -543,7 +543,7 @@ class GtfsRealtimeSource(Source):
         schema = {
             MDB_SOURCE_ID: kwargs.pop(MDB_SOURCE_ID),
             DATA_TYPE: kwargs.pop(DATA_TYPE),
-            PROVIDER: kwargs.pop(PROVIDER),
+            AGENCY: kwargs.pop(AGENCY),
             NAME: kwargs.pop(NAME, None),
             STATIC_REFERENCE: kwargs.pop(STATIC_REFERENCE, None),
             URLS: {

--- a/tools/tests/test_helpers.py
+++ b/tools/tests/test_helpers.py
@@ -214,17 +214,17 @@ class TestCreationFunctions(TestCase):
 
     @patch("tools.helpers.create_filename")
     def test_create_latest_url(self, mock_filename):
-        mock_filename.return_value = "ca-some-subdivision-name-some-provider-gtfs-1.zip"
+        mock_filename.return_value = "ca-some-subdivision-name-some-agency-gtfs-1.zip"
         test_country_code = "CA"
         test_subdivision_name = "Some Subdivision Name"
-        test_provider = "Some Provider"
+        test_agency = "Some Agency"
         test_data_type = "gtfs"
         test_mdb_source_id = "1"
-        test_latest_url = "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-some-subdivision-name-some-provider-gtfs-1.zip?alt=media"
+        test_latest_url = "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-some-subdivision-name-some-agency-gtfs-1.zip?alt=media"
         under_test = create_latest_url(
             country_code=test_country_code,
             subdivision_name=test_subdivision_name,
-            provider=test_provider,
+            agency=test_agency,
             data_type=test_data_type,
             mdb_source_id=test_mdb_source_id,
         )
@@ -234,15 +234,15 @@ class TestCreationFunctions(TestCase):
     def test_create_filename(self):
         test_country_code = "CA"
         test_subdivision_name = "Some Subdivision Name"
-        test_provider = "Some Provider"
+        test_agency = "Some Agency"
         test_data_type = "gtfs"
         test_mdb_source_id = "1"
         test_extension = "zip"
-        test_filename = "ca-some-subdivision-name-some-provider-gtfs-1.zip"
+        test_filename = "ca-some-subdivision-name-some-agency-gtfs-1.zip"
         under_test = create_filename(
             country_code=test_country_code,
             subdivision_name=test_subdivision_name,
-            provider=test_provider,
+            agency=test_agency,
             data_type=test_data_type,
             mdb_source_id=test_mdb_source_id,
             extension=test_extension,

--- a/tools/tests/test_operations.py
+++ b/tools/tests/test_operations.py
@@ -18,14 +18,14 @@ from tools.operations import (
 class TestOperations(TestCase):
     @patch("tools.operations.GtfsRealtimeSourcesCatalog", autospec=True)
     def test_add_gtfs_realtime_source(self, mock_catalog):
-        test_provider = "test_provider"
+        test_agency = "test_agency"
         test_name = "test_name"
         test_static_reference = "test_static_reference"
         test_vehicle_positions_url = "test_vehicle_positions_url"
         test_trip_updates_url = "test_trip_updates_url"
         test_service_alerts_url = "test_service_alerts_url"
         under_test = add_gtfs_realtime_source(
-            provider=test_provider,
+            agency=test_agency,
             name=test_name,
             static_reference=test_static_reference,
             vehicle_positions_url=test_vehicle_positions_url,
@@ -39,7 +39,7 @@ class TestOperations(TestCase):
     @patch("tools.operations.GtfsRealtimeSourcesCatalog", autospec=True)
     def test_update_gtfs_realtime_source(self, mock_catalog):
         test_mdb_source_id = "test_mdb_source_id"
-        test_provider = "test_provider"
+        test_agency = "test_agency"
         test_name = "test_name"
         test_static_reference = "test_static_reference"
         test_vehicle_positions_url = "test_vehicle_positions_url"
@@ -47,7 +47,7 @@ class TestOperations(TestCase):
         test_service_alerts_url = "test_service_alerts_url"
         under_test = update_gtfs_realtime_source(
             mdb_source_id=test_mdb_source_id,
-            provider=test_provider,
+            agency=test_agency,
             name=test_name,
             static_reference=test_static_reference,
             vehicle_positions_url=test_vehicle_positions_url,
@@ -60,7 +60,7 @@ class TestOperations(TestCase):
 
     @patch("tools.operations.GtfsScheduleSourcesCatalog", autospec=True)
     def test_add_gtfs_schedule_source(self, mock_catalog):
-        test_provider = "test_provider"
+        test_agency = "test_agency"
         test_name = "test_name"
         test_country_code = "test_country_code"
         test_subdivision_name = "test_subdivision_name"
@@ -68,7 +68,7 @@ class TestOperations(TestCase):
         test_auto_discovery_url = "test_auto_discovery_url"
         test_license_url = "test_license_url"
         under_test = add_gtfs_schedule_source(
-            provider=test_provider,
+            agency=test_agency,
             name=test_name,
             country_code=test_country_code,
             subdivision_name=test_subdivision_name,
@@ -83,7 +83,7 @@ class TestOperations(TestCase):
     @patch("tools.operations.GtfsScheduleSourcesCatalog", autospec=True)
     def test_update_gtfs_schedule_source(self, mock_catalog):
         test_mdb_source_id = "test_mdb_source_id"
-        test_provider = "test_provider"
+        test_agency = "test_agency"
         test_name = "test_name"
         test_country_code = "test_country_code"
         test_subdivision_name = "test_subdivision_name"
@@ -92,7 +92,7 @@ class TestOperations(TestCase):
         test_license_url = "test_license_url"
         under_test = update_gtfs_schedule_source(
             mdb_source_id=test_mdb_source_id,
-            provider=test_provider,
+            agency=test_agency,
             name=test_name,
             country_code=test_country_code,
             subdivision_name=test_subdivision_name,

--- a/tools/tests/test_representations.py
+++ b/tools/tests/test_representations.py
@@ -13,7 +13,7 @@ from tools.representations import (
     PATH,
     MDB_SOURCE_ID,
     DATA_TYPE,
-    PROVIDER,
+    AGENCY,
     NAME,
     COUNTRY_CODE,
     SUBDIVISION_NAME,
@@ -281,7 +281,7 @@ class TestGtfsScheduleSource(TestCase):
         self.test_kwargs = {
             MDB_SOURCE_ID: self.test_mdb_source_id,
             DATA_TYPE: self.test_data_type,
-            PROVIDER: self.test_provider,
+            AGENCY: self.test_provider,
             NAME: self.test_name,
             FILENAME: self.test_filename,
             COUNTRY_CODE: self.test_country_code,
@@ -299,7 +299,7 @@ class TestGtfsScheduleSource(TestCase):
         self.test_schema = {
             MDB_SOURCE_ID: self.test_mdb_source_id,
             DATA_TYPE: self.test_data_type,
-            PROVIDER: self.test_provider,
+            AGENCY: self.test_provider,
             NAME: self.test_name,
             LOCATION: {
                 COUNTRY_CODE: self.test_country_code,
@@ -401,7 +401,7 @@ class TestGtfsScheduleSource(TestCase):
         self.assertEqual(under_test.bbox_min_lon, self.test_min_lon)
         self.assertEqual(under_test.bbox_max_lon, self.test_max_lon)
         self.assertEqual(under_test.bbox_extracted_on, self.test_extracted_on)
-        self.assertEqual(under_test.provider, self.test_provider)
+        self.assertEqual(under_test.agency, self.test_provider)
         self.assertEqual(under_test.name, self.test_name)
         self.assertEqual(under_test.country_code, self.test_country_code)
         self.assertEqual(under_test.subdivision_name, self.test_subdivision_name)
@@ -429,7 +429,7 @@ class TestGtfsScheduleSource(TestCase):
         mock_time.return_value = test_extracted_on
         under_test = instance.update(
             **{
-                PROVIDER: test_provider,
+                AGENCY: test_provider,
                 NAME: test_name,
                 AUTO_DISCOVERY: test_auto_discovery_url,
                 COUNTRY_CODE: test_country_code,
@@ -444,7 +444,7 @@ class TestGtfsScheduleSource(TestCase):
         self.assertEqual(under_test.bbox_min_lon, test_min_lon)
         self.assertEqual(under_test.bbox_max_lon, test_max_lon)
         self.assertEqual(under_test.bbox_extracted_on, test_extracted_on)
-        self.assertEqual(under_test.provider, test_provider)
+        self.assertEqual(under_test.agency, test_provider)
         self.assertEqual(under_test.name, test_name)
         self.assertEqual(under_test.country_code, test_country_code)
         self.assertEqual(under_test.subdivision_name, test_subdivision_name)
@@ -528,7 +528,7 @@ class TestGtfsRealtimeSource(TestCase):
         self.test_kwargs = {
             MDB_SOURCE_ID: self.test_mdb_source_id,
             DATA_TYPE: self.test_data_type,
-            PROVIDER: self.test_provider,
+            AGENCY: self.test_provider,
             NAME: self.test_name,
             FILENAME: self.test_filename,
             STATIC_REFERENCE: self.test_static_reference,
@@ -539,7 +539,7 @@ class TestGtfsRealtimeSource(TestCase):
         self.test_schema = {
             MDB_SOURCE_ID: self.test_mdb_source_id,
             DATA_TYPE: self.test_data_type,
-            PROVIDER: self.test_provider,
+            AGENCY: self.test_provider,
             NAME: self.test_name,
             STATIC_REFERENCE: self.test_static_reference,
             URLS: {
@@ -632,7 +632,7 @@ class TestGtfsRealtimeSource(TestCase):
     def test_update(self, mock_static_catalog):
         instance = GtfsRealtimeSource(filename=self.test_filename, **self.test_schema)
         under_test = instance.update(**{})
-        self.assertEqual(under_test.provider, self.test_provider)
+        self.assertEqual(under_test.agency, self.test_provider)
         self.assertEqual(under_test.name, self.test_name)
         self.assertEqual(under_test.static_reference, self.test_static_reference)
         self.assertEqual(
@@ -648,7 +648,7 @@ class TestGtfsRealtimeSource(TestCase):
         test_service_alerts_url = "another_service_alerts_url"
         under_test = instance.update(
             **{
-                PROVIDER: test_provider,
+                AGENCY: test_provider,
                 NAME: test_name,
                 STATIC_REFERENCE: test_static_reference,
                 REALTIME_VEHICLE_POSITIONS: test_vehicle_positions_url,
@@ -656,7 +656,7 @@ class TestGtfsRealtimeSource(TestCase):
                 REALTIME_ALERTS: test_service_alerts_url,
             }
         )
-        self.assertEqual(under_test.provider, test_provider)
+        self.assertEqual(under_test.agency, test_provider)
         self.assertEqual(under_test.name, test_name)
         self.assertEqual(under_test.static_reference, test_static_reference)
         self.assertEqual(under_test.vehicle_positions_url, test_vehicle_positions_url)


### PR DESCRIPTION
**Summary:**

Fixes #65: Change providers to agencies.

This PR updates the variables and constants referring to a transit `provider` so that they are now referring to a transit `agency`.

Changes:

- The sources are updated so the key `provider` is now `agency`.
- The schemas are updated.
- The documentation is updated.
- The `tools` module and the related tests are updates.
- The `export_to_csv.yml` workflow is updated.

**Expected behavior:** 

Same as before but with `agency` instead of `provider`. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~