### PR TITLE
feat: Automatically replace accents for file names and latest URLs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ Rtree==0.9.7
 Shapely==1.8.0
 six==1.16.0
 toml==0.10.2
+Unidecode==1.3.4
 urllib3==1.26.8
 utm==0.7.0
 virtualenv==20.13.0

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -5,6 +5,7 @@ import gtfs_kit
 from requests.exceptions import MissingSchema
 import pandas as pd
 from pandas.errors import ParserError
+from unidecode import unidecode
 from tools.constants import (
     STOP_LAT,
     STOP_LON,
@@ -170,9 +171,11 @@ def create_filename(
 
 
 def normalize(string):
-    return "-".join(
-        ("".join(s for s in string.lower() if s.isalnum() or s == " ")).split()
+    string = "-".join(
+        ("".join(s for s in string.lower() if s.isalnum() or s in [" ", "-"])).split()
     )
+    string = unidecode(string, "utf-8")
+    return unidecode(string)
 
 
 def get_iso_time():

--- a/tools/tests/test_helpers.py
+++ b/tools/tests/test_helpers.py
@@ -270,6 +270,10 @@ class TestCreationFunctions(TestCase):
         under_test = normalize(test_string)
         self.assertEqual(under_test, "sources-test")
 
+        test_string = "SOURCé-çø-čõå-ćō-cåã."
+        under_test = normalize(test_string)
+        self.assertEqual(under_test, "source-co-coa-co-caa")
+
     @freeze_time("2022-01-01")
     def test_get_iso_time(self):
         test_time = "2022-01-01T00:00:00+00:00"


### PR DESCRIPTION
**Summary:**

Fixes #76: Automatically replace accents for filename/latest URL

This PR updates the string normalizer function to replace accents automatically.

Changes:

- `helpers.py` to update `normalize()`

**Expected behavior:** 

The `filename` and latest_url of a source no longer contain accents when the `provider` or `subdivision_name` do.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~