### PR TITLE
feat: Support accents in JSON files

### DIFF
--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -25,7 +25,7 @@ def to_json(path, obj):
     :param obj: The JSON compatible object to save.
     """
     with open(path, "w") as fp:
-        json.dump(obj, fp, indent=4)
+        json.dump(obj, fp, indent=4, ensure_ascii=False)
 
 
 def from_json(path):

--- a/tools/representations.py
+++ b/tools/representations.py
@@ -287,7 +287,7 @@ class GtfsScheduleSource(Source):
             LATEST: self.latest_url,
             LICENSE: self.license_url,
         }
-        return json.dumps(self.schematize(**attributes))
+        return json.dumps(self.schematize(**attributes), ensure_ascii=False)
 
     def __repr__(self):
         return f"GtfsScheduleSource({self.__str__()})"
@@ -451,7 +451,7 @@ class GtfsRealtimeSource(Source):
             REALTIME_TRIP_UPDATES: self.trip_updates_url,
             REALTIME_ALERTS: self.service_alerts_url,
         }
-        return json.dumps(self.schematize(**attributes))
+        return json.dumps(self.schematize(**attributes), ensure_ascii=False)
 
     def __repr__(self):
         return f"GtfsRealtimeSource({self.__str__()})"

--- a/tools/tests/test_representations.py
+++ b/tools/tests/test_representations.py
@@ -265,7 +265,7 @@ class TestGtfsScheduleSource(TestCase):
     def setUp(self):
         self.test_mdb_source_id = "some_numerical_id"
         self.test_data_type = "some_data_type"
-        self.test_provider = "some_provider"
+        self.test_provider = "some_provider_with_accents_éàç"
         self.test_name = "some_name"
         self.test_filename = "some_filename"
         self.test_country_code = "some_country_code"
@@ -327,7 +327,7 @@ class TestGtfsScheduleSource(TestCase):
         mock_schema.return_value = self.test_schema
         instance = GtfsScheduleSource(filename=self.test_filename, **self.test_schema)
         under_test = instance.__str__()
-        self.assertEqual(under_test, json.dumps(self.test_schema))
+        self.assertEqual(under_test, json.dumps(self.test_schema, ensure_ascii=False))
 
     @patch("tools.representations.GtfsScheduleSource.__str__")
     def test_repr(self, mock_str):
@@ -535,7 +535,7 @@ class TestGtfsRealtimeSource(TestCase):
     def setUp(self):
         self.test_mdb_source_id = "some_numerical_id"
         self.test_data_type = "some_data_type"
-        self.test_provider = "some_provider"
+        self.test_provider = "some_provider_with_accents_éàç"
         self.test_name = "some_name"
         self.test_filename = "some_filename"
         self.test_static_reference = "some_static_reference"
@@ -573,7 +573,7 @@ class TestGtfsRealtimeSource(TestCase):
         mock_schema.return_value = self.test_schema
         instance = GtfsRealtimeSource(filename=self.test_filename, **self.test_schema)
         under_test = instance.__str__()
-        self.assertEqual(under_test, json.dumps(self.test_schema))
+        self.assertEqual(under_test, json.dumps(self.test_schema, ensure_ascii=False))
 
     @patch("tools.representations.GtfsRealtimeSource.static_catalog")
     @patch("tools.representations.GtfsRealtimeSource.__str__")
@@ -719,7 +719,6 @@ class TestGtfsRealtimeSource(TestCase):
     def test_get_static_source(self, mock_static_catalog):
         test_static_source = "some_static_source"
         mock_static_catalog.get_source.return_value = test_static_source
-        print(mock_static_catalog)
         under_test = GtfsRealtimeSource.get_static_source(self.test_static_reference)
         self.assertEqual(under_test, test_static_source)
 


### PR DESCRIPTION
**Summary:**

Fixes #80: Support accents in JSON files

This PR updates every occurrence of `json.dump` and `json.dumps` to add the parameter `ensure_ascii=False`

Changes:

- `helpers.py` and `representations.py` to update `json.dump` and `json.dumps` occurrences.

**Expected behavior:** 

The JSON files are saved with accents and the representations display them as well.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~