### PR TITLE
feat: Updates job names in workflows (require up to date before merging)

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  export-to-csv:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  integration-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python_style_checker.yml
+++ b/.github/workflows/python_style_checker.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  style-checker:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
**Summary:**

Fixes #79: Require branches to be up to date before merging

This PR updates the job names for 4 different workflows. These job names were all set to "build" before, but to force a branch to be up to date before merging a PR, GitHub asks to choose specific jobs that will be required to pass in the verification process.

Changes:

- The job names in `export_to_csv.yml`, `integration_tests.yml`, `unit_tests.yml` and `python_style_checker.yml`.

**Expected behavior:** 

Before merging a PR into `main`, the branch will be required to be up to date with the latest version of `main`. This will avoid duplication of `mdb_source_id`. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~