### PR TITLE
feat: Add the sources of the first import, part 2 [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-arizona-bullhead-area-transit-system-gtfs-109.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-bullhead-area-transit-system-gtfs-109.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 109,
+    "data_type": "gtfs",
+    "provider": "Bullhead Area Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Bullhead City",
+        "bounding_box": {
+            "minimum_latitude": 35.049874201132,
+            "maximum_latitude": 35.165897,
+            "minimum_longitude": -114.64066405236,
+            "maximum_longitude": -114.53114181833,
+            "extracted_on": "2022-03-14T21:12:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bullheadareatransit-az-us/bullheadareatransit-az-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-bullhead-area-transit-system-gtfs-109.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-cat-tran-shuttle-gtfs-146.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-cat-tran-shuttle-gtfs-146.json
@@ -5,7 +5,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "Arizona",
-        "municipality": "Tucson ",
+        "municipality": "Tucson",
         "bounding_box": {
             "minimum_latitude": 32.2176728,
             "maximum_latitude": 32.2717141860996,

--- a/catalogs/sources/gtfs/schedule/us-arizona-cat-tran-shuttle-gtfs-146.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-cat-tran-shuttle-gtfs-146.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 146,
+    "data_type": "gtfs",
+    "provider": "Cat Tran Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Tucson ",
+        "bounding_box": {
+            "minimum_latitude": 32.2176728,
+            "maximum_latitude": 32.2717141860996,
+            "minimum_longitude": -110.9777239,
+            "maximum_longitude": -110.919471179285,
+            "extracted_on": "2022-03-14T21:13:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cattran-az-us/cattran-az-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-cat-tran-shuttle-gtfs-146.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-city-of-sierra-vista-gtfs-145.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-city-of-sierra-vista-gtfs-145.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 145,
+    "data_type": "gtfs",
+    "provider": "City of Sierra Vista",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Sierra Vista",
+        "bounding_box": {
+            "minimum_latitude": 31.528526,
+            "maximum_latitude": 31.565626,
+            "minimum_longitude": -110.353191,
+            "maximum_longitude": -110.23233,
+            "extracted_on": "2022-03-14T21:13:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://demopro.nationalrtap.org/admin/GTFSzipFiles/3746/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-city-of-sierra-vista-gtfs-145.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-cottonwood-area-transit-cat-gtfs-158.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-cottonwood-area-transit-cat-gtfs-158.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 158,
+    "data_type": "gtfs",
+    "provider": "Cottonwood Area Transit (CAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Cottonwood",
+        "bounding_box": {
+            "minimum_latitude": 34.6901,
+            "maximum_latitude": 34.87282,
+            "minimum_longitude": -112.06924,
+            "maximum_longitude": -111.76015,
+            "extracted_on": "2022-03-14T21:15:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cottonwood-az-us/cottonwood-az-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-cottonwood-area-transit-cat-gtfs-158.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-groome-transportation-arizona-shuttle-gtfs-156.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-groome-transportation-arizona-shuttle-gtfs-156.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 156,
+    "data_type": "gtfs",
+    "provider": "Groome Transportation - Arizona Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "bounding_box": {
+            "minimum_latitude": 32.2282,
+            "maximum_latitude": 36.053855,
+            "minimum_longitude": -112.469814502514,
+            "maximum_longitude": -110.878153,
+            "extracted_on": "2022-03-14T21:15:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/arizonashuttle-az-us/arizonashuttle-az-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-groome-transportation-arizona-shuttle-gtfs-156.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-suntran-gtfs-144.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-suntran-gtfs-144.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 144,
+    "data_type": "gtfs",
+    "provider": "SunTran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Tucson",
+        "bounding_box": {
+            "minimum_latitude": 31.868367,
+            "maximum_latitude": 32.484435,
+            "minimum_longitude": -112.872267,
+            "maximum_longitude": -110.772465,
+            "extracted_on": "2022-03-14T21:13:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.suntran.com/wp-content/uploads/2021/08/SunTranGTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-suntran-gtfs-144.zip?alt=media",
+        "license": "https://www.suntran.com/developers_terms.php"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-valley-metro-vm-gtfs-147.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-valley-metro-vm-gtfs-147.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 147,
+    "data_type": "gtfs",
+    "provider": "Valley Metro (VM)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Phoenix",
+        "bounding_box": {
+            "minimum_latitude": 32.382706,
+            "maximum_latitude": 33.743306,
+            "minimum_longitude": -112.872185,
+            "maximum_longitude": -111.660913,
+            "extracted_on": "2022-03-14T21:13:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://phoenixopendata.com/dataset/3eae9a4a-98b9-40c8-8df7-8c00c1756235/resource/28ccc0a5-49c8-495c-b91f-193de5ce2cb7/download/googletransit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-valley-metro-vm-gtfs-147.zip?alt=media",
+        "license": "http://www.opendefinition.org/licenses/odc-by"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-verde-lynx-gtfs-159.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-verde-lynx-gtfs-159.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 159,
+    "data_type": "gtfs",
+    "provider": "Verde Lynx",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Cottonwood",
+        "bounding_box": {
+            "minimum_latitude": 34.7372657347743,
+            "maximum_latitude": 38.554464,
+            "minimum_longitude": -121.427752,
+            "maximum_longitude": -111.76015,
+            "extracted_on": "2022-03-14T21:15:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/verdelynx-az-us/verdelynx-az-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-verde-lynx-gtfs-159.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-duarte-transit-gtfs-105.json
+++ b/catalogs/sources/gtfs/schedule/us-california-duarte-transit-gtfs-105.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 105,
+    "data_type": "gtfs",
+    "provider": "Duarte Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Duarte",
+        "bounding_box": {
+            "minimum_latitude": 34.1255727,
+            "maximum_latitude": 34.1515031,
+            "minimum_longitude": -117.9888608,
+            "maximum_longitude": -117.9324427,
+            "extracted_on": "2022-03-14T21:11:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/duartetransit-ca-us/duartetransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-duarte-transit-gtfs-105.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-lassen-rural-bus-lrb-gtfs-118.json
+++ b/catalogs/sources/gtfs/schedule/us-california-lassen-rural-bus-lrb-gtfs-118.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 118,
+    "data_type": "gtfs",
+    "provider": "Lassen Rural Bus (LRB)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Susanville",
+        "bounding_box": {
+            "minimum_latitude": 40.026325,
+            "maximum_latitude": 40.7193838449299,
+            "minimum_longitude": -121.230736,
+            "maximum_longitude": -120.103928,
+            "extracted_on": "2022-03-14T21:12:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lassen-ca-us/lassen-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-lassen-rural-bus-lrb-gtfs-118.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-mountain-transit-gtfs-107.json
+++ b/catalogs/sources/gtfs/schedule/us-california-mountain-transit-gtfs-107.json
@@ -5,7 +5,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
-        "municipality": "Big Bear ",
+        "municipality": "Big Bear",
         "bounding_box": {
             "minimum_latitude": 34.1005,
             "maximum_latitude": 34.272346961248,

--- a/catalogs/sources/gtfs/schedule/us-california-mountain-transit-gtfs-107.json
+++ b/catalogs/sources/gtfs/schedule/us-california-mountain-transit-gtfs-107.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 107,
+    "data_type": "gtfs",
+    "provider": "Mountain Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Big Bear ",
+        "bounding_box": {
+            "minimum_latitude": 34.1005,
+            "maximum_latitude": 34.272346961248,
+            "minimum_longitude": -117.326256,
+            "maximum_longitude": -116.790527,
+            "extracted_on": "2022-03-14T21:11:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bigbear-ca-us/bigbear-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-mountain-transit-gtfs-107.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-pass-transit-gtfs-106.json
+++ b/catalogs/sources/gtfs/schedule/us-california-pass-transit-gtfs-106.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 106,
+    "data_type": "gtfs",
+    "provider": "PASS Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Beaumont",
+        "bounding_box": {
+            "minimum_latitude": 33.9132530168794,
+            "maximum_latitude": 34.1001200694937,
+            "minimum_longitude": -117.29498155813,
+            "maximum_longitude": -116.799803651382,
+            "extracted_on": "2022-03-14T21:11:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/beaumont-ca-us/beaumont-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-pass-transit-gtfs-106.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-plumas-transit-gtfs-119.json
+++ b/catalogs/sources/gtfs/schedule/us-california-plumas-transit-gtfs-119.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 119,
+    "data_type": "gtfs",
+    "provider": "Plumas Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Chico",
+        "bounding_box": {
+            "minimum_latitude": 39.766285,
+            "maximum_latitude": 40.3123914556704,
+            "minimum_longitude": -121.240784,
+            "maximum_longitude": -120.460815,
+            "extracted_on": "2022-03-14T21:12:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/plumas-ca-us/plumas-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-plumas-transit-gtfs-119.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-redding-area-bus-authority-raba-gtfs-114.json
+++ b/catalogs/sources/gtfs/schedule/us-california-redding-area-bus-authority-raba-gtfs-114.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 114,
+    "data_type": "gtfs",
+    "provider": "Redding Area Bus Authority (RABA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Redding",
+        "bounding_box": {
+            "minimum_latitude": 40.432539731191,
+            "maximum_latitude": 40.888921,
+            "minimum_longitude": -122.570969723353,
+            "maximum_longitude": -121.65358,
+            "extracted_on": "2022-03-14T21:12:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/redding-ca-us/redding-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-redding-area-bus-authority-raba-gtfs-114.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-regional-transportation-commission-of-southern-nevada-rtc-gtfs-110.json
+++ b/catalogs/sources/gtfs/schedule/us-california-regional-transportation-commission-of-southern-nevada-rtc-gtfs-110.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 110,
+    "data_type": "gtfs",
+    "provider": "Regional Transportation Commission of Southern Nevada (RTC)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 35.960432,
+            "maximum_latitude": 36.314247,
+            "minimum_longitude": -115.331538,
+            "maximum_longitude": -114.825897,
+            "extracted_on": "2022-03-14T21:12:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://rtcws.rtcsnv.com/g/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-regional-transportation-commission-of-southern-nevada-rtc-gtfs-110.zip?alt=media",
+        "license": "https://www.rtcsnv.com/ways-to-travel/transit-services/for-developers/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sage-stage-gtfs-113.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sage-stage-gtfs-113.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 113,
+    "data_type": "gtfs",
+    "provider": "Sage Stage",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Modoc County",
+        "bounding_box": {
+            "minimum_latitude": 39.505241027309,
+            "maximum_latitude": 42.225403,
+            "minimum_longitude": -122.39204,
+            "maximum_longitude": -119.775224,
+            "extracted_on": "2022-03-14T21:12:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sagestage-ca-us/sagestage-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sage-stage-gtfs-113.zip?alt=media",
+        "license": "http://sagestage.com/gtfs-data/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-siskiyou-county-gtfs-117.json
+++ b/catalogs/sources/gtfs/schedule/us-california-siskiyou-county-gtfs-117.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 117,
+    "data_type": "gtfs",
+    "provider": "Siskiyou County ",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Yreka",
+        "bounding_box": {
+            "minimum_latitude": 41.1486739285779,
+            "maximum_latitude": 41.9080402531506,
+            "minimum_longitude": -123.545406460762,
+            "maximum_longitude": -122.127867,
+            "extracted_on": "2022-03-14T21:12:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/siskiyou-ca-us/siskiyou-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-siskiyou-county-gtfs-117.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-siskiyou-county-gtfs-117.json
+++ b/catalogs/sources/gtfs/schedule/us-california-siskiyou-county-gtfs-117.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 117,
     "data_type": "gtfs",
-    "provider": "Siskiyou County ",
+    "provider": "Siskiyou County",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",

--- a/catalogs/sources/gtfs/schedule/us-california-sunline-transit-agency-gtfs-108.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sunline-transit-agency-gtfs-108.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 108,
+    "data_type": "gtfs",
+    "provider": "SunLine Transit Agency",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Thousand Palms",
+        "bounding_box": {
+            "minimum_latitude": 33.522632,
+            "maximum_latitude": 34.179853,
+            "minimum_longitude": -117.326156,
+            "maximum_longitude": -115.921462,
+            "extracted_on": "2022-03-14T21:12:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.sunline.org/transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sunline-transit-agency-gtfs-108.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-tehama-rural-area-express-trax-susanville-indian-rancheria-public-transportation-program-gtfs-116.json
+++ b/catalogs/sources/gtfs/schedule/us-california-tehama-rural-area-express-trax-susanville-indian-rancheria-public-transportation-program-gtfs-116.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 116,
+    "data_type": "gtfs",
+    "provider": "Tehama Rural Area Express (TRAX), Susanville Indian Rancheria Public Transportation Program",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Red Bluff",
+        "bounding_box": {
+            "minimum_latitude": 39.7487666060753,
+            "maximum_latitude": 40.58389179,
+            "minimum_longitude": -122.459110730898,
+            "maximum_longitude": -120.657032132149,
+            "extracted_on": "2022-03-14T21:12:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/tehama-ca-us/tehama-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-tehama-rural-area-express-trax-susanville-indian-rancheria-public-transportation-program-gtfs-116.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-trinity-transit-gtfs-115.json
+++ b/catalogs/sources/gtfs/schedule/us-california-trinity-transit-gtfs-115.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 115,
+    "data_type": "gtfs",
+    "provider": "Trinity Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Redding",
+        "bounding_box": {
+            "minimum_latitude": 40.552313101815,
+            "maximum_latitude": 40.939975,
+            "minimum_longitude": -123.631417798777,
+            "maximum_longitude": -122.353498489549,
+            "extracted_on": "2022-03-14T21:12:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/weaverville-ca-us/weaverville-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-trinity-transit-gtfs-115.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-bustang-gtfs-169.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-bustang-gtfs-169.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 169,
+    "data_type": "gtfs",
+    "provider": "Bustang",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "municipality": "Denver",
+        "bounding_box": {
+            "minimum_latitude": 37.272749883951,
+            "maximum_latitude": 40.589906,
+            "minimum_longitude": -108.564255876715,
+            "maximum_longitude": -102.61859,
+            "extracted_on": "2022-03-14T21:15:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bustang-co-us/bustang-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-bustang-gtfs-169.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-bustang-gtfs-169.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-bustang-gtfs-169.json
@@ -4,7 +4,7 @@
     "provider": "Bustang",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "municipality": "Denver",
         "bounding_box": {
             "minimum_latitude": 37.272749883951,

--- a/catalogs/sources/gtfs/schedule/us-colorado-colorado-mountain-express-gtfs-172.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-colorado-mountain-express-gtfs-172.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 172,
+    "data_type": "gtfs",
+    "provider": "Colorado Mountain Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "municipality": "Denver",
+        "bounding_box": {
+            "minimum_latitude": 39.18745,
+            "maximum_latitude": 39.848793529552,
+            "minimum_longitude": -107.32773,
+            "maximum_longitude": -104.67285727756,
+            "extracted_on": "2022-03-14T21:15:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cme-co-us/cme-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-colorado-mountain-express-gtfs-172.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-colorado-mountain-express-gtfs-172.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-colorado-mountain-express-gtfs-172.json
@@ -4,7 +4,7 @@
     "provider": "Colorado Mountain Express",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "municipality": "Denver",
         "bounding_box": {
             "minimum_latitude": 39.18745,

--- a/catalogs/sources/gtfs/schedule/us-colorado-eco-transit-gtfs-173.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-eco-transit-gtfs-173.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 173,
+    "data_type": "gtfs",
+    "provider": "ECO Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Eagle County",
+        "bounding_box": {
+            "minimum_latitude": 39.2422533,
+            "maximum_latitude": 39.6977981,
+            "minimum_longitude": -107.063881,
+            "maximum_longitude": -106.2909511,
+            "extracted_on": "2022-03-14T21:15:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ecotransit-co-us/ecotransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-eco-transit-gtfs-173.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-grand-valley-transit-gtfs-161.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-grand-valley-transit-gtfs-161.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 161,
+    "data_type": "gtfs",
+    "provider": "Grand Valley Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 39.03089843,
+            "maximum_latitude": 39.16440652,
+            "minimum_longitude": -108.73842357,
+            "maximum_longitude": -108.34844192,
+            "extracted_on": "2022-03-14T21:15:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://emap.mesacounty.us/datadownload/Google_Transit_Feed/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-grand-valley-transit-gtfs-161.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-groome-transportation-colorado-springs-shuttle-gtfs-168.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-groome-transportation-colorado-springs-shuttle-gtfs-168.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 168,
+    "data_type": "gtfs",
+    "provider": "Groome Transportation - Colorado Springs Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Colorado Springs",
+        "bounding_box": {
+            "minimum_latitude": 38.7966284379563,
+            "maximum_latitude": 39.850194,
+            "minimum_longitude": -104.866849332176,
+            "maximum_longitude": -104.672462,
+            "extracted_on": "2022-03-14T21:15:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/coloradoshuttle-co-us/coloradoshuttle-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-groome-transportation-colorado-springs-shuttle-gtfs-168.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-gunnison-valley-transportation-authority-rta-gtfs-163.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-gunnison-valley-transportation-authority-rta-gtfs-163.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 163,
+    "data_type": "gtfs",
+    "provider": "Gunnison Valley Transportation Authority (RTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 38.544247,
+            "maximum_latitude": 38.90068,
+            "minimum_longitude": -106.981294,
+            "maximum_longitude": -106.845795,
+            "extracted_on": "2022-03-14T21:15:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/gunnisonrta_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-gunnison-valley-transportation-authority-rta-gtfs-163.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-regional-transportation-district-rtd-gtfs-178.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-regional-transportation-district-rtd-gtfs-178.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 178,
+    "data_type": "gtfs",
+    "provider": "Regional Transportation District (RTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Denver",
+        "bounding_box": {
+            "minimum_latitude": 39.456877,
+            "maximum_latitude": 40.206556,
+            "minimum_longitude": -105.584149,
+            "maximum_longitude": -104.669533,
+            "extracted_on": "2022-03-14T21:16:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.rtd-denver.com/files/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-regional-transportation-district-rtd-gtfs-178.zip?alt=media",
+        "license": "https://www.rtd-denver.com/business-center/open-spatial-data/gtfs-license-agreement"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-roaring-fork-transportation-authority-gtfs-162.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-roaring-fork-transportation-authority-gtfs-162.json
@@ -4,7 +4,7 @@
     "provider": "Roaring Fork Transportation Authority",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "municipality": "Aspen",
         "bounding_box": {
             "minimum_latitude": 39.0997929,

--- a/catalogs/sources/gtfs/schedule/us-colorado-roaring-fork-transportation-authority-gtfs-162.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-roaring-fork-transportation-authority-gtfs-162.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 162,
+    "data_type": "gtfs",
+    "provider": "Roaring Fork Transportation Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "municipality": "Aspen",
+        "bounding_box": {
+            "minimum_latitude": 39.0997929,
+            "maximum_latitude": 39.5715695,
+            "minimum_longitude": -107.7839413,
+            "maximum_longitude": -106.8009104,
+            "extracted_on": "2022-03-14T21:15:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/rfta-co-us/rfta-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-roaring-fork-transportation-authority-gtfs-162.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.json
@@ -4,7 +4,7 @@
     "provider": "Rocky Mountain National Park Shuttles",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "bounding_box": {
             "minimum_latitude": 40.310401,
             "maximum_latitude": 40.378788,

--- a/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 176,
+    "data_type": "gtfs",
+    "provider": "Rocky Mountain National Park Shuttles",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "bounding_box": {
+            "minimum_latitude": 40.310401,
+            "maximum_latitude": 40.378788,
+            "minimum_longitude": -105.64581,
+            "maximum_longitude": -105.513551,
+            "extracted_on": "2022-03-14T21:15:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/rockymountainnationalpark-co-us/rockymountainnationalpark-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-snowmass-village-transportation-gtfs-164.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-snowmass-village-transportation-gtfs-164.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 164,
+    "data_type": "gtfs",
+    "provider": "Snowmass Village Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "municipality": "Snowmass Village",
+        "bounding_box": {
+            "minimum_latitude": 39.20437012,
+            "maximum_latitude": 39.23284241,
+            "minimum_longitude": -106.9582664,
+            "maximum_longitude": -106.9205645,
+            "extracted_on": "2022-03-14T21:15:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/snowmassvillagetransportation-co-us/snowmassvillagetransportation-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-snowmass-village-transportation-gtfs-164.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-snowmass-village-transportation-gtfs-164.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-snowmass-village-transportation-gtfs-164.json
@@ -4,7 +4,7 @@
     "provider": "Snowmass Village Transportation",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "municipality": "Snowmass Village",
         "bounding_box": {
             "minimum_latitude": 39.20437012,

--- a/catalogs/sources/gtfs/schedule/us-colorado-town-of-estes-park-gtfs-177.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-town-of-estes-park-gtfs-177.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 177,
+    "data_type": "gtfs",
+    "provider": "Town of Estes Park",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Estes Park",
+        "bounding_box": {
+            "minimum_latitude": 40.338083,
+            "maximum_latitude": 40.401946,
+            "minimum_longitude": -105.586316,
+            "maximum_longitude": -105.482392,
+            "extracted_on": "2022-03-14T21:15:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://nationalparkservice.github.io/nps-gtfs/romo-epshuttles/shuttles/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-town-of-estes-park-gtfs-177.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-transfort-city-of-fort-collins-transfort-gtfs-179.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-transfort-city-of-fort-collins-transfort-gtfs-179.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 179,
     "data_type": "gtfs",
-    "provider": "Transfort \u2013 City of Fort Collins (Transfort)",
+    "provider": "Transfort – City of Fort Collins (Transfort)",
     "location": {
         "country_code": "US",
         "subdivision_name": "Colorado",

--- a/catalogs/sources/gtfs/schedule/us-colorado-transfort-city-of-fort-collins-transfort-gtfs-179.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-transfort-city-of-fort-collins-transfort-gtfs-179.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 179,
+    "data_type": "gtfs",
+    "provider": "Transfort \u2013 City of Fort Collins (Transfort)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Fort Collins",
+        "bounding_box": {
+            "minimum_latitude": 40.005197,
+            "maximum_latitude": 40.615324,
+            "minimum_longitude": -105.276138,
+            "maximum_longitude": -104.996501,
+            "extracted_on": "2022-03-14T21:16:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.ridetransfort.com/img/site_specific/uploads/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-transfort-city-of-fort-collins-transfort-gtfs-179.zip?alt=media",
+        "license": "http://www.ridetransfort.com/img/site_specific/uploads/Transfort_GTFS_License_Agreement.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-vail-transit-gtfs-174.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-vail-transit-gtfs-174.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 174,
+    "data_type": "gtfs",
+    "provider": "Vail Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "municipality": "Vail",
+        "bounding_box": {
+            "minimum_latitude": 39.6184584,
+            "maximum_latitude": 39.647846,
+            "minimum_longitude": -106.4333535,
+            "maximum_longitude": -106.2820446,
+            "extracted_on": "2022-03-14T21:15:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/vailtransit-co-us/vailtransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-vail-transit-gtfs-174.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-vail-transit-gtfs-174.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-vail-transit-gtfs-174.json
@@ -4,7 +4,7 @@
     "provider": "Vail Transit",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "municipality": "Vail",
         "bounding_box": {
             "minimum_latitude": 39.6184584,

--- a/catalogs/sources/gtfs/schedule/us-colorado-via-mobility-gtfs-180.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-via-mobility-gtfs-180.json
@@ -4,7 +4,7 @@
     "provider": "Via Mobility",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "municipality": "Boulder",
         "bounding_box": {
             "minimum_latitude": 39.930438,

--- a/catalogs/sources/gtfs/schedule/us-colorado-via-mobility-gtfs-180.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-via-mobility-gtfs-180.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 180,
+    "data_type": "gtfs",
+    "provider": "Via Mobility",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "municipality": "Boulder",
+        "bounding_box": {
+            "minimum_latitude": 39.930438,
+            "maximum_latitude": 40.0633309480155,
+            "minimum_longitude": -105.594805,
+            "maximum_longitude": -105.16944,
+            "extracted_on": "2022-03-14T21:16:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/viamobilityservices-co-us/viamobilityservices-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-via-mobility-gtfs-180.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-winter-park-transit-gtfs-175.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-winter-park-transit-gtfs-175.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 175,
+    "data_type": "gtfs",
+    "provider": "Winter Park Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado ",
+        "municipality": "Winter Park",
+        "bounding_box": {
+            "minimum_latitude": 39.875221225649,
+            "maximum_latitude": 40.092112815711,
+            "minimum_longitude": -105.94675589542,
+            "maximum_longitude": -105.755830246798,
+            "extracted_on": "2022-03-14T21:15:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/winterpark-co-us/winterpark-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-winter-park-transit-gtfs-175.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-winter-park-transit-gtfs-175.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-winter-park-transit-gtfs-175.json
@@ -4,7 +4,7 @@
     "provider": "Winter Park Transit",
     "location": {
         "country_code": "US",
-        "subdivision_name": "Colorado ",
+        "subdivision_name": "Colorado",
         "municipality": "Winter Park",
         "bounding_box": {
             "minimum_latitude": 39.875221225649,

--- a/catalogs/sources/gtfs/schedule/us-idaho-mountain-rides-transportation-authority-mrta-gtfs-143.json
+++ b/catalogs/sources/gtfs/schedule/us-idaho-mountain-rides-transportation-authority-mrta-gtfs-143.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 143,
+    "data_type": "gtfs",
+    "provider": "Mountain Rides Transportation Authority  (MRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Idaho",
+        "municipality": "Ketchum",
+        "bounding_box": {
+            "minimum_latitude": 43.4524983137032,
+            "maximum_latitude": 43.7199139686023,
+            "minimum_longitude": -114.4052723050118,
+            "maximum_longitude": -114.2553716897965,
+            "extracted_on": "2022-03-14T21:13:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/mountainrides-id-us/mountainrides-id-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-idaho-mountain-rides-transportation-authority-mrta-gtfs-143.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-idaho-pocatello-regional-transit-gtfs-171.json
+++ b/catalogs/sources/gtfs/schedule/us-idaho-pocatello-regional-transit-gtfs-171.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 171,
+    "data_type": "gtfs",
+    "provider": "Pocatello Regional Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Idaho",
+        "municipality": "Pocatello",
+        "bounding_box": {
+            "minimum_latitude": 42.8234842,
+            "maximum_latitude": 42.93489,
+            "minimum_longitude": -112.4958565,
+            "maximum_longitude": -112.3898471,
+            "extracted_on": "2022-03-14T21:15:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://pocatellotransit.com/gtfs/pocatello-regional-transit-gtfs.zip?v=current",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-idaho-pocatello-regional-transit-gtfs-171.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-idaho-valleyride-gtfs-142.json
+++ b/catalogs/sources/gtfs/schedule/us-idaho-valleyride-gtfs-142.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 142,
+    "data_type": "gtfs",
+    "provider": "ValleyRide",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Idaho",
+        "municipality": "Boise",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-14T21:13:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.valleyregionaltransit.org/GTFS/vrt_transit1.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-idaho-valleyride-gtfs-142.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-mississipi-jtran-gtfs-155.json
+++ b/catalogs/sources/gtfs/schedule/us-mississipi-jtran-gtfs-155.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 155,
+    "data_type": "gtfs",
+    "provider": "JTRAN",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Mississipi",
+        "municipality": "Jackson",
+        "bounding_box": {
+            "minimum_latitude": 32.2419270099218,
+            "maximum_latitude": 32.4002295047721,
+            "minimum_longitude": -90.27725556,
+            "maximum_longitude": -90.1110177815618,
+            "extracted_on": "2022-03-14T21:14:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/jatran-ms-us/jatran-ms-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-mississipi-jtran-gtfs-155.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-nevada-regional-transportation-commission-rtc-gtfs-120.json
+++ b/catalogs/sources/gtfs/schedule/us-nevada-regional-transportation-commission-rtc-gtfs-120.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 120,
+    "data_type": "gtfs",
+    "provider": "Regional Transportation Commission (RTC)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Nevada",
+        "bounding_box": {
+            "minimum_latitude": 39.157417,
+            "maximum_latitude": 39.65477,
+            "minimum_longitude": -119.897018,
+            "maximum_longitude": -119.697891,
+            "extracted_on": "2022-03-14T21:12:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/rtc-nv-us/rtc-nv-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-nevada-regional-transportation-commission-rtc-gtfs-120.zip?alt=media",
+        "license": "https://www.rtcwashoe.com/terms-of-use/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-abq-ride-gtfs-166.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-abq-ride-gtfs-166.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 166,
+    "data_type": "gtfs",
+    "provider": "ABQ RIDE",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "municipality": "Albuquerque",
+        "bounding_box": {
+            "minimum_latitude": 34.951438,
+            "maximum_latitude": 35.243993,
+            "minimum_longitude": -106.753875,
+            "maximum_longitude": -106.489192,
+            "extracted_on": "2022-03-14T21:15:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.cabq.gov/transit/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-abq-ride-gtfs-166.zip?alt=media",
+        "license": "http://www.cabq.gov/abq-data/abq-data-disclaimer-1"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-carlsbad-municipal-transit-system-gtfs-149.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-carlsbad-municipal-transit-system-gtfs-149.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 149,
+    "data_type": "gtfs",
+    "provider": "Carlsbad Municipal Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "municipality": "Carlsbad",
+        "bounding_box": {
+            "minimum_latitude": 32.3748,
+            "maximum_latitude": 32.4425,
+            "minimum_longitude": -104.2649,
+            "maximum_longitude": -104.221,
+            "extracted_on": "2022-03-14T21:13:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/ethan-nelson/carlsbadnmtransit/blob/master/gtfs-odbl/carlsbadtransit-odbl.zip?raw=true",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-carlsbad-municipal-transit-system-gtfs-149.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-navajo-transit-system-gtfs-157.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-navajo-transit-system-gtfs-157.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 157,
+    "data_type": "gtfs",
+    "provider": "Navajo Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "bounding_box": {
+            "minimum_latitude": 35.19678643,
+            "maximum_latitude": 37.63285827,
+            "minimum_longitude": -111.23706119,
+            "maximum_longitude": -108.13576118,
+            "extracted_on": "2022-03-14T21:15:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/navajo_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-navajo-transit-system-gtfs-157.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-red-apple-transit-gtfs-160.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-red-apple-transit-gtfs-160.json
@@ -5,7 +5,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "New Mexico",
-        "municipality": "Farmington ",
+        "municipality": "Farmington",
         "bounding_box": {
             "minimum_latitude": 36.7009555,
             "maximum_latitude": 36.8269741,

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-red-apple-transit-gtfs-160.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-red-apple-transit-gtfs-160.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 160,
+    "data_type": "gtfs",
+    "provider": "Red Apple Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "municipality": "Farmington ",
+        "bounding_box": {
+            "minimum_latitude": 36.7009555,
+            "maximum_latitude": 36.8269741,
+            "minimum_longitude": -108.3599403,
+            "maximum_longitude": -107.9791283,
+            "extracted_on": "2022-03-14T21:15:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/redappletransit-nm-us/redappletransit-nm-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-red-apple-transit-gtfs-160.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-rio-metro-regional-transit-district-gtfs-165.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-rio-metro-regional-transit-district-gtfs-165.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 165,
+    "data_type": "gtfs",
+    "provider": "Rio Metro Regional Transit District",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "bounding_box": {
+            "minimum_latitude": 34.653719,
+            "maximum_latitude": 36.030039,
+            "minimum_longitude": -106.96151,
+            "maximum_longitude": -105.946625,
+            "extracted_on": "2022-03-14T21:15:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.riometro.org/DocumentCenter/View/2195/nmrailrunner_google_transit",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-rio-metro-regional-transit-district-gtfs-165.zip?alt=media",
+        "license": "https://www.riometro.org/261/GTFS-Data"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-sandia-shuttle-gtfs-167.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-sandia-shuttle-gtfs-167.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 167,
+    "data_type": "gtfs",
+    "provider": "Sandia Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "bounding_box": {
+            "minimum_latitude": 35.049588,
+            "maximum_latitude": 35.6871,
+            "minimum_longitude": -106.616901,
+            "maximum_longitude": -105.9419,
+            "extracted_on": "2022-03-14T21:15:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sandiashuttle-nm-us/sandiashuttle-nm-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-sandia-shuttle-gtfs-167.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 135,
+    "data_type": "gtfs",
+    "provider": "LINX Transit, Linn-Benton Loop, Albany Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Albany",
+        "bounding_box": {
+            "minimum_latitude": 44.515628,
+            "maximum_latitude": 44.657,
+            "minimum_longitude": -123.273597394,
+            "maximum_longitude": -122.899202,
+            "extracted_on": "2022-03-14T21:13:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/albanytransit-or-us/albanytransit-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-basin-transit-service-bts-gtfs-125.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-basin-transit-service-bts-gtfs-125.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 125,
+    "data_type": "gtfs",
+    "provider": "Basin Transit Service  (BTS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Klamath Falls",
+        "bounding_box": {
+            "minimum_latitude": 42.174625,
+            "maximum_latitude": 42.5752845423563,
+            "minimum_longitude": -121.874721,
+            "maximum_longitude": -121.271743550926,
+            "extracted_on": "2022-03-14T21:12:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/basin-or-us/basin-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-basin-transit-service-bts-gtfs-125.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-benton-area-transportation-gtfs-126.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-benton-area-transportation-gtfs-126.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 126,
+    "data_type": "gtfs",
+    "provider": "Benton Area Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Corvallis",
+        "bounding_box": {
+            "minimum_latitude": 44.539028,
+            "maximum_latitude": 44.67828,
+            "minimum_longitude": -124.05396483388,
+            "maximum_longitude": -123.066012766411,
+            "extracted_on": "2022-03-14T21:12:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/benton-or-us/benton-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-benton-area-transportation-gtfs-126.zip?alt=media",
+        "license": "https://oregon-gtfs.trilliumtransit.com"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-caravan-airport-transportation-gtfs-127.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-caravan-airport-transportation-gtfs-127.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 127,
+    "data_type": "gtfs",
+    "provider": "Caravan Airport Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "bounding_box": {
+            "minimum_latitude": 44.3112647738553,
+            "maximum_latitude": 45.588654,
+            "minimum_longitude": -124.104154855013,
+            "maximum_longitude": -122.593117,
+            "extracted_on": "2022-03-14T21:12:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/caravan-or-us/caravan-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-caravan-airport-transportation-gtfs-127.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-cascades-east-transit-cet-gtfs-138.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-cascades-east-transit-cet-gtfs-138.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 138,
+    "data_type": "gtfs",
+    "provider": "Cascades East Transit  (CET)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Bend",
+        "bounding_box": {
+            "minimum_latitude": 43.67033,
+            "maximum_latitude": 44.7779309239482,
+            "minimum_longitude": -121.678688,
+            "maximum_longitude": -120.842453,
+            "extracted_on": "2022-03-14T21:13:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/cascadeseast-or-us/cascadeseast-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-cascades-east-transit-cet-gtfs-138.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-central-oregon-breeze-gtfs-139.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-central-oregon-breeze-gtfs-139.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 139,
+    "data_type": "gtfs",
+    "provider": "Central Oregon Breeze",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Bend",
+        "bounding_box": {
+            "minimum_latitude": 44.058324,
+            "maximum_latitude": 45.589073,
+            "minimum_longitude": -122.677383,
+            "maximum_longitude": -121.13298,
+            "extracted_on": "2022-03-14T21:13:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/cobreeze-or-us/cobreeze-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-central-oregon-breeze-gtfs-139.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-cherriots-gtfs-128.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-cherriots-gtfs-128.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 128,
+    "data_type": "gtfs",
+    "provider": "Cherriots",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Salem",
+        "bounding_box": {
+            "minimum_latitude": 44.749211,
+            "maximum_latitude": 45.310938,
+            "minimum_longitude": -123.31752,
+            "maximum_longitude": -122.416812,
+            "extracted_on": "2022-03-14T21:12:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.cherriots.org/media/doc/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-cherriots-gtfs-128.zip?alt=media",
+        "license": "https://www.cherriots.org/datalicense/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-city-2-city-shuttle-gtfs-129.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-city-2-city-shuttle-gtfs-129.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 129,
+    "data_type": "gtfs",
+    "provider": "City 2 City Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Eugene",
+        "bounding_box": {
+            "minimum_latitude": 44.0433463805757,
+            "maximum_latitude": 45.5891390943276,
+            "minimum_longitude": -123.074482932092,
+            "maximum_longitude": -122.592041363794,
+            "extracted_on": "2022-03-14T21:12:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/citytocityshuttle-or-us/citytocityshuttle-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-city-2-city-shuttle-gtfs-129.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-city-of-corvallis-gtfs-136.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-city-of-corvallis-gtfs-136.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 136,
+    "data_type": "gtfs",
+    "provider": "City of Corvallis",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Corvallis",
+        "bounding_box": {
+            "minimum_latitude": 44.530912,
+            "maximum_latitude": 44.615308,
+            "minimum_longitude": -123.377022609,
+            "maximum_longitude": -123.234437,
+            "extracted_on": "2022-03-14T21:13:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/corvallis-or-us/corvallis-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-city-of-corvallis-gtfs-136.zip?alt=media",
+        "license": "https://oregon-gtfs.trilliumtransit.com"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-diamond-express-gtfs-130.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-diamond-express-gtfs-130.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 130,
+    "data_type": "gtfs",
+    "provider": "Diamond Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Oakridge",
+        "bounding_box": {
+            "minimum_latitude": 43.742044,
+            "maximum_latitude": 44.0551965657442,
+            "minimum_longitude": -123.094219662968,
+            "maximum_longitude": -122.460348,
+            "extracted_on": "2022-03-14T21:13:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/diamondexpress-or-us/diamondexpress-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-diamond-express-gtfs-130.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-bend-gtfs-140.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-bend-gtfs-140.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 140,
+    "data_type": "gtfs",
+    "provider": "Eugene to BEND",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Eugene",
+        "bounding_box": {
+            "minimum_latitude": 43.3690937400976,
+            "maximum_latitude": 44.9329323929629,
+            "minimum_longitude": -124.213689565659,
+            "maximum_longitude": -121.282496452332,
+            "extracted_on": "2022-03-14T21:13:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/eugenetobend-or-us/eugenetobend-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-eugene-to-bend-gtfs-140.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-josephine-county-transit-jct-gtfs-121.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-josephine-county-transit-jct-gtfs-121.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 121,
+    "data_type": "gtfs",
+    "provider": "Josephine County Transit (JCT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Grants Pass",
+        "bounding_box": {
+            "minimum_latitude": 42.162895,
+            "maximum_latitude": 42.69524,
+            "minimum_longitude": -123.650417,
+            "maximum_longitude": -122.871036,
+            "extracted_on": "2022-03-14T21:12:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/josephinecounty-or-us/josephinecounty-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-josephine-county-transit-jct-gtfs-121.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-klamath-shuttle-crater-lake-trolley-gtfs-124.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-klamath-shuttle-crater-lake-trolley-gtfs-124.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 124,
+    "data_type": "gtfs",
+    "provider": "Klamath Shuttle - Crater Lake Trolley",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Klamath Falls",
+        "bounding_box": {
+            "minimum_latitude": 42.225506,
+            "maximum_latitude": 42.91113,
+            "minimum_longitude": -122.144812,
+            "maximum_longitude": -121.771952,
+            "extracted_on": "2022-03-14T21:12:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/craterlaketrolley-or-us/craterlaketrolley-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-klamath-shuttle-crater-lake-trolley-gtfs-124.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-lane-transit-district-ltd-gtfs-131.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-lane-transit-district-ltd-gtfs-131.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 131,
+    "data_type": "gtfs",
+    "provider": "Lane Transit District (LTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Eugene",
+        "bounding_box": {
+            "minimum_latitude": 43.7849362,
+            "maximum_latitude": 44.2226569,
+            "minimum_longitude": -123.3561683,
+            "maximum_longitude": -122.1152746,
+            "extracted_on": "2022-03-14T21:13:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.ltd.org/files/library/ltdgtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-lane-transit-district-ltd-gtfs-131.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-linn-shuttle-gtfs-137.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-linn-shuttle-gtfs-137.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 137,
+    "data_type": "gtfs",
+    "provider": "Linn Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Sweet Home",
+        "bounding_box": {
+            "minimum_latitude": 44.348301,
+            "maximum_latitude": 44.6391624771784,
+            "minimum_longitude": -123.115110397339,
+            "maximum_longitude": -121.996021,
+            "extracted_on": "2022-03-14T21:13:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/linnshuttle-or-us/linnshuttle-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-linn-shuttle-gtfs-137.zip?alt=media",
+        "license": "https://oregon-gtfs.trilliumtransit.com"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-malheur-council-on-aging-community-services-gtfs-141.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-malheur-council-on-aging-community-services-gtfs-141.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 141,
+    "data_type": "gtfs",
+    "provider": "Malheur Council on Aging & Community Services",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Ontario",
+        "bounding_box": {
+            "minimum_latitude": 43.876076,
+            "maximum_latitude": 44.0356123,
+            "minimum_longitude": -117.2416815,
+            "maximum_longitude": -116.9238317,
+            "extracted_on": "2022-03-14T21:13:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/mcacs-or-us/mcacs-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-malheur-council-on-aging-community-services-gtfs-141.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-oregon-express-shuttle-gtfs-132.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-oregon-express-shuttle-gtfs-132.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 132,
+    "data_type": "gtfs",
+    "provider": "Oregon Express Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Albany",
+        "bounding_box": {
+            "minimum_latitude": 44.0431237157416,
+            "maximum_latitude": 45.58905,
+            "minimum_longitude": -123.28133,
+            "maximum_longitude": -122.59229,
+            "extracted_on": "2022-03-14T21:13:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/oregonexpressshuttle-or-us/oregonexpressshuttle-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-oregon-express-shuttle-gtfs-132.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-pacific-crest-bus-lines-gtfs-133.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-pacific-crest-bus-lines-gtfs-133.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 133,
+    "data_type": "gtfs",
+    "provider": "Pacific Crest Bus Lines",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Eugene",
+        "bounding_box": {
+            "minimum_latitude": 42.2067453083721,
+            "maximum_latitude": 44.7365194756296,
+            "minimum_longitude": -124.213689565659,
+            "maximum_longitude": -121.161056,
+            "extracted_on": "2022-03-14T21:13:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/pacificcrest-or-us/pacificcrest-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-pacific-crest-bus-lines-gtfs-133.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-people-mover-gtfs-112.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-people-mover-gtfs-112.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 112,
+    "data_type": "gtfs",
+    "provider": "People Mover",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "bounding_box": {
+            "minimum_latitude": 43.5730477,
+            "maximum_latitude": 46.0523909,
+            "minimum_longitude": -121.300789,
+            "maximum_longitude": -116.9382,
+            "extracted_on": "2022-03-14T21:12:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/peoplemover-or-us/peoplemover-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-people-mover-gtfs-112.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-rogue-valley-transportation-district-rvtd-gtfs-122.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-rogue-valley-transportation-district-rvtd-gtfs-122.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 122,
+    "data_type": "gtfs",
+    "provider": "Rogue Valley Transportation District (RVTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Medford",
+        "bounding_box": {
+            "minimum_latitude": 42.175814788092,
+            "maximum_latitude": 42.481486,
+            "minimum_longitude": -122.9667,
+            "maximum_longitude": -122.671537,
+            "extracted_on": "2022-03-14T21:12:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/rvtd-or-us/rvtd-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-rogue-valley-transportation-district-rvtd-gtfs-122.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-south-lane-wheels-gtfs-134.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-south-lane-wheels-gtfs-134.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 134,
+    "data_type": "gtfs",
+    "provider": "South Lane Wheels",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Cottage Grove ",
+        "bounding_box": {
+            "minimum_latitude": 43.780193,
+            "maximum_latitude": 43.80619,
+            "minimum_longitude": -123.069565,
+            "maximum_longitude": -123.039391,
+            "extracted_on": "2022-03-14T21:13:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/southlanewheels-or-us/southlanewheels-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-south-lane-wheels-gtfs-134.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-south-lane-wheels-gtfs-134.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-south-lane-wheels-gtfs-134.json
@@ -5,7 +5,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "Oregon",
-        "municipality": "Cottage Grove ",
+        "municipality": "Cottage Grove",
         "bounding_box": {
             "minimum_latitude": 43.780193,
             "maximum_latitude": 43.80619,

--- a/catalogs/sources/gtfs/schedule/us-oregon-utrans-gtfs-123.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-utrans-gtfs-123.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 123,
+    "data_type": "gtfs",
+    "provider": "UTrans",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Roseburg",
+        "bounding_box": {
+            "minimum_latitude": 42.737182450611,
+            "maximum_latitude": 43.695870028905,
+            "minimum_longitude": -124.17377849378,
+            "maximum_longitude": -123.01875661,
+            "extracted_on": "2022-03-14T21:12:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/umpquatransit-or-us/umpquatransit-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-utrans-gtfs-123.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-capital-metro-gtfs-150.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-capital-metro-gtfs-150.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 150,
+    "data_type": "gtfs",
+    "provider": "Capital Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Austin",
+        "bounding_box": {
+            "minimum_latitude": 30.147252,
+            "maximum_latitude": 30.587897,
+            "minimum_longitude": -97.9911,
+            "maximum_longitude": -97.370389,
+            "extracted_on": "2022-03-14T21:14:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.texas.gov/download/r4v4-vz24/application/zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-capital-metro-gtfs-150.zip?alt=media",
+        "license": "https://www.capmetro.org/metrolabs/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-dallas-area-rapid-transit-dart-gtfs-152.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-dallas-area-rapid-transit-dart-gtfs-152.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 152,
+    "data_type": "gtfs",
+    "provider": "Dallas Area Rapid Transit (DART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Dallas",
+        "bounding_box": {
+            "minimum_latitude": 32.55906,
+            "maximum_latitude": 33.084348,
+            "minimum_longitude": -97.328201,
+            "maximum_longitude": -96.562516,
+            "extracted_on": "2022-03-14T21:14:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.dart.org/transitdata/latest/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-dallas-area-rapid-transit-dart-gtfs-152.zip?alt=media",
+        "license": "https://ridedart.com/business-center/developer-resources"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-denton-county-transportation-authority-dcta-gtfs-151.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-denton-county-transportation-authority-dcta-gtfs-151.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 151,
+    "data_type": "gtfs",
+    "provider": "Denton County Transportation Authority (DCTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Denton",
+        "bounding_box": {
+            "minimum_latitude": 32.9219927592917,
+            "maximum_latitude": 33.254102116153,
+            "minimum_longitude": -97.318639869811,
+            "maximum_longitude": -96.926476,
+            "extracted_on": "2022-03-14T21:14:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://trilliumtransit.com/transit_feeds/dentoncounty-tx-us/dentoncounty-tx-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-denton-county-transportation-authority-dcta-gtfs-151.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-metro-houston-gtfs-154.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-metro-houston-gtfs-154.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 154,
+    "data_type": "gtfs",
+    "provider": "METRO Houston",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Houston",
+        "bounding_box": {
+            "minimum_latitude": 29.531098,
+            "maximum_latitude": 30.30941,
+            "minimum_longitude": -95.776256,
+            "maximum_longitude": -94.986966,
+            "extracted_on": "2022-03-14T21:14:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.ridemetro.org/Downloads/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-metro-houston-gtfs-154.zip?alt=media",
+        "license": "https://www.ridemetro.org/Pages/DigitalAssets.aspx"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-star-transit-gtfs-153.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-star-transit-gtfs-153.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 153,
+    "data_type": "gtfs",
+    "provider": "STAR Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Dallas",
+        "bounding_box": {
+            "minimum_latitude": 32.564837,
+            "maximum_latitude": 32.7657540972602,
+            "minimum_longitude": -96.946236,
+            "maximum_longitude": -96.249843,
+            "extracted_on": "2022-03-14T21:14:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/startransit-tx-us/startransit-tx-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-star-transit-gtfs-153.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-sun-metro-gtfs-148.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-sun-metro-gtfs-148.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 148,
+    "data_type": "gtfs",
+    "provider": "Sun Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "El Paso",
+        "bounding_box": {
+            "minimum_latitude": 31.584279,
+            "maximum_latitude": 31.960464,
+            "minimum_longitude": -106.624945,
+            "maximum_longitude": -106.216594,
+            "extracted_on": "2022-03-14T21:13:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://transit.sunmetro.net/google_transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-sun-metro-gtfs-148.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-utah-suntran-utah-gtfs-111.json
+++ b/catalogs/sources/gtfs/schedule/us-utah-suntran-utah-gtfs-111.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 111,
+    "data_type": "gtfs",
+    "provider": "SunTran Utah",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Utah",
+        "municipality": "St. George",
+        "bounding_box": {
+            "minimum_latitude": 37.061946,
+            "maximum_latitude": 37.188009,
+            "minimum_longitude": -113.679685,
+            "maximum_longitude": -113.490836,
+            "extracted_on": "2022-03-14T21:12:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.fivecounty.utah.gov/transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-utah-suntran-utah-gtfs-111.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-utah-utah-transit-authority-uta-gtfs-170.json
+++ b/catalogs/sources/gtfs/schedule/us-utah-utah-transit-authority-uta-gtfs-170.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 170,
+    "data_type": "gtfs",
+    "provider": "Utah Transit Authority (UTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Utah",
+        "municipality": "Salt Lake City",
+        "bounding_box": {
+            "minimum_latitude": 39.975518,
+            "maximum_latitude": 41.528157,
+            "minimum_longitude": -112.325431,
+            "maximum_longitude": -111.546827,
+            "extracted_on": "2022-03-14T21:15:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsfeed.rideuta.com/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-utah-utah-transit-authority-uta-gtfs-170.zip?alt=media",
+        "license": "http://developer.rideuta.com/TermsOfUse.aspx"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the first GTFS Schedule sources in the catalogs. It also serves as a first test before importing all of the data.

Changes:

- The GTFS Schedule Sources catalog is extended with 76 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~