### PR TITLE
feat: Add 100 sources of the first import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ar-buenos-aires-subterraneos-de-buenos-aires-subte-gtfs-6.json
+++ b/catalogs/sources/gtfs/schedule/ar-buenos-aires-subterraneos-de-buenos-aires-subte-gtfs-6.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 6,
     "data_type": "gtfs",
-    "provider": "Subterr\u00e1neos de Buenos Aires (SUBTE)",
+    "provider": "Subterráneos de Buenos Aires (SUBTE)",
     "location": {
         "country_code": "AR",
         "subdivision_name": "Buenos Aires",

--- a/catalogs/sources/gtfs/schedule/ar-buenos-aires-subterraneos-de-buenos-aires-subte-gtfs-6.json
+++ b/catalogs/sources/gtfs/schedule/ar-buenos-aires-subterraneos-de-buenos-aires-subte-gtfs-6.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 6,
+    "data_type": "gtfs",
+    "provider": "Subterr\u00e1neos de Buenos Aires (SUBTE)",
+    "location": {
+        "country_code": "AR",
+        "subdivision_name": "Buenos Aires",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-14T20:02:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://cdn.buenosaires.gob.ar/datosabiertos/datasets/sbase/subte-gtfs/subte-gtfs-zip.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ar-buenos-aires-subterraneos-de-buenos-aires-subte-gtfs-6.zip?alt=media",
+        "license": "https://data.buenosaires.gob.ar/dataset/subte-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-9.json
+++ b/catalogs/sources/gtfs/schedule/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-9.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 9,
+    "data_type": "gtfs",
+    "provider": "Empresa de Transportes e Transito de Belo Horizonte (BHTRANS)",
+    "location": {
+        "country_code": "BR",
+        "subdivision_name": "Minas Gerais ",
+        "municipality": "Belo Horizonte",
+        "bounding_box": {
+            "minimum_latitude": -20.0284450406583,
+            "maximum_latitude": -19.7762119628908,
+            "minimum_longitude": -44.0594627202399,
+            "maximum_longitude": -43.8624469938131,
+            "extracted_on": "2022-03-14T20:04:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ckan.pbh.gov.br/dataset/77764a7e-63fc-4111-ace3-fb7d3037953a/resource/f0fa78dc-74c3-49fa-8971-c310a76a07fa/download/gtfsfiles.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-9.zip?alt=media",
+        "license": "https://dados.pbh.gov.br/dataset/gtfs-estatico-do-sistema-convencional"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-9.json
+++ b/catalogs/sources/gtfs/schedule/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-9.json
@@ -4,7 +4,7 @@
     "provider": "Empresa de Transportes e Transito de Belo Horizonte (BHTRANS)",
     "location": {
         "country_code": "BR",
-        "subdivision_name": "Minas Gerais ",
+        "subdivision_name": "Minas Gerais",
         "municipality": "Belo Horizonte",
         "bounding_box": {
             "minimum_latitude": -20.0284450406583,

--- a/catalogs/sources/gtfs/schedule/br-rio-grande-do-sul-empresa-publica-de-transportes-e-circulacao-eptc-gtfs-7.json
+++ b/catalogs/sources/gtfs/schedule/br-rio-grande-do-sul-empresa-publica-de-transportes-e-circulacao-eptc-gtfs-7.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 7,
+    "data_type": "gtfs",
+    "provider": "Empresa Publica de Transportes e Circula\u00e7\u00e3o (EPTC)",
+    "location": {
+        "country_code": "BR",
+        "subdivision_name": "Rio Grande do Sul",
+        "municipality": "Porto Alegre",
+        "bounding_box": {
+            "minimum_latitude": -30.241904,
+            "maximum_latitude": -29.970497,
+            "minimum_longitude": -51.280762,
+            "maximum_longitude": -51.02079,
+            "extracted_on": "2022-03-14T20:03:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://dadosabertos.poa.br/dataset/1fe9c2c1-9fbe-48ea-841b-61e30597ecd6/resource/b3bce61f-78ee-49eb-be57-6236d82bd5e0/download/outputfiles.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/br-rio-grande-do-sul-empresa-publica-de-transportes-e-circulacao-eptc-gtfs-7.zip?alt=media",
+        "license": "http://datapoa.com.br/dataset/gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/br-rio-grande-do-sul-empresa-publica-de-transportes-e-circulacao-eptc-gtfs-7.json
+++ b/catalogs/sources/gtfs/schedule/br-rio-grande-do-sul-empresa-publica-de-transportes-e-circulacao-eptc-gtfs-7.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 7,
     "data_type": "gtfs",
-    "provider": "Empresa Publica de Transportes e Circula\u00e7\u00e3o (EPTC)",
+    "provider": "Empresa Publica de Transportes e Circulação (EPTC)",
     "location": {
         "country_code": "BR",
         "subdivision_name": "Rio Grande do Sul",

--- a/catalogs/sources/gtfs/schedule/br-sao-paulo-sao-paulo-transporte-sptrans-gtfs-8.json
+++ b/catalogs/sources/gtfs/schedule/br-sao-paulo-sao-paulo-transporte-sptrans-gtfs-8.json
@@ -1,11 +1,11 @@
 {
     "mdb_source_id": 8,
     "data_type": "gtfs",
-    "provider": "S\u00e3o Paulo Transporte (SPTrans)",
+    "provider": "São Paulo Transporte (SPTrans)",
     "location": {
         "country_code": "BR",
-        "subdivision_name": "S\u00e3o Paulo ",
-        "municipality": "S\u00e3o Paulo ",
+        "subdivision_name": "São Paulo ",
+        "municipality": "São Paulo ",
         "bounding_box": {
             "minimum_latitude": -23.911109,
             "maximum_latitude": -23.195643,

--- a/catalogs/sources/gtfs/schedule/br-sao-paulo-sao-paulo-transporte-sptrans-gtfs-8.json
+++ b/catalogs/sources/gtfs/schedule/br-sao-paulo-sao-paulo-transporte-sptrans-gtfs-8.json
@@ -4,8 +4,8 @@
     "provider": "São Paulo Transporte (SPTrans)",
     "location": {
         "country_code": "BR",
-        "subdivision_name": "São Paulo ",
-        "municipality": "São Paulo ",
+        "subdivision_name": "São Paulo",
+        "municipality": "São Paulo",
         "bounding_box": {
             "minimum_latitude": -23.911109,
             "maximum_latitude": -23.195643,

--- a/catalogs/sources/gtfs/schedule/br-sao-paulo-sao-paulo-transporte-sptrans-gtfs-8.json
+++ b/catalogs/sources/gtfs/schedule/br-sao-paulo-sao-paulo-transporte-sptrans-gtfs-8.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 8,
+    "data_type": "gtfs",
+    "provider": "S\u00e3o Paulo Transporte (SPTrans)",
+    "location": {
+        "country_code": "BR",
+        "subdivision_name": "S\u00e3o Paulo ",
+        "municipality": "S\u00e3o Paulo ",
+        "bounding_box": {
+            "minimum_latitude": -23.911109,
+            "maximum_latitude": -23.195643,
+            "minimum_longitude": -46.983928,
+            "maximum_longitude": -46.18493,
+            "extracted_on": "2022-03-14T20:03:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/blob/master/sao-paulo-sptrans.zip?raw=true",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/br-sao-paulo-sao-paulo-transporte-sptrans-gtfs-8.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-yuma-county-intergovernmental-public-transportation-authority-ycipta-gtfs-17.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-yuma-county-intergovernmental-public-transportation-authority-ycipta-gtfs-17.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 17,
+    "data_type": "gtfs",
+    "provider": "Yuma County Intergovernmental Public Transportation Authority (YCIPTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Yuma",
+        "bounding_box": {
+            "minimum_latitude": 32.484682743136176,
+            "maximum_latitude": 32.79171205546877,
+            "minimum_longitude": -115.56963801383972,
+            "maximum_longitude": -114.1335509410652,
+            "extracted_on": "2022-03-14T20:06:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.ycipta.org/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-yuma-county-intergovernmental-public-transportation-authority-ycipta-gtfs-17.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-airport-valet-express-gtfs-27.json
+++ b/catalogs/sources/gtfs/schedule/us-california-airport-valet-express-gtfs-27.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 27,
+    "data_type": "gtfs",
+    "provider": "Airport Valet Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Bakersfield",
+        "bounding_box": {
+            "minimum_latitude": 33.942609,
+            "maximum_latitude": 35.3533707819563,
+            "minimum_longitude": -119.062001238098,
+            "maximum_longitude": -118.398682,
+            "extracted_on": "2022-03-14T20:06:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/airportvaletexpress-ca-us/airportvaletexpress-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-airport-valet-express-gtfs-27.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-amador-transit-gtfs-92.json
+++ b/catalogs/sources/gtfs/schedule/us-california-amador-transit-gtfs-92.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 92,
+    "data_type": "gtfs",
+    "provider": "Amador Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Jackson",
+        "bounding_box": {
+            "minimum_latitude": 38.29376141,
+            "maximum_latitude": 38.57956697,
+            "minimum_longitude": -121.5038998,
+            "maximum_longitude": -120.512016,
+            "extracted_on": "2022-03-14T20:11:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/amador-ca-us/amador-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-amador-transit-gtfs-92.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-anaheim-resort-transportation-art-gtfs-100.json
+++ b/catalogs/sources/gtfs/schedule/us-california-anaheim-resort-transportation-art-gtfs-100.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 100,
+    "data_type": "gtfs",
+    "provider": "Anaheim Resort Transportation (ART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Anaheim",
+        "bounding_box": {
+            "minimum_latitude": 33.77473,
+            "maximum_latitude": 33.85486,
+            "minimum_longitude": -117.99815,
+            "maximum_longitude": -117.83989,
+            "extracted_on": "2022-03-14T20:12:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/anaheim-ca-us/anaheim-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-anaheim-resort-transportation-art-gtfs-100.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-arcata-mad-river-transit-system-gtfs-19.json
+++ b/catalogs/sources/gtfs/schedule/us-california-arcata-mad-river-transit-system-gtfs-19.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 19,
+    "data_type": "gtfs",
+    "provider": "Arcata & Mad River Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Arcata",
+        "bounding_box": {
+            "minimum_latitude": 40.0680453004959,
+            "maximum_latitude": 41.061448107054,
+            "minimum_longitude": -124.223416986081,
+            "maximum_longitude": -123.631606,
+            "extracted_on": "2022-03-14T20:06:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/humboldtcounty-ca-us/humboldtcounty-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-arcata-mad-river-transit-system-gtfs-19.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-avalon-transit-gtfs-12.json
+++ b/catalogs/sources/gtfs/schedule/us-california-avalon-transit-gtfs-12.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 12,
+    "data_type": "gtfs",
+    "provider": "Avalon Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Long Beach",
+        "bounding_box": {
+            "minimum_latitude": 33.3265468093768,
+            "maximum_latitude": 33.350836003873,
+            "minimum_longitude": -118.340356050519,
+            "maximum_longitude": -118.32185964799,
+            "extracted_on": "2022-03-14T20:04:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/avalon-ca-us/avalon-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-avalon-transit-gtfs-12.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-bay-area-rapid-transit-bart-gtfs-53.json
+++ b/catalogs/sources/gtfs/schedule/us-california-bay-area-rapid-transit-bart-gtfs-53.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 53,
+    "data_type": "gtfs",
+    "provider": "Bay Area Rapid Transit (BART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.368473,
+            "maximum_latitude": 38.01891,
+            "minimum_longitude": -122.468908,
+            "maximum_longitude": -121.780346,
+            "extracted_on": "2022-03-14T20:08:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.bart.gov/dev/schedules/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-bay-area-rapid-transit-bart-gtfs-53.zip?alt=media",
+        "license": "http://www.bart.gov/schedules/developers/developer-license-agreement"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-big-blue-bus-gtfs-37.json
+++ b/catalogs/sources/gtfs/schedule/us-california-big-blue-bus-gtfs-37.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 37,
+    "data_type": "gtfs",
+    "provider": "Big Blue Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Monica ",
+        "bounding_box": {
+            "minimum_latitude": 33.929498,
+            "maximum_latitude": 34.075669,
+            "minimum_longitude": -118.549205,
+            "maximum_longitude": -118.237266,
+            "extracted_on": "2022-03-14T20:07:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.bigbluebus.com/current.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-big-blue-bus-gtfs-37.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-big-blue-bus-gtfs-37.json
+++ b/catalogs/sources/gtfs/schedule/us-california-big-blue-bus-gtfs-37.json
@@ -5,7 +5,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
-        "municipality": "Santa Monica ",
+        "municipality": "Santa Monica",
         "bounding_box": {
             "minimum_latitude": 33.929498,
             "maximum_latitude": 34.075669,

--- a/catalogs/sources/gtfs/schedule/us-california-calaveras-transit-gtfs-93.json
+++ b/catalogs/sources/gtfs/schedule/us-california-calaveras-transit-gtfs-93.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 93,
+    "data_type": "gtfs",
+    "provider": "Calaveras Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Andreas",
+        "bounding_box": {
+            "minimum_latitude": 37.932161,
+            "maximum_latitude": 38.398985,
+            "minimum_longitude": -120.8387301,
+            "maximum_longitude": -120.347157,
+            "extracted_on": "2022-03-14T20:12:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/calaveras-ca-us/calaveras-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-calaveras-transit-gtfs-93.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-caltrain-gtfs-54.json
+++ b/catalogs/sources/gtfs/schedule/us-california-caltrain-gtfs-54.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 54,
+    "data_type": "gtfs",
+    "provider": "Caltrain",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.003485,
+            "maximum_latitude": 37.776404,
+            "minimum_longitude": -122.411709050687,
+            "maximum_longitude": -121.566088,
+            "extracted_on": "2022-03-14T20:08:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/caltrain-ca-us/caltrain-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-caltrain-gtfs-54.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-capitol-corridor-joint-powers-authority-capitol-corridor-gtfs-74.json
+++ b/catalogs/sources/gtfs/schedule/us-california-capitol-corridor-joint-powers-authority-capitol-corridor-gtfs-74.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 74,
+    "data_type": "gtfs",
+    "provider": "Capitol Corridor Joint Powers Authority (Capitol Corridor)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Oakland",
+        "bounding_box": {
+            "minimum_latitude": 37.329935,
+            "maximum_latitude": 39.099809,
+            "minimum_longitude": -122.410306,
+            "maximum_longitude": -120.952693,
+            "extracted_on": "2022-03-14T20:10:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.capitolcorridor.org/googletransit/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-capitol-corridor-joint-powers-authority-capitol-corridor-gtfs-74.zip?alt=media",
+        "license": "https://www.capitolcorridor.org/developer_resources/#terms"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-madera-gtfs-91.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-madera-gtfs-91.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 91,
     "data_type": "gtfs",
-    "provider": "City of Madera ",
+    "provider": "City of Madera",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-madera-gtfs-91.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-madera-gtfs-91.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 91,
+    "data_type": "gtfs",
+    "provider": "City of Madera ",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Madera",
+        "bounding_box": {
+            "minimum_latitude": 36.924336241916,
+            "maximum_latitude": 36.9830004943818,
+            "minimum_longitude": -120.103310277225,
+            "maximum_longitude": -119.99758478924,
+            "extracted_on": "2022-03-14T20:11:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cityofmadera-ca-us/cityofmadera-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-of-madera-gtfs-91.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-san-luis-obispo-transit-gtfs-44.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-san-luis-obispo-transit-gtfs-44.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 44,
+    "data_type": "gtfs",
+    "provider": "City of San Luis Obispo Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Luis Obispo",
+        "bounding_box": {
+            "minimum_latitude": 35.23933972,
+            "maximum_latitude": 35.302551,
+            "minimum_longitude": -120.70909948,
+            "maximum_longitude": -120.63319399,
+            "extracted_on": "2022-03-14T20:08:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://app.mecatran.com/urb/ws/feed/c2l0ZT1zbG90cmFuc2l0O2NsaWVudD1zZWxmO2V4cGlyZT07dHlwZT1ndGZzO2tleT0zZTMwMzM1OTRiMTE2NzA0N2IxNjQwNjA0ZjQwMGMzMzdiM2E1MTQ0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-of-san-luis-obispo-transit-gtfs-44.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-clovis-transit-gtfs-89.json
+++ b/catalogs/sources/gtfs/schedule/us-california-clovis-transit-gtfs-89.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 89,
+    "data_type": "gtfs",
+    "provider": "Clovis Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Clovis",
+        "bounding_box": {
+            "minimum_latitude": 36.7868979640758,
+            "maximum_latitude": 36.85201434,
+            "minimum_longitude": -119.754093,
+            "maximum_longitude": -119.660908,
+            "extracted_on": "2022-03-14T20:11:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/clovistransit-ca-us/clovistransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-clovis-transit-gtfs-89.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-commuteorg-san-mateo-county-shuttles-gtfs-61.json
+++ b/catalogs/sources/gtfs/schedule/us-california-commuteorg-san-mateo-county-shuttles-gtfs-61.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 61,
+    "data_type": "gtfs",
+    "provider": "Commute.org San Mateo County Shuttles",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Mateo",
+        "bounding_box": {
+            "minimum_latitude": 37.423779,
+            "maximum_latitude": 37.7211495911134,
+            "minimum_longitude": -122.469273263981,
+            "maximum_longitude": -122.142022,
+            "extracted_on": "2022-03-14T20:09:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/commute-ca-us/commute-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-commuteorg-san-mateo-county-shuttles-gtfs-61.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-corona-cruiser-gtfs-104.json
+++ b/catalogs/sources/gtfs/schedule/us-california-corona-cruiser-gtfs-104.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 104,
+    "data_type": "gtfs",
+    "provider": "Corona Cruiser",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Corona",
+        "bounding_box": {
+            "minimum_latitude": 33.813968645208,
+            "maximum_latitude": 33.8990059361134,
+            "minimum_longitude": -117.6013863782,
+            "maximum_longitude": -117.50625785349,
+            "extracted_on": "2022-03-14T20:12:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/corona-ca-us/corona-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-corona-cruiser-gtfs-104.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-culver-city-bus-gtfs-38.json
+++ b/catalogs/sources/gtfs/schedule/us-california-culver-city-bus-gtfs-38.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 38,
     "data_type": "gtfs",
-    "provider": "Culver City Bus ",
+    "provider": "Culver City Bus",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",

--- a/catalogs/sources/gtfs/schedule/us-california-culver-city-bus-gtfs-38.json
+++ b/catalogs/sources/gtfs/schedule/us-california-culver-city-bus-gtfs-38.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 38,
+    "data_type": "gtfs",
+    "provider": "Culver City Bus ",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Culver City",
+        "bounding_box": {
+            "minimum_latitude": 33.929593,
+            "maximum_latitude": 34.068294,
+            "minimum_longitude": -118.471525,
+            "maximum_longitude": -118.36869,
+            "extracted_on": "2022-03-14T20:07:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.culvercity.org/files/assets/public/documents/information-technology/maps/culvergtfs_06_01_2021.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-culver-city-bus-gtfs-38.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-eastern-sierra-transit-gtfs-25.json
+++ b/catalogs/sources/gtfs/schedule/us-california-eastern-sierra-transit-gtfs-25.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 25,
+    "data_type": "gtfs",
+    "provider": "Eastern Sierra Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Bishop",
+        "bounding_box": {
+            "minimum_latitude": 34.696209,
+            "maximum_latitude": 39.53475879,
+            "minimum_longitude": -119.818352,
+            "maximum_longitude": -115.908348,
+            "extracted_on": "2022-03-14T20:06:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/easternsierra-ca-us/easternsierra-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-eastern-sierra-transit-gtfs-25.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-el-monte-transit-gtfs-103.json
+++ b/catalogs/sources/gtfs/schedule/us-california-el-monte-transit-gtfs-103.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 103,
+    "data_type": "gtfs",
+    "provider": "El Monte Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "El Monte",
+        "bounding_box": {
+            "minimum_latitude": 34.043981602068,
+            "maximum_latitude": 34.09689398778,
+            "minimum_longitude": -118.0686841,
+            "maximum_longitude": -118.00382343434,
+            "extracted_on": "2022-03-14T20:12:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/elmonte-ca-us/elmonte-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-el-monte-transit-gtfs-103.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-emery-goround-gtfs-63.json
+++ b/catalogs/sources/gtfs/schedule/us-california-emery-goround-gtfs-63.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 63,
+    "data_type": "gtfs",
+    "provider": "Emery Go-Round",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Emeryville",
+        "bounding_box": {
+            "minimum_latitude": 37.829413295667,
+            "maximum_latitude": 37.8523174318222,
+            "minimum_longitude": -122.313441419571,
+            "maximum_longitude": -122.26671053997,
+            "extracted_on": "2022-03-14T20:09:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/emerygoround-ca-us/emerygoround-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-emery-goround-gtfs-63.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-etrans-gtfs-65.json
+++ b/catalogs/sources/gtfs/schedule/us-california-etrans-gtfs-65.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 65,
+    "data_type": "gtfs",
+    "provider": "eTrans",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Escalon",
+        "bounding_box": {
+            "minimum_latitude": 37.685265,
+            "maximum_latitude": 37.80286,
+            "minimum_longitude": -121.215854287148,
+            "maximum_longitude": -120.98274,
+            "extracted_on": "2022-03-14T20:09:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/escalon-ca-us/escalon-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-etrans-gtfs-65.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-fairfield-and-suisun-transit-fast-transit-gtfs-76.json
+++ b/catalogs/sources/gtfs/schedule/us-california-fairfield-and-suisun-transit-fast-transit-gtfs-76.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 76,
+    "data_type": "gtfs",
+    "provider": "Fairfield and Suisun Transit  (FAST Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Fairfield",
+        "bounding_box": {
+            "minimum_latitude": 37.9054783569681,
+            "maximum_latitude": 38.584657,
+            "minimum_longitude": -122.317048,
+            "maximum_longitude": -121.496009650077,
+            "extracted_on": "2022-03-14T20:11:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/fairfield-ca-us/fairfield-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-fairfield-and-suisun-transit-fast-transit-gtfs-76.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-foothill-transit-gtfs-101.json
+++ b/catalogs/sources/gtfs/schedule/us-california-foothill-transit-gtfs-101.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 101,
+    "data_type": "gtfs",
+    "provider": "Foothill Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Pasadena",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-14T20:12:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://foothilltransit.org/gtfs/foothilltransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-foothill-transit-gtfs-101.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-fresno-area-express-fax-gtfs-90.json
+++ b/catalogs/sources/gtfs/schedule/us-california-fresno-area-express-fax-gtfs-90.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 90,
+    "data_type": "gtfs",
+    "provider": "Fresno Area Express (FAX)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Fresno",
+        "bounding_box": {
+            "minimum_latitude": 36.681009,
+            "maximum_latitude": 36.888538,
+            "minimum_longitude": -119.908969,
+            "maximum_longitude": -119.677657,
+            "extracted_on": "2022-03-14T20:11:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gis4u.fresno.gov/downloads/fax_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-fresno-area-express-fax-gtfs-90.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-fresno-county-rural-transit-agency-fcrta-gtfs-85.json
+++ b/catalogs/sources/gtfs/schedule/us-california-fresno-county-rural-transit-agency-fcrta-gtfs-85.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 85,
+    "data_type": "gtfs",
+    "provider": "Fresno County Rural Transit Agency (FCRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Fresno",
+        "bounding_box": {
+            "minimum_latitude": 36.134471,
+            "maximum_latitude": 36.868542,
+            "minimum_longitude": -120.463387,
+            "maximum_longitude": -119.312622,
+            "extracted_on": "2022-03-14T20:11:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/fresnocounty-ca-us/fresnocounty-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-fresno-county-rural-transit-agency-fcrta-gtfs-85.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-gold-coast-transit-south-coast-area-transit-gtfs-32.json
+++ b/catalogs/sources/gtfs/schedule/us-california-gold-coast-transit-south-coast-area-transit-gtfs-32.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 32,
+    "data_type": "gtfs",
+    "provider": "Gold Coast Transit, South Coast Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Oxnard",
+        "bounding_box": {
+            "minimum_latitude": 34.14269871250784,
+            "maximum_latitude": 34.44820108297236,
+            "minimum_longitude": -119.30746185,
+            "maximum_longitude": -119.13247253857648,
+            "extracted_on": "2022-03-14T20:07:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.goldcoasttransit.org/images/GTFS/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-gold-coast-transit-south-coast-area-transit-gtfs-32.zip?alt=media",
+        "license": "http://www.goldcoasttransit.org/2-uncategorised/250-gtfs-data-download"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-golden-empire-transit-district-get-gtfs-46.json
+++ b/catalogs/sources/gtfs/schedule/us-california-golden-empire-transit-district-get-gtfs-46.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 46,
+    "data_type": "gtfs",
+    "provider": "Golden Empire Transit District (GET)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Bakersfield",
+        "bounding_box": {
+            "minimum_latitude": 34.976628,
+            "maximum_latitude": 35.447091,
+            "minimum_longitude": -119.145718,
+            "maximum_longitude": -118.91409,
+            "extracted_on": "2022-03-14T20:08:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://eta.getbus.org/rtt/public/utility/gtfs.aspx",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-golden-empire-transit-district-get-gtfs-46.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-golden-gate-transit-gtfs-67.json
+++ b/catalogs/sources/gtfs/schedule/us-california-golden-gate-transit-gtfs-67.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 67,
+    "data_type": "gtfs",
+    "provider": "Golden Gate Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.777609,
+            "maximum_latitude": 38.472081,
+            "minimum_longitude": -122.740448,
+            "maximum_longitude": -122.26649,
+            "extracted_on": "2022-03-14T20:10:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://realtime.goldengate.org/gtfsstatic/GTFSTransitData.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-golden-gate-transit-gtfs-67.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-grapeline-gtfs-83.json
+++ b/catalogs/sources/gtfs/schedule/us-california-grapeline-gtfs-83.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 83,
+    "data_type": "gtfs",
+    "provider": "GrapeLine",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Lodi",
+        "bounding_box": {
+            "minimum_latitude": 38.101806,
+            "maximum_latitude": 38.1457562509751,
+            "minimum_longitude": -121.309442,
+            "maximum_longitude": -121.252695,
+            "extracted_on": "2022-03-14T20:11:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.lodi.gov/DocumentCenter/View/2453/lodi_gtfs-ZIP",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-grapeline-gtfs-83.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-kern-transit-gtfs-47.json
+++ b/catalogs/sources/gtfs/schedule/us-california-kern-transit-gtfs-47.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 47,
+    "data_type": "gtfs",
+    "provider": "Kern Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Bakersfield",
+        "bounding_box": {
+            "minimum_latitude": 34.4136741299023,
+            "maximum_latitude": 35.77525384,
+            "minimum_longitude": -119.694137,
+            "maximum_longitude": -117.6462533,
+            "extracted_on": "2022-03-14T20:08:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/kerncounty-ca-us/kerncounty-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-kern-transit-gtfs-47.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-kings-area-rural-transit-gtfs-42.json
+++ b/catalogs/sources/gtfs/schedule/us-california-kings-area-rural-transit-gtfs-42.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 42,
+    "data_type": "gtfs",
+    "provider": "Kings Area Rural Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Hanford",
+        "bounding_box": {
+            "minimum_latitude": 36.002941,
+            "maximum_latitude": 36.885069,
+            "minimum_longitude": -120.14516,
+            "maximum_longitude": -119.288234,
+            "extracted_on": "2022-03-14T20:07:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/kcapta-ca-us/kcapta-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-kings-area-rural-transit-gtfs-42.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-la-go-bus-gtfs-28.json
+++ b/catalogs/sources/gtfs/schedule/us-california-la-go-bus-gtfs-28.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 28,
+    "data_type": "gtfs",
+    "provider": "LA Go Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.908508,
+            "maximum_latitude": 34.4928267927541,
+            "minimum_longitude": -118.607944,
+            "maximum_longitude": -117.880424,
+            "extracted_on": "2022-03-14T20:07:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/dpwlacounty-ca-us/dpwlacounty-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-la-go-bus-gtfs-28.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-la-metro-rail-gtfs-30.json
+++ b/catalogs/sources/gtfs/schedule/us-california-la-metro-rail-gtfs-30.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 30,
+    "data_type": "gtfs",
+    "provider": "LA Metro Rail",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.76804,
+            "maximum_latitude": 34.16906,
+            "minimum_longitude": -118.49189,
+            "maximum_longitude": -117.89085,
+            "extracted_on": "2022-03-14T20:07:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gitlab.com/LACMTA/gtfs_rail/raw/master/gtfs_rail.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-la-metro-rail-gtfs-30.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-laguna-beach-transit-lbt-gtfs-16.json
+++ b/catalogs/sources/gtfs/schedule/us-california-laguna-beach-transit-lbt-gtfs-16.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 16,
+    "data_type": "gtfs",
+    "provider": "Laguna Beach Transit (LBT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Laguna Beach",
+        "bounding_box": {
+            "minimum_latitude": 33.476315,
+            "maximum_latitude": 33.656395,
+            "minimum_longitude": -117.799868,
+            "maximum_longitude": -117.716808,
+            "extracted_on": "2022-03-14T20:06:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lagunabeach-ca-us/lagunabeach-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-laguna-beach-transit-lbt-gtfs-16.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-lake-transit-authority-lta-gtfs-68.json
+++ b/catalogs/sources/gtfs/schedule/us-california-lake-transit-authority-lta-gtfs-68.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 68,
+    "data_type": "gtfs",
+    "provider": "Lake Transit Authority (LTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 38.542878,
+            "maximum_latitude": 39.1896831,
+            "minimum_longitude": -123.2264562,
+            "maximum_longitude": -122.475567,
+            "extracted_on": "2022-03-14T20:10:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/laketransit-ca-us/laketransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-lake-transit-authority-lta-gtfs-68.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-lawndale-beat-gtfs-36.json
+++ b/catalogs/sources/gtfs/schedule/us-california-lawndale-beat-gtfs-36.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 36,
+    "data_type": "gtfs",
+    "provider": "Lawndale Beat",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Lawndale",
+        "bounding_box": {
+            "minimum_latitude": 33.8708620651923,
+            "maximum_latitude": 33.9017846932411,
+            "minimum_longitude": -118.369570637078,
+            "maximum_longitude": -118.344004807838,
+            "extracted_on": "2022-03-14T20:07:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cityoflawndale-ca-us/cityoflawndale-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-lawndale-beat-gtfs-36.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-livermore-amador-valley-transit-authority-gtfs-64.json
+++ b/catalogs/sources/gtfs/schedule/us-california-livermore-amador-valley-transit-authority-gtfs-64.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 64,
+    "data_type": "gtfs",
+    "provider": "Livermore Amador Valley Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Livermore",
+        "bounding_box": {
+            "minimum_latitude": 37.631448,
+            "maximum_latitude": 37.732502,
+            "minimum_longitude": -121.98229,
+            "maximum_longitude": -121.717493,
+            "extracted_on": "2022-03-14T20:09:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://webwatch.lavta.org/TMGTFSRealTimeWebService/GTFS-Static/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-livermore-amador-valley-transit-authority-gtfs-64.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-los-angeles-county-metropolitan-transportation-authority-gtfs-29.json
+++ b/catalogs/sources/gtfs/schedule/us-california-los-angeles-county-metropolitan-transportation-authority-gtfs-29.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 29,
+    "data_type": "gtfs",
+    "provider": " Los Angeles County Metropolitan Transportation Authority",
+    "name": "Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.706853,
+            "maximum_latitude": 34.326157,
+            "minimum_longitude": -118.860915,
+            "maximum_longitude": -117.913475,
+            "extracted_on": "2022-03-14T20:07:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gitlab.com/LACMTA/gtfs_bus/raw/master/gtfs_bus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-los-angeles-county-metropolitan-transportation-authority-gtfs-29.zip?alt=media",
+        "license": "http://developer.metro.net/the-basics/policies/terms-and-conditions/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-los-angeles-county-metropolitan-transportation-authority-gtfs-29.json
+++ b/catalogs/sources/gtfs/schedule/us-california-los-angeles-county-metropolitan-transportation-authority-gtfs-29.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 29,
     "data_type": "gtfs",
-    "provider": " Los Angeles County Metropolitan Transportation Authority",
+    "provider": "Los Angeles County Metropolitan Transportation Authority",
     "name": "Bus",
     "location": {
         "country_code": "US",

--- a/catalogs/sources/gtfs/schedule/us-california-marin-transit-gtfs-71.json
+++ b/catalogs/sources/gtfs/schedule/us-california-marin-transit-gtfs-71.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 71,
+    "data_type": "gtfs",
+    "provider": "Marin Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.857136,
+            "maximum_latitude": 38.124256,
+            "minimum_longitude": -122.851524,
+            "maximum_longitude": -122.4561,
+            "extracted_on": "2022-03-14T20:10:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.marintransit.org/data/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-marin-transit-gtfs-71.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-mendocino-transit-authority-gtfs-69.json
+++ b/catalogs/sources/gtfs/schedule/us-california-mendocino-transit-authority-gtfs-69.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 69,
+    "data_type": "gtfs",
+    "provider": "Mendocino Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Ukiah",
+        "bounding_box": {
+            "minimum_latitude": 38.3242,
+            "maximum_latitude": 39.45186,
+            "minimum_longitude": -123.816132,
+            "maximum_longitude": -122.713719,
+            "extracted_on": "2022-03-14T20:10:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/mendocino-ca-us/mendocino-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-mendocino-transit-authority-gtfs-69.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-merced-county-transit-the-bus-gtfs-86.json
+++ b/catalogs/sources/gtfs/schedule/us-california-merced-county-transit-the-bus-gtfs-86.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 86,
+    "data_type": "gtfs",
+    "provider": "Merced County Transit (The Bus)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Merced",
+        "bounding_box": {
+            "minimum_latitude": 36.9645033416456,
+            "maximum_latitude": 37.5217855174328,
+            "minimum_longitude": -121.020239964565,
+            "maximum_longitude": -120.248,
+            "extracted_on": "2022-03-14T20:11:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/mercedthebus-ca-us/mercedthebus-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-merced-county-transit-the-bus-gtfs-86.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-metrolink-gtfs-96.json
+++ b/catalogs/sources/gtfs/schedule/us-california-metrolink-gtfs-96.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 96,
+    "data_type": "gtfs",
+    "provider": "Metrolink",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 33.192554,
+            "maximum_latitude": 34.696579,
+            "minimum_longitude": -119.205025,
+            "maximum_longitude": -117.205711,
+            "extracted_on": "2022-03-14T20:12:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://metrolinktrains.com/globalassets/about/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-metrolink-gtfs-96.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-mission-bay-transportation-management-association-tma-gtfs-51.json
+++ b/catalogs/sources/gtfs/schedule/us-california-mission-bay-transportation-management-association-tma-gtfs-51.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 51,
+    "data_type": "gtfs",
+    "provider": "Mission Bay Transportation Management Association (TMA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.766910305944,
+            "maximum_latitude": 37.7919901456108,
+            "minimum_longitude": -122.41602803586,
+            "maximum_longitude": -122.38623989798,
+            "extracted_on": "2022-03-14T20:08:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/missionbaytma-ca-us/missionbaytma-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-mission-bay-transportation-management-association-tma-gtfs-51.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-modesto-area-express-gtfs-55.json
+++ b/catalogs/sources/gtfs/schedule/us-california-modesto-area-express-gtfs-55.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 55,
+    "data_type": "gtfs",
+    "provider": "Modesto Area Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Modesto",
+        "bounding_box": {
+            "minimum_latitude": 37.580162,
+            "maximum_latitude": 37.954866,
+            "minimum_longitude": -121.898961218,
+            "maximum_longitude": -120.9133,
+            "extracted_on": "2022-03-14T20:08:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.modestoareaexpress.com/preview-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-modesto-area-express-gtfs-55.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-montereysalinas-transit-mst-gtfs-56.json
+++ b/catalogs/sources/gtfs/schedule/us-california-montereysalinas-transit-mst-gtfs-56.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 56,
+    "data_type": "gtfs",
+    "provider": "Monterey-Salinas Transit (MST)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Monterey",
+        "bounding_box": {
+            "minimum_latitude": 35.615187,
+            "maximum_latitude": 36.909498,
+            "minimum_longitude": -121.936046,
+            "maximum_longitude": -120.680343,
+            "extracted_on": "2022-03-14T20:08:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.mst.org/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-montereysalinas-transit-mst-gtfs-56.zip?alt=media",
+        "license": "https://mst.org/about-mst/developer-resources/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-morro-bay-transit-gtfs-45.json
+++ b/catalogs/sources/gtfs/schedule/us-california-morro-bay-transit-gtfs-45.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 45,
+    "data_type": "gtfs",
+    "provider": "Morro Bay Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Morro Bay",
+        "bounding_box": {
+            "minimum_latitude": 35.3469986712409,
+            "maximum_latitude": 35.4033897704827,
+            "minimum_longitude": -120.867305248975,
+            "maximum_longitude": -120.840760767459,
+            "extracted_on": "2022-03-14T20:08:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/morrobay_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-morro-bay-transit-gtfs-45.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-mountain-view-transportation-management-association-gtfs-60.json
+++ b/catalogs/sources/gtfs/schedule/us-california-mountain-view-transportation-management-association-gtfs-60.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 60,
+    "data_type": "gtfs",
+    "provider": "Mountain View Transportation Management Association",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Mountain View",
+        "bounding_box": {
+            "minimum_latitude": 37.387655512462,
+            "maximum_latitude": 37.4314288965063,
+            "minimum_longitude": -122.111591291827,
+            "maximum_longitude": -122.04758367268,
+            "extracted_on": "2022-03-14T20:09:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/mountainview-ca-us/mountainview-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-mountain-view-transportation-management-association-gtfs-60.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-nevada-county-connects-gold-country-stage-gtfs-84.json
+++ b/catalogs/sources/gtfs/schedule/us-california-nevada-county-connects-gold-country-stage-gtfs-84.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 84,
+    "data_type": "gtfs",
+    "provider": "Nevada County Connects (Gold Country Stage)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Nevada County",
+        "bounding_box": {
+            "minimum_latitude": 38.90302085,
+            "maximum_latitude": 39.3707053363352,
+            "minimum_longitude": -121.20505269,
+            "maximum_longitude": -120.990358820743,
+            "extracted_on": "2022-03-14T20:11:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/goldcountrystage-ca-us/goldcountrystage-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-nevada-county-connects-gold-country-stage-gtfs-84.zip?alt=media",
+        "license": "http://creativecommons.org/licenses/by/4.0/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-north-county-transit-district-nctd-gtfs-14.json
+++ b/catalogs/sources/gtfs/schedule/us-california-north-county-transit-district-nctd-gtfs-14.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 14,
+    "data_type": "gtfs",
+    "provider": "North County Transit District (NCTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Diego",
+        "bounding_box": {
+            "minimum_latitude": 32.716895,
+            "maximum_latitude": 33.394164,
+            "minimum_longitude": -117.514206,
+            "maximum_longitude": -116.869776,
+            "extracted_on": "2022-03-14T20:05:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.gonctd.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-north-county-transit-district-nctd-gtfs-14.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-norwalk-transit-system-nts-gtfs-102.json
+++ b/catalogs/sources/gtfs/schedule/us-california-norwalk-transit-system-nts-gtfs-102.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 102,
+    "data_type": "gtfs",
+    "provider": "Norwalk Transit System (NTS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.8654944889,
+            "maximum_latitude": 34.0724551769048,
+            "minimum_longitude": -118.133963901,
+            "maximum_longitude": -117.959304257,
+            "extracted_on": "2022-03-14T20:12:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/nts-ca-us/nts-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-norwalk-transit-system-nts-gtfs-102.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-omnitrans-gtfs-97.json
+++ b/catalogs/sources/gtfs/schedule/us-california-omnitrans-gtfs-97.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 97,
+    "data_type": "gtfs",
+    "provider": "OmniTrans",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Bernardino",
+        "bounding_box": {
+            "minimum_latitude": 33.975393,
+            "maximum_latitude": 34.189763,
+            "minimum_longitude": -117.751245,
+            "maximum_longitude": -117.034458,
+            "extracted_on": "2022-03-14T20:12:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.omnitrans.org/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-omnitrans-gtfs-97.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-orange-county-transportation-authority-octa-gtfs-15.json
+++ b/catalogs/sources/gtfs/schedule/us-california-orange-county-transportation-authority-octa-gtfs-15.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 15,
+    "data_type": "gtfs",
+    "provider": "Orange County Transportation Authority (OCTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Orange County",
+        "bounding_box": {
+            "minimum_latitude": 33.39627,
+            "maximum_latitude": 33.93947,
+            "minimum_longitude": -118.11913,
+            "maximum_longitude": -117.57766,
+            "extracted_on": "2022-03-14T20:06:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.octa.net/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-orange-county-transportation-authority-octa-gtfs-15.zip?alt=media",
+        "license": "http://www.octa.net/News-and-Resources/Open-Data/Overview/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-palo-verde-valley-transit-agency-gtfs-18.json
+++ b/catalogs/sources/gtfs/schedule/us-california-palo-verde-valley-transit-agency-gtfs-18.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 18,
+    "data_type": "gtfs",
+    "provider": "Palo Verde Valley Transit Agency",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 33.521321,
+            "maximum_latitude": 33.83888769,
+            "minimum_longitude": -116.5437887,
+            "maximum_longitude": -114.517118,
+            "extracted_on": "2022-03-14T20:06:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/paloverde_valley-ca-us/paloverde_valley-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-palo-verde-valley-transit-agency-gtfs-18.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-palos-verdes-peninsula-transit-authority-pvpta-gtfs-35.json
+++ b/catalogs/sources/gtfs/schedule/us-california-palos-verdes-peninsula-transit-authority-pvpta-gtfs-35.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 35,
+    "data_type": "gtfs",
+    "provider": "Palos Verdes Peninsula Transit Authority  (PVPTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 33.720604,
+            "maximum_latitude": 33.819042,
+            "minimum_longitude": -118.423141,
+            "maximum_longitude": -118.287674940168,
+            "extracted_on": "2022-03-14T20:07:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/pvpta-ca-us/pvpta-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-palos-verdes-peninsula-transit-authority-pvpta-gtfs-35.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-pasadena-transit-gtfs-41.json
+++ b/catalogs/sources/gtfs/schedule/us-california-pasadena-transit-gtfs-41.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 41,
+    "data_type": "gtfs",
+    "provider": "Pasadena Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Pasadena",
+        "bounding_box": {
+            "minimum_latitude": 34.127464,
+            "maximum_latitude": 34.197933,
+            "minimum_longitude": -118.185589,
+            "maximum_longitude": -118.068852,
+            "extracted_on": "2022-03-14T20:07:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://rt.pasadenatransit.net/rtt/public/utility/gtfs.aspx",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-pasadena-transit-gtfs-41.zip?alt=media",
+        "license": "https://www.cityofpasadena.net/pasadena-transit/real-time-applications/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-petaluma-transit-gtfs-72.json
+++ b/catalogs/sources/gtfs/schedule/us-california-petaluma-transit-gtfs-72.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 72,
+    "data_type": "gtfs",
+    "provider": "Petaluma Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Petaluma",
+        "bounding_box": {
+            "minimum_latitude": 38.217522404908,
+            "maximum_latitude": 38.276555,
+            "minimum_longitude": -122.669474,
+            "maximum_longitude": -122.585068,
+            "extracted_on": "2022-03-14T20:10:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/petalumatransit-petaluma-ca-us/petalumatransit-petaluma-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-petaluma-transit-gtfs-72.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-placer-county-transit-gtfs-77.json
+++ b/catalogs/sources/gtfs/schedule/us-california-placer-county-transit-gtfs-77.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 77,
+    "data_type": "gtfs",
+    "provider": "Placer County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Sacremento",
+        "bounding_box": {
+            "minimum_latitude": 38.5727195121879,
+            "maximum_latitude": 39.2071204380246,
+            "minimum_longitude": -121.503338951854,
+            "maximum_longitude": -120.810972099331,
+            "extracted_on": "2022-03-14T20:11:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/placercounty-ca-us/placercounty-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-placer-county-transit-gtfs-77.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-porterville-transit-gtfs-48.json
+++ b/catalogs/sources/gtfs/schedule/us-california-porterville-transit-gtfs-48.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 48,
+    "data_type": "gtfs",
+    "provider": "Porterville Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Tulare",
+        "bounding_box": {
+            "minimum_latitude": 36.027009,
+            "maximum_latitude": 36.098346,
+            "minimum_longitude": -119.079056,
+            "maximum_longitude": -118.77602944931,
+            "extracted_on": "2022-03-14T20:08:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/porterville-ca-us/porterville-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-porterville-transit-gtfs-48.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-redwood-coast-transit-rct-gtfs-20.json
+++ b/catalogs/sources/gtfs/schedule/us-california-redwood-coast-transit-rct-gtfs-20.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 20,
+    "data_type": "gtfs",
+    "provider": "Redwood Coast Transit (RCT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Crescent City",
+        "bounding_box": {
+            "minimum_latitude": 40.868565,
+            "maximum_latitude": 41.957411,
+            "minimum_longitude": -124.216937405798,
+            "maximum_longitude": -123.96551954304,
+            "extracted_on": "2022-03-14T20:06:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/delnorte-ca-us/delnorte-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-redwood-coast-transit-rct-gtfs-20.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-rio-vista-delta-breeze-gtfs-81.json
+++ b/catalogs/sources/gtfs/schedule/us-california-rio-vista-delta-breeze-gtfs-81.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 81,
+    "data_type": "gtfs",
+    "provider": "Rio Vista Delta Breeze",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Rio Vista",
+        "bounding_box": {
+            "minimum_latitude": 37.997593,
+            "maximum_latitude": 38.2629,
+            "minimum_longitude": -122.0839,
+            "maximum_longitude": -121.612557023764,
+            "extracted_on": "2022-03-14T20:11:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/riovista-ca-us/riovista-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-rio-vista-delta-breeze-gtfs-81.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-riverside-transit-agency-gtfs-98.json
+++ b/catalogs/sources/gtfs/schedule/us-california-riverside-transit-agency-gtfs-98.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 98,
+    "data_type": "gtfs",
+    "provider": "Riverside Transit Agency",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Riverside",
+        "bounding_box": {
+            "minimum_latitude": 33.452304,
+            "maximum_latitude": 34.10009,
+            "minimum_longitude": -117.915548,
+            "maximum_longitude": -116.875799,
+            "extracted_on": "2022-03-14T20:12:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.riversidetransit.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-riverside-transit-agency-gtfs-98.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-benito-county-express-sbce-gtfs-58.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-benito-county-express-sbce-gtfs-58.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 58,
+    "data_type": "gtfs",
+    "provider": "San Benito County Express (SBCE)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Hollister",
+        "bounding_box": {
+            "minimum_latitude": 36.828106,
+            "maximum_latitude": 37.004068,
+            "minimum_longitude": -121.570689082146,
+            "maximum_longitude": -121.366669,
+            "extracted_on": "2022-03-14T20:09:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sanbenitocounty-ca-us/sanbenitocounty-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-benito-county-express-sbce-gtfs-58.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-diego-international-airport-metropolitan-transit-system-mts-gtfs-13.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-diego-international-airport-metropolitan-transit-system-mts-gtfs-13.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 13,
+    "data_type": "gtfs",
+    "provider": "San Diego International Airport, Metropolitan Transit System (MTS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Diego",
+        "bounding_box": {
+            "minimum_latitude": 32.542819141808,
+            "maximum_latitude": 33.256886800725,
+            "minimum_longitude": -117.277923661848,
+            "maximum_longitude": -116.184457875596,
+            "extracted_on": "2022-03-14T20:05:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.sdmts.com/google_transit_files/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-diego-international-airport-metropolitan-transit-system-mts-gtfs-13.zip?alt=media",
+        "license": "https://www.sdmts.com/business-center-developers/terms-and-conditions"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-francisco-bay-area-water-emergency-transportation-authority-gtfs-62.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-francisco-bay-area-water-emergency-transportation-authority-gtfs-62.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 62,
+    "data_type": "gtfs",
+    "provider": "San Francisco Bay Area Water Emergency Transportation Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco ",
+        "bounding_box": {
+            "minimum_latitude": 37.662676,
+            "maximum_latitude": 38.10127,
+            "minimum_longitude": -122.41209,
+            "maximum_longitude": -122.25692,
+            "extracted_on": "2022-03-14T20:09:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sfbayferry-ca-us/sfbayferry-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-francisco-bay-area-water-emergency-transportation-authority-gtfs-62.zip?alt=media",
+        "license": "http://assets.511.org/pdf/nextgen/developers/511_Data_Agreement_Final.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-francisco-bay-area-water-emergency-transportation-authority-gtfs-62.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-francisco-bay-area-water-emergency-transportation-authority-gtfs-62.json
@@ -5,7 +5,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
-        "municipality": "San Francisco ",
+        "municipality": "San Francisco",
         "bounding_box": {
             "minimum_latitude": 37.662676,
             "maximum_latitude": 38.10127,

--- a/catalogs/sources/gtfs/schedule/us-california-san-francisco-municipal-transportation-agency-sfmta-gtfs-50.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-francisco-municipal-transportation-agency-sfmta-gtfs-50.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 50,
+    "data_type": "gtfs",
+    "provider": "San Francisco Municipal Transportation Agency (SFMTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.702085,
+            "maximum_latitude": 37.829848,
+            "minimum_longitude": -122.510792,
+            "maximum_longitude": -122.365593,
+            "extracted_on": "2022-03-14T20:08:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.sfmta.com/transitdata/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-francisco-municipal-transportation-agency-sfmta-gtfs-50.zip?alt=media",
+        "license": "http://www.sfmta.com/about-sfmta/reports/gtfs-transit-data"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-luis-obispo-regional-transit-authority-slorta-gtfs-43.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-luis-obispo-regional-transit-authority-slorta-gtfs-43.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 43,
+    "data_type": "gtfs",
+    "provider": "San Luis Obispo Regional Transit Authority (SLORTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Luis Obispo",
+        "bounding_box": {
+            "minimum_latitude": 34.944001,
+            "maximum_latitude": 35.752511,
+            "minimum_longitude": -121.186588,
+            "maximum_longitude": -120.413275,
+            "extracted_on": "2022-03-14T20:08:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://slo.connexionz.net/rtt/public/resource/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-luis-obispo-regional-transit-authority-slorta-gtfs-43.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-mateo-county-transit-district-samtrans-gtfs-49.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-mateo-county-transit-district-samtrans-gtfs-49.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 49,
+    "data_type": "gtfs",
+    "provider": "San Mateo County Transit District (samTrans)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.250304,
+            "maximum_latitude": 37.795815,
+            "minimum_longitude": -122.51796,
+            "maximum_longitude": -122.129824,
+            "extracted_on": "2022-03-14T20:08:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.samtrans.com/Assets/GTFS/samtrans/ST-GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-mateo-county-transit-district-samtrans-gtfs-49.zip?alt=media",
+        "license": "http://www.samtrans.com/Developer.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-santa-clara-valley-transportation-authority-vta-gtfs-57.json
+++ b/catalogs/sources/gtfs/schedule/us-california-santa-clara-valley-transportation-authority-vta-gtfs-57.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 57,
+    "data_type": "gtfs",
+    "provider": "Santa Clara Valley Transportation Authority (VTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Jose",
+        "bounding_box": {
+            "minimum_latitude": 36.974922,
+            "maximum_latitude": 37.458086,
+            "minimum_longitude": -122.173639,
+            "maximum_longitude": -121.549029,
+            "extracted_on": "2022-03-14T20:09:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.vta.org/gtfs_vta.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-santa-clara-valley-transportation-authority-vta-gtfs-57.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-santa-maria-area-transit-gtfs-26.json
+++ b/catalogs/sources/gtfs/schedule/us-california-santa-maria-area-transit-gtfs-26.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 26,
+    "data_type": "gtfs",
+    "provider": "Santa Maria Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Maria",
+        "bounding_box": {
+            "minimum_latitude": 34.595943118981,
+            "maximum_latitude": 34.98595,
+            "minimum_longitude": -120.52211,
+            "maximum_longitude": -120.140531457672,
+            "extracted_on": "2022-03-14T20:06:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/smat-ca-us/smat-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-santa-maria-area-transit-gtfs-26.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-santa-rosa-citybus-gtfs-73.json
+++ b/catalogs/sources/gtfs/schedule/us-california-santa-rosa-citybus-gtfs-73.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 73,
+    "data_type": "gtfs",
+    "provider": "Santa Rosa CityBus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Rosa",
+        "bounding_box": {
+            "minimum_latitude": 38.401882,
+            "maximum_latitude": 38.486115,
+            "minimum_longitude": -122.769814,
+            "maximum_longitude": -122.653511,
+            "extracted_on": "2022-03-14T20:10:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://srcity.org/DocumentCenter/View/21635/google_transit",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-santa-rosa-citybus-gtfs-73.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-simi-valley-transit-gtfs-40.json
+++ b/catalogs/sources/gtfs/schedule/us-california-simi-valley-transit-gtfs-40.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 40,
+    "data_type": "gtfs",
+    "provider": "Simi Valley Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Simi Valley",
+        "bounding_box": {
+            "minimum_latitude": 34.22958457,
+            "maximum_latitude": 34.3021463101492,
+            "minimum_longitude": -118.83637467254,
+            "maximum_longitude": -118.598911921367,
+            "extracted_on": "2022-03-14T20:07:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/simivalley-ca-us/simivalley-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-simi-valley-transit-gtfs-40.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-soltrans-gtfs-80.json
+++ b/catalogs/sources/gtfs/schedule/us-california-soltrans-gtfs-80.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 80,
+    "data_type": "gtfs",
+    "provider": "SolTrans",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Fairfield",
+        "bounding_box": {
+            "minimum_latitude": 37.796306,
+            "maximum_latitude": 38.248682,
+            "minimum_longitude": -122.395363,
+            "maximum_longitude": -122.041634,
+            "extracted_on": "2022-03-14T20:11:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/soltrans-ca-us/soltrans-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-soltrans-gtfs-80.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sonoma-county-airport-express-gtfs-66.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sonoma-county-airport-express-gtfs-66.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 66,
+    "data_type": "gtfs",
+    "provider": "Sonoma County Airport Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Mateo",
+        "bounding_box": {
+            "minimum_latitude": 37.615612,
+            "maximum_latitude": 38.5100997340212,
+            "minimum_longitude": -122.805338301203,
+            "maximum_longitude": -122.212134,
+            "extracted_on": "2022-03-14T20:09:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/airportexpressinc-ca-us/airportexpressinc-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-county-airport-express-gtfs-66.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sonoma-county-transit-sct-gtfs-70.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sonoma-county-transit-sct-gtfs-70.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 70,
+    "data_type": "gtfs",
+    "provider": "Sonoma County Transit  (SCT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Rosa",
+        "bounding_box": {
+            "minimum_latitude": 37.97116752,
+            "maximum_latitude": 38.8123488647763,
+            "minimum_longitude": -123.1264984029,
+            "maximum_longitude": -122.4580372,
+            "extracted_on": "2022-03-14T20:10:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sonomacounty-ca-us/sonomacounty-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-county-transit-sct-gtfs-70.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-spirit-bus-gtfs-39.json
+++ b/catalogs/sources/gtfs/schedule/us-california-spirit-bus-gtfs-39.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 39,
+    "data_type": "gtfs",
+    "provider": "Spirit Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Monterey Park",
+        "bounding_box": {
+            "minimum_latitude": 34.0365252,
+            "maximum_latitude": 34.0697248,
+            "minimum_longitude": -118.1686876,
+            "maximum_longitude": -118.1088128,
+            "extracted_on": "2022-03-14T20:07:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/montereypark-ca-us/montereypark-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-spirit-bus-gtfs-39.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-stanford-marguerite-shuttle-sms-gtfs-59.json
+++ b/catalogs/sources/gtfs/schedule/us-california-stanford-marguerite-shuttle-sms-gtfs-59.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 59,
+    "data_type": "gtfs",
+    "provider": "Stanford Marguerite Shuttle (SMS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Stanford",
+        "bounding_box": {
+            "minimum_latitude": 37.39404,
+            "maximum_latitude": 37.589874,
+            "minimum_longitude": -122.23088832,
+            "maximum_longitude": -121.975618,
+            "extracted_on": "2022-03-14T20:09:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transportation-forms.stanford.edu/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-stanford-marguerite-shuttle-sms-gtfs-59.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-stanislaus-regional-transit-start-gtfs-87.json
+++ b/catalogs/sources/gtfs/schedule/us-california-stanislaus-regional-transit-start-gtfs-87.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 87,
+    "data_type": "gtfs",
+    "provider": "Stanislaus Regional Transit (StaRT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Modesto",
+        "bounding_box": {
+            "minimum_latitude": 37.25707509,
+            "maximum_latitude": 37.77173034,
+            "minimum_longitude": -121.897639,
+            "maximum_longitude": -120.488203167915,
+            "extracted_on": "2022-03-14T20:11:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/stanislaus-ca-us/stanislaus-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-stanislaus-regional-transit-start-gtfs-87.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-tahoe-area-regional-transit-tart-north-lake-tahoe-express-gtfs-94.json
+++ b/catalogs/sources/gtfs/schedule/us-california-tahoe-area-regional-transit-tart-north-lake-tahoe-express-gtfs-94.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 94,
+    "data_type": "gtfs",
+    "provider": "Tahoe Area Regional Transit (TART), North Lake Tahoe Express",
+    "name": "Placer County",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Tahoe City",
+        "bounding_box": {
+            "minimum_latitude": 39.0575273,
+            "maximum_latitude": 39.50729,
+            "minimum_longitude": -120.3888378,
+            "maximum_longitude": -119.775261,
+            "extracted_on": "2022-03-14T20:12:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/laketahoe-ca-us/laketahoe-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-tahoe-area-regional-transit-tart-north-lake-tahoe-express-gtfs-94.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-thousand-oaks-transit-gtfs-33.json
+++ b/catalogs/sources/gtfs/schedule/us-california-thousand-oaks-transit-gtfs-33.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 33,
+    "data_type": "gtfs",
+    "provider": "Thousand Oaks Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Thousand Oaks",
+        "bounding_box": {
+            "minimum_latitude": 34.021383769332,
+            "maximum_latitude": 34.285345,
+            "minimum_longitude": -118.981959,
+            "maximum_longitude": -118.815668825,
+            "extracted_on": "2022-03-14T20:07:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/thousandoaks-ca-us/thousandoaks-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-thousand-oaks-transit-gtfs-33.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-tideline-water-taxi-gtfs-52.json
+++ b/catalogs/sources/gtfs/schedule/us-california-tideline-water-taxi-gtfs-52.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 52,
+    "data_type": "gtfs",
+    "provider": "Tideline Water Taxi",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.7708398,
+            "maximum_latitude": 37.913659,
+            "minimum_longitude": -122.3950251,
+            "maximum_longitude": -122.31393184362,
+            "extracted_on": "2022-03-14T20:08:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://trilliumtransit.com/transit_feeds/tidelinewatertaxi-ca-us/tidelinewatertaxi-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-tideline-water-taxi-gtfs-52.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-torrance-transit-gtfs-34.json
+++ b/catalogs/sources/gtfs/schedule/us-california-torrance-transit-gtfs-34.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 34,
+    "data_type": "gtfs",
+    "provider": "Torrance Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Torrance",
+        "bounding_box": {
+            "minimum_latitude": 33.768128,
+            "maximum_latitude": 34.059919,
+            "minimum_longitude": -118.399852,
+            "maximum_longitude": -118.189549,
+            "extracted_on": "2022-03-14T20:07:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transit.torranceca.gov/home/showdocument?id=16673",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-torrance-transit-gtfs-34.zip?alt=media",
+        "license": "https://transit.torranceca.gov/home/showdocument?id=6052"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-unitrans-gtfs-82.json
+++ b/catalogs/sources/gtfs/schedule/us-california-unitrans-gtfs-82.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 82,
+    "data_type": "gtfs",
+    "provider": "Unitrans",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Davis",
+        "bounding_box": {
+            "minimum_latitude": 38.530406,
+            "maximum_latitude": 38.573359,
+            "minimum_longitude": -121.789079,
+            "maximum_longitude": -121.683489,
+            "extracted_on": "2022-03-14T20:11:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://unitrans.ucdavis.edu/media/gtfs/Unitrans_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-unitrans-gtfs-82.zip?alt=media",
+        "license": "https://unitrans.ucdavis.edu/about/gtfs/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-ventura-county-transportation-commission-gtfs-31.json
+++ b/catalogs/sources/gtfs/schedule/us-california-ventura-county-transportation-commission-gtfs-31.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 31,
+    "data_type": "gtfs",
+    "provider": "Ventura County Transportation Commission",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Barbara",
+        "bounding_box": {
+            "minimum_latitude": 34.15384,
+            "maximum_latitude": 34.4439177,
+            "minimum_longitude": -119.865593734324,
+            "maximum_longitude": -118.588218,
+            "extracted_on": "2022-03-14T20:07:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/vctc-ca-us/vctc-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-ventura-county-transportation-commission-gtfs-31.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-victor-valley-transit-authority-vvta-gtfs-99.json
+++ b/catalogs/sources/gtfs/schedule/us-california-victor-valley-transit-authority-vvta-gtfs-99.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 99,
+    "data_type": "gtfs",
+    "provider": "Victor Valley Transit Authority (VVTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Hesperia",
+        "bounding_box": {
+            "minimum_latitude": 34.072411,
+            "maximum_latitude": 35.273818,
+            "minimum_longitude": -117.64669,
+            "maximum_longitude": -116.609954,
+            "extracted_on": "2022-03-14T20:12:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/victorville-ca-us/victorville-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-victor-valley-transit-authority-vvta-gtfs-99.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-westcat-gtfs-78.json
+++ b/catalogs/sources/gtfs/schedule/us-california-westcat-gtfs-78.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 78,
+    "data_type": "gtfs",
+    "provider": "WestCAT",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Pinole",
+        "bounding_box": {
+            "minimum_latitude": 37.788966,
+            "maximum_latitude": 38.05572,
+            "minimum_longitude": -122.397233,
+            "maximum_longitude": -122.11445,
+            "extracted_on": "2022-03-14T20:11:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/westcat-ca-us/westcat-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-westcat-gtfs-78.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-yosemite-area-regional-transportation-system-yarts-gtfs-88.json
+++ b/catalogs/sources/gtfs/schedule/us-california-yosemite-area-regional-transportation-system-yarts-gtfs-88.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 88,
+    "data_type": "gtfs",
+    "provider": "Yosemite Area Regional Transportation System (YARTS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Merced",
+        "bounding_box": {
+            "minimum_latitude": 36.738144,
+            "maximum_latitude": 37.980406,
+            "minimum_longitude": -120.515457,
+            "maximum_longitude": -118.964912,
+            "extracted_on": "2022-03-14T20:11:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/yosemite-ca-us/yosemite-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-yosemite-area-regional-transportation-system-yarts-gtfs-88.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-yubasutter-transit-gtfs-79.json
+++ b/catalogs/sources/gtfs/schedule/us-california-yubasutter-transit-gtfs-79.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 79,
+    "data_type": "gtfs",
+    "provider": "Yuba-Sutter Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Yuba City",
+        "bounding_box": {
+            "minimum_latitude": 38.572670409003,
+            "maximum_latitude": 39.4572019644274,
+            "minimum_longitude": -121.67273923052,
+            "maximum_longitude": -121.25373447668,
+            "extracted_on": "2022-03-14T20:11:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/yubasutter-ca-us/yubasutter-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-yubasutter-transit-gtfs-79.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-el-dorado-transit-gtfs-75.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-el-dorado-transit-gtfs-75.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 75,
+    "data_type": "gtfs",
+    "provider": "El Dorado Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 38.551646,
+            "maximum_latitude": 38.957753,
+            "minimum_longitude": -121.502804,
+            "maximum_longitude": -119.942393,
+            "extracted_on": "2022-03-14T20:10:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/eldoradotransit-ca-us/eldoradotransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-el-dorado-transit-gtfs-75.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-hawaii-thebus-gtfs-10.json
+++ b/catalogs/sources/gtfs/schedule/us-hawaii-thebus-gtfs-10.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 10,
+    "data_type": "gtfs",
+    "provider": "TheBus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Hawaii",
+        "municipality": "Honolulu",
+        "bounding_box": {
+            "minimum_latitude": 21.255957,
+            "maximum_latitude": 21.70327,
+            "minimum_longitude": -158.228463,
+            "maximum_longitude": -157.662429,
+            "extracted_on": "2022-03-14T20:04:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://webapps.thebus.org/transitdata/Production/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-hawaii-thebus-gtfs-10.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-nevada-jump-around-carson-gtfs-95.json
+++ b/catalogs/sources/gtfs/schedule/us-nevada-jump-around-carson-gtfs-95.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 95,
+    "data_type": "gtfs",
+    "provider": "Jump Around Carson",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Nevada",
+        "municipality": "Carson City",
+        "bounding_box": {
+            "minimum_latitude": 39.11556,
+            "maximum_latitude": 39.20368,
+            "minimum_longitude": -119.79043,
+            "maximum_longitude": -119.72803,
+            "extracted_on": "2022-03-14T20:12:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://r.peaktransit.com/res/76/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-nevada-jump-around-carson-gtfs-95.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-st-lawrence-county-public-transit-gtfs-5.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-st-lawrence-county-public-transit-gtfs-5.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 5,
+    "data_type": "gtfs",
+    "provider": "St Lawrence County Public Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York ",
+        "municipality": "Canton",
+        "bounding_box": {
+            "minimum_latitude": 44.148476,
+            "maximum_latitude": 44.979369,
+            "minimum_longitude": -75.75695,
+            "maximum_longitude": -74.611761,
+            "extracted_on": "2022-03-14T20:02:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/St_Lawrence_County_Public_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-st-lawrence-county-public-transit-gtfs-5.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-st-lawrence-county-public-transit-gtfs-5.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-st-lawrence-county-public-transit-gtfs-5.json
@@ -4,7 +4,7 @@
     "provider": "St Lawrence County Public Transit",
     "location": {
         "country_code": "US",
-        "subdivision_name": "New York ",
+        "subdivision_name": "New York",
         "municipality": "Canton",
         "bounding_box": {
             "minimum_latitude": 44.148476,

--- a/catalogs/sources/gtfs/schedule/us-oregon-coos-county-area-transit-ccat-gtfs-21.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-coos-county-area-transit-ccat-gtfs-21.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 21,
+    "data_type": "gtfs",
+    "provider": "Coos County Area Transit (CCAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Coos Bay",
+        "bounding_box": {
+            "minimum_latitude": 42.87881944,
+            "maximum_latitude": 43.982245,
+            "minimum_longitude": -124.434431,
+            "maximum_longitude": -123.345208,
+            "extracted_on": "2022-03-14T20:06:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/cooscounty-or-us/cooscounty-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-coos-county-area-transit-ccat-gtfs-21.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-curry-public-transit-gtfs-22.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-curry-public-transit-gtfs-22.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 22,
+    "data_type": "gtfs",
+    "provider": "Curry Public Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Brookings",
+        "bounding_box": {
+            "minimum_latitude": 41.9570322655811,
+            "maximum_latitude": 43.4160571073338,
+            "minimum_longitude": -124.498078553064,
+            "maximum_longitude": -124.203528654532,
+            "extracted_on": "2022-03-14T20:06:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/currypublictransit-or-us/currypublictransit-brookings-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-curry-public-transit-gtfs-22.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-lincoln-county-transit-lct-gtfs-23.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-lincoln-county-transit-lct-gtfs-23.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 23,
+    "data_type": "gtfs",
+    "provider": "Lincoln County Transit  (LCT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Newport",
+        "bounding_box": {
+            "minimum_latitude": 44.3116263048855,
+            "maximum_latitude": 45.01935811,
+            "minimum_longitude": -124.105422953253,
+            "maximum_longitude": -123.10286,
+            "extracted_on": "2022-03-14T20:06:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/lincolncounty-or-us/lincolncounty-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-lincoln-county-transit-lct-gtfs-23.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-rhody-express-gtfs-24.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-rhody-express-gtfs-24.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 24,
+    "data_type": "gtfs",
+    "provider": "Rhody Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Florence",
+        "bounding_box": {
+            "minimum_latitude": 43.9663292158148,
+            "maximum_latitude": 44.00783688,
+            "minimum_longitude": -124.118156,
+            "maximum_longitude": -124.086991158899,
+            "extracted_on": "2022-03-14T20:06:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/rhodyexpress-or-us/rhodyexpress-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-rhody-express-gtfs-24.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-unknown-amtrak-gtfs-11.json
+++ b/catalogs/sources/gtfs/schedule/us-unknown-amtrak-gtfs-11.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 11,
+    "data_type": "gtfs",
+    "provider": "Amtrak",
+    "location": {
+        "country_code": "US",
+        "bounding_box": {
+            "minimum_latitude": 25.849554,
+            "maximum_latitude": 49.273757,
+            "minimum_longitude": -124.16933,
+            "maximum_longitude": -69.965541,
+            "extracted_on": "2022-03-14T20:04:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://content.amtrak.com/content/gtfs/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-unknown-amtrak-gtfs-11.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the first GTFS Schedule sources in the catalogs. It also serves as a first test before importing all of the data.

Changes:

- The GTFS Schedule Sources catalog is extended with 100 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~