### PR TITLE
fix: Cronjob workflow fails

### DIFF
--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -17,9 +17,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel numpy
-      - name: Get added and modified files
-        id: files
-        uses: jitterbit/get-changed-files@v1
       - name: Create URLs matrix with the auto-discovery and latest URLs
         shell: python
         run: |


### PR DESCRIPTION
**Summary:**

Fixes #68: Cronjob workflow fails.

This PR removes an unnecessary step in `store_latest_dataset_cronjob.yml`  that was causing the workflow to fail on `schedule` events.

Changes:
- `store_latest_dataset_cronjob.yml` is updated to remove the step causing the problem.

**Expected behavior:** 
The cronjob should run daily without failing.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~