### PR TITLE
feat: Second import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-alaska-anchorage-people-mover-gtfs-225.json
+++ b/catalogs/sources/gtfs/schedule/us-alaska-anchorage-people-mover-gtfs-225.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 225,
+    "data_type": "gtfs",
+    "provider": "Anchorage People Mover",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alaska",
+        "municipality": "Anchorage",
+        "bounding_box": {
+            "minimum_latitude": 61.099553,
+            "maximum_latitude": 61.327765,
+            "minimum_longitude": -149.979292,
+            "maximum_longitude": -149.570576,
+            "extracted_on": "2022-03-15T17:43:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.muni.org/People_Mover.gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alaska-anchorage-people-mover-gtfs-225.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alaska-inter-island-ferry-gtfs-243.json
+++ b/catalogs/sources/gtfs/schedule/us-alaska-inter-island-ferry-gtfs-243.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 243,
+    "data_type": "gtfs",
+    "provider": "Inter-Island Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alaska",
+        "municipality": "Klawock ",
+        "bounding_box": {
+            "minimum_latitude": 55.267992850502,
+            "maximum_latitude": 55.4904042,
+            "minimum_longitude": -132.62209827778,
+            "maximum_longitude": -131.5681712827,
+            "extracted_on": "2022-03-15T17:43:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/interisland-ak-us/interisland-ak-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alaska-inter-island-ferry-gtfs-243.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alaska-ketchikan-gateway-borough-gtfs-244.json
+++ b/catalogs/sources/gtfs/schedule/us-alaska-ketchikan-gateway-borough-gtfs-244.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 244,
+    "data_type": "gtfs",
+    "provider": "Ketchikan Gateway Borough",
+    "name": "The Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alaska",
+        "municipality": "Ketchikan",
+        "bounding_box": {
+            "minimum_latitude": 55.3012741,
+            "maximum_latitude": 55.46752692,
+            "minimum_longitude": -131.8199521,
+            "maximum_longitude": -131.5323131,
+            "extracted_on": "2022-03-15T17:43:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/kgb-ak-us/kgb-ak-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alaska-ketchikan-gateway-borough-gtfs-244.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alaska-metropolitan-area-commuter-system-gtfs-232.json
+++ b/catalogs/sources/gtfs/schedule/us-alaska-metropolitan-area-commuter-system-gtfs-232.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 232,
+    "data_type": "gtfs",
+    "provider": "Metropolitan Area Commuter System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alaska",
+        "municipality": "Fairbanks",
+        "bounding_box": {
+            "minimum_latitude": 64.74791061828516,
+            "maximum_latitude": 64.8996653247773,
+            "minimum_longitude": -147.8732170364887,
+            "maximum_longitude": -147.3279313082579,
+            "extracted_on": "2022-03-15T17:43:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.fnsb.gov/DocumentCenter/View/690/General-Transit-Feed-Specification-ZIP",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alaska-metropolitan-area-commuter-system-gtfs-232.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-benson-area-transit-gtfs-229.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-benson-area-transit-gtfs-229.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 229,
+    "data_type": "gtfs",
+    "provider": "Benson Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Benson",
+        "bounding_box": {
+            "minimum_latitude": 31.9605125138286,
+            "maximum_latitude": 31.9730373580076,
+            "minimum_longitude": -110.314375760002,
+            "maximum_longitude": -110.285654261814,
+            "extracted_on": "2022-03-15T17:43:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/benson-az-us/benson-az-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-benson-area-transit-gtfs-229.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arkansas-jonesboro-economical-transportation-jet-gtfs-186.json
+++ b/catalogs/sources/gtfs/schedule/us-arkansas-jonesboro-economical-transportation-jet-gtfs-186.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 186,
+    "data_type": "gtfs",
+    "provider": "Jonesboro Economical Transportation (JET)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arkansas",
+        "municipality": "Jonesboro",
+        "bounding_box": {
+            "minimum_latitude": 35.78435,
+            "maximum_latitude": 35.87903,
+            "minimum_longitude": -90.72583,
+            "maximum_longitude": -90.62452,
+            "extracted_on": "2022-03-15T17:40:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.jonesboro.org/DocumentCenter/View/2432",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arkansas-jonesboro-economical-transportation-jet-gtfs-186.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-alhambra-community-transit-gtfs-211.json
+++ b/catalogs/sources/gtfs/schedule/us-california-alhambra-community-transit-gtfs-211.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 211,
+    "data_type": "gtfs",
+    "provider": "Alhambra Community Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Alhambra",
+        "bounding_box": {
+            "minimum_latitude": 34.0632123260011,
+            "maximum_latitude": 34.099084205323,
+            "minimum_longitude": -118.172849994219,
+            "maximum_longitude": -118.111230539029,
+            "extracted_on": "2022-03-15T17:42:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/alhambra-ca-us/alhambra-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-alhambra-community-transit-gtfs-211.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-antelope-valley-transit-authority-avta-gtfs-214.json
+++ b/catalogs/sources/gtfs/schedule/us-california-antelope-valley-transit-authority-avta-gtfs-214.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 214,
+    "data_type": "gtfs",
+    "provider": "Antelope Valley Transit Authority (AVTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Lancaster",
+        "bounding_box": {
+            "minimum_latitude": 34.043438,
+            "maximum_latitude": 34.718879,
+            "minimum_longitude": -118.597604,
+            "maximum_longitude": -117.8236947,
+            "extracted_on": "2022-03-15T17:42:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.avta.com/userfiles/files/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-antelope-valley-transit-authority-avta-gtfs-214.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-arcadia-transit-gtfs-215.json
+++ b/catalogs/sources/gtfs/schedule/us-california-arcadia-transit-gtfs-215.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 215,
+    "data_type": "gtfs",
+    "provider": "Arcadia Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Arcadia",
+        "bounding_box": {
+            "minimum_latitude": 34.107294,
+            "maximum_latitude": 34.152812,
+            "minimum_longitude": -118.064574,
+            "maximum_longitude": -118.018327,
+            "extracted_on": "2022-03-15T17:42:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/arcadia-ca-us/arcadia-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-arcadia-transit-gtfs-215.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-arvin-transit-gtfs-216.json
+++ b/catalogs/sources/gtfs/schedule/us-california-arvin-transit-gtfs-216.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 216,
+    "data_type": "gtfs",
+    "provider": "Arvin Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Arvin",
+        "bounding_box": {
+            "minimum_latitude": 34.9762807989774,
+            "maximum_latitude": 35.4098552664964,
+            "minimum_longitude": -119.038573243251,
+            "maximum_longitude": -118.824334301576,
+            "extracted_on": "2022-03-15T17:42:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/arvin-ca-us/arvin-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-arvin-transit-gtfs-216.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-auburn-transit-gtfs-217.json
+++ b/catalogs/sources/gtfs/schedule/us-california-auburn-transit-gtfs-217.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 217,
+    "data_type": "gtfs",
+    "provider": "Auburn Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Auburn",
+        "bounding_box": {
+            "minimum_latitude": 38.878361,
+            "maximum_latitude": 38.931944,
+            "minimum_longitude": -121.082945,
+            "maximum_longitude": -121.035781594468,
+            "extracted_on": "2022-03-15T17:42:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/auburntransit-ca-us/auburntransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-auburn-transit-gtfs-217.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-baldwin-park-transit-gtfs-219.json
+++ b/catalogs/sources/gtfs/schedule/us-california-baldwin-park-transit-gtfs-219.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 219,
+    "data_type": "gtfs",
+    "provider": "Baldwin Park Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Baldwin Park",
+        "bounding_box": {
+            "minimum_latitude": 34.0633818198338,
+            "maximum_latitude": 34.1059616341679,
+            "minimum_longitude": -117.997131929879,
+            "maximum_longitude": -117.944715604821,
+            "extracted_on": "2022-03-15T17:42:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/baldwinpark-ca-us/baldwinpark-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-baldwin-park-transit-gtfs-219.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-bell-gardens-trolley-gtfs-228.json
+++ b/catalogs/sources/gtfs/schedule/us-california-bell-gardens-trolley-gtfs-228.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 228,
+    "data_type": "gtfs",
+    "provider": "Bell Gardens Trolley",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Bell Gardens",
+        "bounding_box": {
+            "minimum_latitude": 33.953848,
+            "maximum_latitude": 33.975241,
+            "minimum_longitude": -118.167153856536,
+            "maximum_longitude": -118.13744,
+            "extracted_on": "2022-03-15T17:43:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bellgardens-ca-us/bellgardens-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-bell-gardens-trolley-gtfs-228.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-bellflower-bus-gtfs-227.json
+++ b/catalogs/sources/gtfs/schedule/us-california-bellflower-bus-gtfs-227.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 227,
+    "data_type": "gtfs",
+    "provider": "Bellflower Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Bellflower",
+        "bounding_box": {
+            "minimum_latitude": 33.865684,
+            "maximum_latitude": 33.909496,
+            "minimum_longitude": -118.142691,
+            "maximum_longitude": -118.108606,
+            "extracted_on": "2022-03-15T17:43:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bellflower-ca-us/bellflower-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-bellflower-bus-gtfs-227.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-blossom-express-gtfs-236.json
+++ b/catalogs/sources/gtfs/schedule/us-california-blossom-express-gtfs-236.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 236,
+    "data_type": "gtfs",
+    "provider": "Blossom Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Ripon",
+        "bounding_box": {
+            "minimum_latitude": 37.6893884368282,
+            "maximum_latitude": 37.753899387218,
+            "minimum_longitude": -121.142215569397,
+            "maximum_longitude": -121.050065418927,
+            "extracted_on": "2022-03-15T17:43:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/blossomexpress-ca-us/blossomexpress-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-blossom-express-gtfs-236.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-banning-transit-gtfs-220.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-banning-transit-gtfs-220.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 220,
+    "data_type": "gtfs",
+    "provider": "City of Banning Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Banning",
+        "bounding_box": {
+            "minimum_latitude": 33.90046637,
+            "maximum_latitude": 33.93990647,
+            "minimum_longitude": -116.9751263,
+            "maximum_longitude": -116.7543268,
+            "extracted_on": "2022-03-15T17:42:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/banning-ca-us/banning-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-of-banning-transit-gtfs-220.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-university-of-california-berkeley-shuttle-bear-transit-gtfs-226.json
+++ b/catalogs/sources/gtfs/schedule/us-california-university-of-california-berkeley-shuttle-bear-transit-gtfs-226.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 226,
+    "data_type": "gtfs",
+    "provider": "University of California Berkeley Shuttle (Bear Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Berkeley",
+        "bounding_box": {
+            "minimum_latitude": 37.8641395035463,
+            "maximum_latitude": 37.9170547484884,
+            "minimum_longitude": -122.338632368571,
+            "maximum_longitude": -122.238629251794,
+            "extracted_on": "2022-03-15T17:43:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/beartransit-ca-us/beartransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-university-of-california-berkeley-shuttle-bear-transit-gtfs-226.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-all-points-transit-gtfs-212.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-all-points-transit-gtfs-212.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 212,
+    "data_type": "gtfs",
+    "provider": "All Points Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Montrose",
+        "bounding_box": {
+            "minimum_latitude": 37.9372925642184,
+            "maximum_latitude": 38.61346,
+            "minimum_longitude": -108.572094675909,
+            "maximum_longitude": -107.747576129767,
+            "extracted_on": "2022-03-15T17:42:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/allpointstransit-co-us/allpointstransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-all-points-transit-gtfs-212.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-avon-transit-gtfs-218.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-avon-transit-gtfs-218.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 218,
+    "data_type": "gtfs",
+    "provider": "Avon Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Avon",
+        "bounding_box": {
+            "minimum_latitude": 39.6039284878294,
+            "maximum_latitude": 39.639706,
+            "minimum_longitude": -106.537655,
+            "maximum_longitude": -106.501871,
+            "extracted_on": "2022-03-15T17:42:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/avon-co-us/avon-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-avon-transit-gtfs-218.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-bent-county-transit-gtfs-230.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-bent-county-transit-gtfs-230.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 230,
+    "data_type": "gtfs",
+    "provider": "Bent County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Las Animas",
+        "bounding_box": {
+            "minimum_latitude": 37.971134,
+            "maximum_latitude": 38.153546,
+            "minimum_longitude": -103.555608,
+            "maximum_longitude": -102.609512,
+            "extracted_on": "2022-03-15T17:43:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bentcounty-co-us/bentcounty-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-bent-county-transit-gtfs-230.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-blackhawk-and-central-city-tramway-gtfs-234.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-blackhawk-and-central-city-tramway-gtfs-234.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 234,
+    "data_type": "gtfs",
+    "provider": "Blackhawk and Central City Tramway",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 39.798227,
+            "maximum_latitude": 39.8021812172629,
+            "minimum_longitude": -105.51270199162,
+            "maximum_longitude": -105.482782,
+            "extracted_on": "2022-03-15T17:43:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/blackhawktramway-co-us/blackhawktramway-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-blackhawk-and-central-city-tramway-gtfs-234.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-breckenridge-free-ride-gtfs-237.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-breckenridge-free-ride-gtfs-237.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 237,
+    "data_type": "gtfs",
+    "provider": "Breckenridge Free Ride",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Breckenridge",
+        "bounding_box": {
+            "minimum_latitude": 39.464212,
+            "maximum_latitude": 39.5135459612638,
+            "minimum_longitude": -106.066622436046,
+            "maximum_longitude": -106.019672,
+            "extracted_on": "2022-03-15T17:43:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/breckenridgefreeride-co-us/breckenridgefreeride-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-breckenridge-free-ride-gtfs-237.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-university-of-colorado-boulder-gtfs-181.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-university-of-colorado-boulder-gtfs-181.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 181,
+    "data_type": "gtfs",
+    "provider": "University of Colorado Boulder",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Boulder",
+        "bounding_box": {
+            "minimum_latitude": 39.99664,
+            "maximum_latitude": 40.017101,
+            "minimum_longitude": -105.275559,
+            "maximum_longitude": -105.24371,
+            "extracted_on": "2022-03-15T17:40:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/universitycoloradoboulder-co-us/universitycoloradoboulder-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-university-of-colorado-boulder-gtfs-181.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-metro-rock-island-county-metropolitan-mass-transit-district-gtfs-201.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-metro-rock-island-county-metropolitan-mass-transit-district-gtfs-201.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 201,
+    "data_type": "gtfs",
+    "provider": "Metro Rock Island County Metropolitan Mass Transit District",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Rock Island",
+        "bounding_box": {
+            "minimum_latitude": 41.41090532837012,
+            "maximum_latitude": 41.55671667777778,
+            "minimum_longitude": -90.63877833333332,
+            "maximum_longitude": -90.21917333333334,
+            "extracted_on": "2022-03-15T17:41:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.gogreenmetro.com/latest/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-metro-rock-island-county-metropolitan-mass-transit-district-gtfs-201.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-10-15-transit-gtfs-195.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-10-15-transit-gtfs-195.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 195,
+    "data_type": "gtfs",
+    "provider": "10-15 Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Ottumwa",
+        "bounding_box": {
+            "minimum_latitude": 40.993499836155,
+            "maximum_latitude": 41.312688620846,
+            "minimum_longitude": -92.669851610855,
+            "maximum_longitude": -92.374030358351,
+            "extracted_on": "2022-03-15T17:41:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/10-15transit-ia-us/10-15transit-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-10-15-transit-gtfs-195.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-burlington-urban-service-gtfs-199.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-burlington-urban-service-gtfs-199.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 199,
+    "data_type": "gtfs",
+    "provider": "Burlington Urban Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Burlington",
+        "bounding_box": {
+            "minimum_latitude": 40.7746289,
+            "maximum_latitude": 40.8342948,
+            "minimum_longitude": -91.175124,
+            "maximum_longitude": -91.0985631,
+            "extracted_on": "2022-03-15T17:41:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/burlington-ia-us/burlington-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-burlington-urban-service-gtfs-199.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-cedar-rapids-transit-gtfs-198.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-cedar-rapids-transit-gtfs-198.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 198,
+    "data_type": "gtfs",
+    "provider": "Cedar Rapids Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Cedar Rapids",
+        "bounding_box": {
+            "minimum_latitude": 41.88927863,
+            "maximum_latitude": 42.05866359,
+            "minimum_longitude": -91.75489032,
+            "maximum_longitude": -91.5454324636,
+            "extracted_on": "2022-03-15T17:41:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cedarrapids-ia-us/cedarrapids-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-cedar-rapids-transit-gtfs-198.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-clinton-municipal-transit-administration-clinton-mta-gtfs-202.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-clinton-municipal-transit-administration-clinton-mta-gtfs-202.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 202,
+    "data_type": "gtfs",
+    "provider": "Clinton Municipal Transit Administration (Clinton MTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Clinton",
+        "bounding_box": {
+            "minimum_latitude": 41.814816020445,
+            "maximum_latitude": 41.887103994511,
+            "minimum_longitude": -90.25437316662,
+            "maximum_longitude": -90.176788336577,
+            "extracted_on": "2022-03-15T17:41:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/clintonmta-ia-us/clintonmta-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-clinton-municipal-transit-administration-clinton-mta-gtfs-202.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-coralville-transit-gtfs-196.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-coralville-transit-gtfs-196.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 196,
+    "data_type": "gtfs",
+    "provider": "Coralville Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Coralville",
+        "bounding_box": {
+            "minimum_latitude": 41.66034191106,
+            "maximum_latitude": 41.75054803919,
+            "minimum_longitude": -91.614688763131,
+            "maximum_longitude": -91.534762424275,
+            "extracted_on": "2022-03-15T17:41:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/coralvilletransitsystem-ia-us/coralvilletransitsystem-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-coralville-transit-gtfs-196.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-des-moines-area-regional-transit-authority-dart-gtfs-193.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-des-moines-area-regional-transit-authority-dart-gtfs-193.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 193,
+    "data_type": "gtfs",
+    "provider": "Des Moines Area Regional Transit Authority (DART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Des Moines",
+        "bounding_box": {
+            "minimum_latitude": 41.511765,
+            "maximum_latitude": 41.732874,
+            "minimum_longitude": -93.832726,
+            "maximum_longitude": -93.466485,
+            "extracted_on": "2022-03-15T17:41:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.ridedart.com/gtfs/data/gtfsdata",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-des-moines-area-regional-transit-authority-dart-gtfs-193.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-dodger-area-rapid-transit-gtfs-203.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-dodger-area-rapid-transit-gtfs-203.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 203,
+    "data_type": "gtfs",
+    "provider": "Dodger Area Rapid Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Fort Dodge",
+        "bounding_box": {
+            "minimum_latitude": 42.4761248,
+            "maximum_latitude": 42.536627119116,
+            "minimum_longitude": -94.223038545239,
+            "maximum_longitude": -94.148164198338,
+            "extracted_on": "2022-03-15T17:41:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/dart-ia-us/dart-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-dodger-area-rapid-transit-gtfs-203.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-marshalltown-municipal-transit-gtfs-194.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-marshalltown-municipal-transit-gtfs-194.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 194,
+    "data_type": "gtfs",
+    "provider": "Marshalltown Municipal Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Marshalltown",
+        "bounding_box": {
+            "minimum_latitude": 42.001345427954,
+            "maximum_latitude": 42.0630934764924,
+            "minimum_longitude": -92.9366935666204,
+            "maximum_longitude": -92.8861078870026,
+            "extracted_on": "2022-03-15T17:41:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/marshalltownmunicipaltransit-ia-us/marshalltownmunicipaltransit-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-marshalltown-municipal-transit-gtfs-194.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-mason-city-public-transit-gtfs-204.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-mason-city-public-transit-gtfs-204.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 204,
+    "data_type": "gtfs",
+    "provider": "Mason City Public Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Mason City",
+        "bounding_box": {
+            "minimum_latitude": 43.12889880784,
+            "maximum_latitude": 43.169472329595,
+            "minimum_longitude": -93.267866896241,
+            "maximum_longitude": -93.130789378269,
+            "extracted_on": "2022-03-15T17:41:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/masoncity-ia-us/masoncity-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-mason-city-public-transit-gtfs-204.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-muscabus-gtfs-200.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-muscabus-gtfs-200.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 200,
+    "data_type": "gtfs",
+    "provider": "MuscaBus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Muscatine",
+        "bounding_box": {
+            "minimum_latitude": 41.399477,
+            "maximum_latitude": 41.474813,
+            "minimum_longitude": -91.085022,
+            "maximum_longitude": -91.000096,
+            "extracted_on": "2022-03-15T17:41:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/muscabus-ia-us/muscabus-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-muscabus-gtfs-200.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-sioux-city-transit-system-gtfs-191.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-sioux-city-transit-system-gtfs-191.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 191,
+    "data_type": "gtfs",
+    "provider": "Sioux City Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Sioux City",
+        "bounding_box": {
+            "minimum_latitude": 42.399216844341,
+            "maximum_latitude": 42.545166582532,
+            "minimum_longitude": -96.497762,
+            "maximum_longitude": -96.32917641277,
+            "extracted_on": "2022-03-15T17:41:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/siouxcity-ia-us/siouxcity-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-sioux-city-transit-system-gtfs-191.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-the-jule-gtfs-207.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-the-jule-gtfs-207.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 207,
+    "data_type": "gtfs",
+    "provider": "The Jule",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Dubuque",
+        "bounding_box": {
+            "minimum_latitude": 42.4779857681981,
+            "maximum_latitude": 42.5400547707114,
+            "minimum_longitude": -90.7497887760275,
+            "maximum_longitude": -90.6435773160206,
+            "extracted_on": "2022-03-15T17:42:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.cityofdubuque.org/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-the-jule-gtfs-207.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-university-of-iowa---cambus-cambus-gtfs-197.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-university-of-iowa---cambus-cambus-gtfs-197.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 197,
+    "data_type": "gtfs",
+    "provider": "University of Iowa - CAMBUS (CAMBUS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Iowa City",
+        "bounding_box": {
+            "minimum_latitude": 41.654493,
+            "maximum_latitude": 41.718345747258,
+            "minimum_longitude": -91.605722815901,
+            "maximum_longitude": -91.532009,
+            "extracted_on": "2022-03-15T17:41:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cambus-ia-us/cambus-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-university-of-iowa---cambus-cambus-gtfs-197.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-university-of-iowa-cambus-cambus-gtfs-197.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-university-of-iowa-cambus-cambus-gtfs-197.json
@@ -16,6 +16,6 @@
     },
     "urls": {
         "direct_download": "http://data.trilliumtransit.com/gtfs/cambus-ia-us/cambus-ia-us.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-university-of-iowa---cambus-cambus-gtfs-197.zip?alt=media"
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-university-of-iowa-cambus-cambus-gtfs-197.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-kansas-ku-on-wheels-lawrence-transit-system-gtfs-188.json
+++ b/catalogs/sources/gtfs/schedule/us-kansas-ku-on-wheels-lawrence-transit-system-gtfs-188.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 188,
+    "data_type": "gtfs",
+    "provider": "KU on Wheels & Lawrence Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Kansas",
+        "municipality": "Lawrence",
+        "bounding_box": {
+            "minimum_latitude": 38.92462422,
+            "maximum_latitude": 39.000906,
+            "minimum_longitude": -95.33271,
+            "maximum_longitude": -95.18171654,
+            "extracted_on": "2022-03-15T17:41:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://assets.lawrenceks.org/assets/gis/google-transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-kansas-ku-on-wheels-lawrence-transit-system-gtfs-188.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-kansas-wichita-transit-gtfs-185.json
+++ b/catalogs/sources/gtfs/schedule/us-kansas-wichita-transit-gtfs-185.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 185,
+    "data_type": "gtfs",
+    "provider": "Wichita Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Kansas",
+        "municipality": "Witchita",
+        "bounding_box": {
+            "minimum_latitude": 37.605752,
+            "maximum_latitude": 37.757113,
+            "minimum_longitude": -97.466211,
+            "maximum_longitude": -97.189472,
+            "extracted_on": "2022-03-15T17:40:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/blob/master/wichita-transit.zip?raw=true",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-kansas-wichita-transit-gtfs-185.zip?alt=media",
+        "license": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/blob/master/wichita-transit-license.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-louisiana-capital-area-transit-system-cats-gtfs-222.json
+++ b/catalogs/sources/gtfs/schedule/us-louisiana-capital-area-transit-system-cats-gtfs-222.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 222,
+    "data_type": "gtfs",
+    "provider": "Capital Area Transit System (CATS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Louisiana",
+        "municipality": "Baton Rouge",
+        "bounding_box": {
+            "minimum_latitude": 30.346346,
+            "maximum_latitude": 30.594509,
+            "minimum_longitude": -91.200005,
+            "maximum_longitude": -91.000862,
+            "extracted_on": "2022-03-15T17:42:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/f-baton~rouge~cats.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-louisiana-capital-area-transit-system-cats-gtfs-222.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-bethesda-circulator-gtfs-231.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-bethesda-circulator-gtfs-231.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 231,
+    "data_type": "gtfs",
+    "provider": "Bethesda Circulator",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Bethesda",
+        "bounding_box": {
+            "minimum_latitude": 38.978095,
+            "maximum_latitude": 38.99237,
+            "minimum_longitude": -77.103033,
+            "maximum_longitude": -77.091436,
+            "extracted_on": "2022-03-15T17:43:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/bethesdacirculator-md-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-bethesda-circulator-gtfs-231.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-bay-area-transportation-authority-gtfs-223.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-bay-area-transportation-authority-gtfs-223.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 223,
+    "data_type": "gtfs",
+    "provider": "Bay Area Transportation Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Traverse City",
+        "bounding_box": {
+            "minimum_latitude": 44.5768836504099,
+            "maximum_latitude": 45.129802,
+            "minimum_longitude": -85.769084,
+            "maximum_longitude": -85.3471678875275,
+            "extracted_on": "2022-03-15T17:42:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/5109/BATA_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-bay-area-transportation-authority-gtfs-223.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-minnesota-metro-transit-metro-transit-met-council-maple-grove-plymouth-southwest-transit-airport-mac-university-of-minnesota-catch-the-link-gtfs-205.json
+++ b/catalogs/sources/gtfs/schedule/us-minnesota-metro-transit-metro-transit-met-council-maple-grove-plymouth-southwest-transit-airport-mac-university-of-minnesota-catch-the-link-gtfs-205.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 205,
+    "data_type": "gtfs",
+    "provider": "Metro Transit, Metro Transit (Met Council), Maple Grove, Plymouth, SouthWest Transit, Airport (MAC), University of Minnesota, Catch the Link",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Minnesota",
+        "municipality": "Minneapolis",
+        "bounding_box": {
+            "minimum_latitude": 44.725492,
+            "maximum_latitude": 45.560123,
+            "minimum_longitude": -94.157367,
+            "maximum_longitude": -92.805903,
+            "extracted_on": "2022-03-15T17:42:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://svc.metrotransit.org/mtgtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-minnesota-metro-transit-metro-transit-met-council-maple-grove-plymouth-southwest-transit-airport-mac-university-of-minnesota-catch-the-link-gtfs-205.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-minnesota-minnesota-valley-transit-authority-mvta-gtfs-206.json
+++ b/catalogs/sources/gtfs/schedule/us-minnesota-minnesota-valley-transit-authority-mvta-gtfs-206.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 206,
+    "data_type": "gtfs",
+    "provider": "Minnesota Valley Transit Authority (MVTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Minnesota",
+        "municipality": "Minneapolis",
+        "bounding_box": {
+            "minimum_latitude": 44.688092,
+            "maximum_latitude": 44.982204,
+            "minimum_longitude": -93.554253,
+            "maximum_longitude": -93.080275,
+            "extracted_on": "2022-03-15T17:42:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://wiki.mvta.com/files/Home/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-minnesota-minnesota-valley-transit-authority-mvta-gtfs-206.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-missouri-jeffco-express-gtfs-189.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-jeffco-express-gtfs-189.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 189,
+    "data_type": "gtfs",
+    "provider": "JeffCo Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Missouri",
+        "municipality": "St. Louis",
+        "bounding_box": {
+            "minimum_latitude": 38.13287285,
+            "maximum_latitude": 38.5095497153418,
+            "minimum_longitude": -90.6538801515205,
+            "maximum_longitude": -90.35315012,
+            "extracted_on": "2022-03-15T17:41:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/jeffersoncounty-mo-us/jeffersoncounty-mo-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-missouri-jeffco-express-gtfs-189.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-missouri-kansas-city-area-transportation-authority-kcata-gtfs-187.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-kansas-city-area-transportation-authority-kcata-gtfs-187.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 187,
+    "data_type": "gtfs",
+    "provider": "Kansas City Area Transportation Authority (KCATA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Missouri",
+        "municipality": "Kansas City",
+        "bounding_box": {
+            "minimum_latitude": 38.767456,
+            "maximum_latitude": 39.30926,
+            "minimum_longitude": -95.262773,
+            "maximum_longitude": -94.27259,
+            "extracted_on": "2022-03-15T17:41:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.kc-metro.com/gtf/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-missouri-kansas-city-area-transportation-authority-kcata-gtfs-187.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-190.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-190.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 190,
+    "data_type": "gtfs",
+    "provider": "Metro St. Louis",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Missouri",
+        "municipality": "St. Louis",
+        "bounding_box": {
+            "minimum_latitude": 38.469747,
+            "maximum_latitude": 38.825646,
+            "minimum_longitude": -90.662094,
+            "maximum_longitude": -89.874657,
+            "extracted_on": "2022-03-15T17:41:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://metrostlouis.org/Transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-missouri-metro-st-louis-gtfs-190.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-montana-butte-regional-transit-b-line-gtfs-241.json
+++ b/catalogs/sources/gtfs/schedule/us-montana-butte-regional-transit-b-line-gtfs-241.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 241,
+    "data_type": "gtfs",
+    "provider": "Butte Regional Transit (B-Line)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Montana",
+        "municipality": "Butte",
+        "bounding_box": {
+            "minimum_latitude": 39.3632006265641,
+            "maximum_latitude": 39.8491485326975,
+            "minimum_longitude": -121.898691618365,
+            "maximum_longitude": -121.463442830053,
+            "extracted_on": "2022-03-15T17:43:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.blinetransit.com/documents/Google%20Transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-montana-butte-regional-transit-b-line-gtfs-241.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-academy-bus-gtfs-209.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-academy-bus-gtfs-209.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 209,
+    "data_type": "gtfs",
+    "provider": "Academy Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 39.951653,
+            "maximum_latitude": 40.764429,
+            "minimum_longitude": -74.891731,
+            "maximum_longitude": -73.971167,
+            "extracted_on": "2022-03-15T17:42:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Academy_Express_-_Staten_Island.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-academy-bus-gtfs-209.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-birnie-bus-gtfs-233.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-birnie-bus-gtfs-233.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 233,
+    "data_type": "gtfs",
+    "provider": "Birnie Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Utica",
+        "bounding_box": {
+            "minimum_latitude": 42.307476,
+            "maximum_latitude": 44.163689,
+            "minimum_longitude": -77.884659,
+            "maximum_longitude": -74.752197,
+            "extracted_on": "2022-03-15T17:43:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Birnie_Bus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-birnie-bus-gtfs-233.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-broome-county-transit-bc-transit-gtfs-239.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-broome-county-transit-bc-transit-gtfs-239.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 239,
+    "data_type": "gtfs",
+    "provider": "Broome County Transit (B.C. Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Binghamton",
+        "bounding_box": {
+            "minimum_latitude": 42.035993,
+            "maximum_latitude": 42.168976,
+            "minimum_longitude": -76.091274,
+            "maximum_longitude": -75.80634,
+            "extracted_on": "2022-03-15T17:43:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.gobroomecounty.com/sites/default/files/dept/transit/BCT_GTFS_012222.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-broome-county-transit-bc-transit-gtfs-239.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-allen-county-regional-transit-authority-gtfs-210.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-allen-county-regional-transit-authority-gtfs-210.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 210,
+    "data_type": "gtfs",
+    "provider": "Allen County Regional Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Lima",
+        "bounding_box": {
+            "minimum_latitude": 40.686444269947,
+            "maximum_latitude": 40.9021584330236,
+            "minimum_longitude": -84.3395975534096,
+            "maximum_longitude": -83.8710286672719,
+            "extracted_on": "2022-03-15T17:42:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/acrta-oh-us/acrta-oh-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-allen-county-regional-transit-authority-gtfs-210.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-butler-county-regional-transit-authority-gtfs-240.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-butler-county-regional-transit-authority-gtfs-240.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 240,
+    "data_type": "gtfs",
+    "provider": "Butler County Regional Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Hamilton",
+        "bounding_box": {
+            "minimum_latitude": 39.2832317,
+            "maximum_latitude": 39.540703,
+            "minimum_longitude": -84.7675,
+            "maximum_longitude": -84.315188,
+            "extracted_on": "2022-03-15T17:43:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.butlercountyrta.com/wp-content/uploads/2019/11/Bcrta-GTFS-1.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-butler-county-regional-transit-authority-gtfs-240.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oklahoma-campus-area-rapid-transit-cart-gtfs-182.json
+++ b/catalogs/sources/gtfs/schedule/us-oklahoma-campus-area-rapid-transit-cart-gtfs-182.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 182,
+    "data_type": "gtfs",
+    "provider": "Campus Area Rapid Transit (CART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oklahoma",
+        "municipality": "Norman",
+        "bounding_box": {
+            "minimum_latitude": 35.182977,
+            "maximum_latitude": 35.216008,
+            "minimum_longitude": -97.45147400000002,
+            "maximum_longitude": -97.435609,
+            "extracted_on": "2022-03-15T17:40:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.cartgps.com/gtfs",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oklahoma-campus-area-rapid-transit-cart-gtfs-182.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oklahoma-embark-gtfs-183.json
+++ b/catalogs/sources/gtfs/schedule/us-oklahoma-embark-gtfs-183.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 183,
+    "data_type": "gtfs",
+    "provider": "Embark",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oklahoma",
+        "municipality": "Oklahoma City",
+        "bounding_box": {
+            "minimum_latitude": 35.201592,
+            "maximum_latitude": 35.614976,
+            "minimum_longitude": -97.654389,
+            "maximum_longitude": -97.300641,
+            "extracted_on": "2022-03-15T17:40:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://embarkok.com/data/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oklahoma-embark-gtfs-183.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oklahoma-metropolitan-tulsa-transit-authority-mtta-gtfs-184.json
+++ b/catalogs/sources/gtfs/schedule/us-oklahoma-metropolitan-tulsa-transit-authority-mtta-gtfs-184.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 184,
+    "data_type": "gtfs",
+    "provider": "Metropolitan Tulsa Transit Authority (MTTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oklahoma",
+        "municipality": "Tulsa",
+        "bounding_box": {
+            "minimum_latitude": 35.973884,
+            "maximum_latitude": 36.247851,
+            "minimum_longitude": -96.120174,
+            "maximum_longitude": -95.79037,
+            "extracted_on": "2022-03-15T17:40:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.tulsatransit.org/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oklahoma-metropolitan-tulsa-transit-authority-mtta-gtfs-184.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-blue-star-bus-gtfs-256.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-blue-star-bus-gtfs-256.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 256,
+    "data_type": "gtfs",
+    "provider": "Blue Star Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 45.506638,
+            "maximum_latitude": 45.588928,
+            "minimum_longitude": -122.687492,
+            "maximum_longitude": -122.592392,
+            "extracted_on": "2022-03-15T17:44:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/bluestar-or-us/bluestar-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-blue-star-bus-gtfs-256.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-canby-area-transit-cat-gtfs-252.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-canby-area-transit-cat-gtfs-252.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 252,
+    "data_type": "gtfs",
+    "provider": "Canby Area Transit (CAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Canby",
+        "bounding_box": {
+            "minimum_latitude": 45.1511972,
+            "maximum_latitude": 45.359991,
+            "minimum_longitude": -122.8349536,
+            "maximum_longitude": -122.604267,
+            "extracted_on": "2022-03-15T17:44:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/canbytransit-or-us/canbytransit-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-canby-area-transit-cat-gtfs-252.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-city-of-milton-freewater-public-transportation-gtfs-274.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-city-of-milton-freewater-public-transportation-gtfs-274.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 274,
+    "data_type": "gtfs",
+    "provider": "City of Milton-Freewater Public Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Milton-Freewater",
+        "bounding_box": {
+            "minimum_latitude": 45.91563132,
+            "maximum_latitude": 46.065943241891,
+            "minimum_longitude": -118.401544,
+            "maximum_longitude": -118.3308595,
+            "extracted_on": "2022-03-15T17:45:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/milton-freewater-or-us/milton-freewater-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-city-of-milton-freewater-public-transportation-gtfs-274.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-clackamas-community-college-ccc-xpress-gtfs-257.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-clackamas-community-college-ccc-xpress-gtfs-257.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 257,
+    "data_type": "gtfs",
+    "provider": "Clackamas Community College (CCC) Xpress",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "bounding_box": {
+            "minimum_latitude": 45.3220761144049,
+            "maximum_latitude": 45.43618452638,
+            "minimum_longitude": -122.582843,
+            "maximum_longitude": -122.568429,
+            "extracted_on": "2022-03-15T17:44:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/cccxpress-or-us/cccxpress-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-clackamas-community-college-ccc-xpress-gtfs-257.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-columbia-area-transit-cat-gtfs-260.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-columbia-area-transit-cat-gtfs-260.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 260,
+    "data_type": "gtfs",
+    "provider": "Columbia Area Transit (CAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Hood River",
+        "bounding_box": {
+            "minimum_latitude": 45.3026111500122,
+            "maximum_latitude": 45.727946,
+            "minimum_longitude": -122.652617,
+            "maximum_longitude": -120.96411126454,
+            "extracted_on": "2022-03-15T17:44:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/hoodriver-or-us/hoodriver-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-columbia-area-transit-cat-gtfs-260.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-kayak-transit-ctuir-gtfs-272.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-kayak-transit-ctuir-gtfs-272.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 272,
+    "data_type": "gtfs",
+    "provider": "Kayak Transit (CTUIR)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Pendleton",
+        "bounding_box": {
+            "minimum_latitude": 45.3193040477042,
+            "maximum_latitude": 46.0661407,
+            "minimum_longitude": -119.499208245983,
+            "maximum_longitude": -118.077631,
+            "extracted_on": "2022-03-15T17:45:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/ctuir-or-us/ctuir-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-kayak-transit-ctuir-gtfs-272.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-ride-connection-gtfs-253.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-ride-connection-gtfs-253.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 253,
+    "data_type": "gtfs",
+    "provider": "Ride Connection",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 45.147045,
+            "maximum_latitude": 45.617867,
+            "minimum_longitude": -123.143750977524,
+            "maximum_longitude": -121.996403,
+            "extracted_on": "2022-03-15T17:44:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/rideconnection-or-us/rideconnection-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-ride-connection-gtfs-253.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-sandy-area-metro-sam-gtfs-261.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-sandy-area-metro-sam-gtfs-261.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 261,
+    "data_type": "gtfs",
+    "provider": "Sandy Area Metro (SAM)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Sandy",
+        "bounding_box": {
+            "minimum_latitude": 45.285866,
+            "maximum_latitude": 45.502997144364,
+            "minimum_longitude": -122.427862,
+            "maximum_longitude": -121.7089955,
+            "extracted_on": "2022-03-15T17:44:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/sandy-or-us/sandy-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-sandy-area-metro-sam-gtfs-261.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-south-metro-area-regional-transit-smart-gtfs-248.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-south-metro-area-regional-transit-smart-gtfs-248.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 248,
+    "data_type": "gtfs",
+    "provider": "South Metro Area Regional Transit (SMART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Wilsonville",
+        "bounding_box": {
+            "minimum_latitude": 44.937789,
+            "maximum_latitude": 45.394674,
+            "minimum_longitude": -123.035021,
+            "maximum_longitude": -122.691596,
+            "extracted_on": "2022-03-15T17:44:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/wilsonville-or-us/wilsonville-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-south-metro-area-regional-transit-smart-gtfs-248.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-sunset-empire-transportation-district-setd-tillamook-county-transportation-district-columbia-county-rider-gtfs-246.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-sunset-empire-transportation-district-setd-tillamook-county-transportation-district-columbia-county-rider-gtfs-246.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 246,
+    "data_type": "gtfs",
+    "provider": "Sunset Empire Transportation District (SETD), Tillamook County Transportation District, Columbia County Rider",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Tillamook",
+        "bounding_box": {
+            "minimum_latitude": 44.924787739481,
+            "maximum_latitude": 46.19935,
+            "minimum_longitude": -124.010371416807,
+            "maximum_longitude": -122.677082455061,
+            "extracted_on": "2022-03-15T17:43:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/tillamook-or-us/tillamook-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-sunset-empire-transportation-district-setd-tillamook-county-transportation-district-columbia-county-rider-gtfs-246.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-swan-island-evening-shuttle-gtfs-255.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-swan-island-evening-shuttle-gtfs-255.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 255,
+    "data_type": "gtfs",
+    "provider": "Swan Island Evening Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 45.5183498528882,
+            "maximum_latitude": 45.572858,
+            "minimum_longitude": -122.718875009787,
+            "maximum_longitude": -122.665648,
+            "extracted_on": "2022-03-15T17:44:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/swanisland-or-us/swanisland-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-swan-island-evening-shuttle-gtfs-255.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-trimet-portland-streetcar-gtfs-247.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-trimet-portland-streetcar-gtfs-247.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 247,
+    "data_type": "gtfs",
+    "provider": "TriMet, Portland Streetcar",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 45.285216,
+            "maximum_latitude": 45.637726,
+            "minimum_longitude": -123.115448,
+            "maximum_longitude": -122.333048,
+            "extracted_on": "2022-03-15T17:44:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://developer.trimet.org/schedule/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-trimet-portland-streetcar-gtfs-247.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-wahkiakum-on-the-move-gtfs-249.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-wahkiakum-on-the-move-gtfs-249.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 249,
+    "data_type": "gtfs",
+    "provider": "Wahkiakum on the Move",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Astoria",
+        "bounding_box": {
+            "minimum_latitude": 46.11987482,
+            "maximum_latitude": 46.37641594,
+            "minimum_longitude": -123.80452661,
+            "maximum_longitude": -122.90088792271,
+            "extracted_on": "2022-03-15T17:44:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/wotm-wa-us/wotm-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-wahkiakum-on-the-move-gtfs-249.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-washington-park-shuttle-gtfs-254.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-washington-park-shuttle-gtfs-254.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 254,
+    "data_type": "gtfs",
+    "provider": "Washington Park Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 45.510506,
+            "maximum_latitude": 45.521694,
+            "minimum_longitude": -122.716926,
+            "maximum_longitude": -122.700742129279,
+            "extracted_on": "2022-03-15T17:44:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/washingtonparkshuttle-or-us/washingtonparkshuttle-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-washington-park-shuttle-gtfs-254.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-woodburn-transit-service-wts-gtfs-251.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-woodburn-transit-service-wts-gtfs-251.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 251,
+    "data_type": "gtfs",
+    "provider": "Woodburn Transit Service (WTS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Woodburn",
+        "bounding_box": {
+            "minimum_latitude": 44.979376,
+            "maximum_latitude": 45.1565210390247,
+            "minimum_longitude": -122.979012,
+            "maximum_longitude": -122.830040925148,
+            "extracted_on": "2022-03-15T17:44:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/woodburn-or-us/woodburn-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-woodburn-transit-service-wts-gtfs-251.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-yamhill-county-transit-area-gtfs-250.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-yamhill-county-transit-area-gtfs-250.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 250,
+    "data_type": "gtfs",
+    "provider": "Yamhill County Transit Area",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Yamhill",
+        "bounding_box": {
+            "minimum_latitude": 44.951319,
+            "maximum_latitude": 45.521608,
+            "minimum_longitude": -123.617235,
+            "maximum_longitude": -122.768607,
+            "extracted_on": "2022-03-15T17:44:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://ycta.connexionz.net/rtt/public/resource/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-yamhill-county-transit-area-gtfs-250.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-berks-area-regional-transportation-authority-barta-gtfs-221.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-berks-area-regional-transportation-authority-barta-gtfs-221.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 221,
+    "data_type": "gtfs",
+    "provider": "Berks Area Regional Transportation Authority (BARTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Berks Area",
+        "bounding_box": {
+            "minimum_latitude": 40.2538235326223,
+            "maximum_latitude": 40.5647832629499,
+            "minimum_longitude": -76.1888396673733,
+            "maximum_longitude": -75.760175174387,
+            "extracted_on": "2022-03-15T17:42:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/barta.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-berks-area-regional-transportation-authority-barta-gtfs-221.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-south-dakota-sioux-area-metro-sam-gtfs-192.json
+++ b/catalogs/sources/gtfs/schedule/us-south-dakota-sioux-area-metro-sam-gtfs-192.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 192,
+    "data_type": "gtfs",
+    "provider": "Sioux Area Metro (SAM)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "South Dakota",
+        "municipality": "Sioux Falls",
+        "bounding_box": {
+            "minimum_latitude": 43.5002433633973,
+            "maximum_latitude": 43.602973,
+            "minimum_longitude": -96.81075632,
+            "maximum_longitude": -96.65301448,
+            "extracted_on": "2022-03-15T17:41:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/siouxareametro-sd-us/siouxareametro-sd-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-south-dakota-sioux-area-metro-sam-gtfs-192.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-amarillo-city-transit-gtfs-213.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-amarillo-city-transit-gtfs-213.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 213,
+    "data_type": "gtfs",
+    "provider": "Amarillo City Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Amarillo",
+        "bounding_box": {
+            "minimum_latitude": 35.14924024,
+            "maximum_latitude": 35.247835,
+            "minimum_longitude": -101.938349,
+            "maximum_longitude": -101.764893,
+            "extracted_on": "2022-03-15T17:42:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://code.amarillo.gov/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-amarillo-city-transit-gtfs-213.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-bay-transit-gtfs-224.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-bay-transit-gtfs-224.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 224,
+    "data_type": "gtfs",
+    "provider": "Bay Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "bounding_box": {
+            "minimum_latitude": 37.26023,
+            "maximum_latitude": 38.2726602035688,
+            "minimum_longitude": -76.9954227419775,
+            "maximum_longitude": -76.3520131228819,
+            "extracted_on": "2022-03-15T17:42:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/baytransit-va-us/baytransit-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-bay-transit-gtfs-224.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-blackstone-area-bus-service-gtfs-235.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-blackstone-area-bus-service-gtfs-235.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 235,
+    "data_type": "gtfs",
+    "provider": "Blackstone Area Bus Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Blackstone",
+        "bounding_box": {
+            "minimum_latitude": 36.7490050777501,
+            "maximum_latitude": 37.6274515436988,
+            "minimum_longitude": -78.5513342286278,
+            "maximum_longitude": -77.4053047094211,
+            "extracted_on": "2022-03-15T17:43:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/blackstone-va-us/blackstone-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-blackstone-area-bus-service-gtfs-235.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-bristol-virginia-transit-gtfs-238.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-bristol-virginia-transit-gtfs-238.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 238,
+    "data_type": "gtfs",
+    "provider": "Bristol Virginia Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Bristol",
+        "bounding_box": {
+            "minimum_latitude": 36.594351,
+            "maximum_latitude": 36.6345349574896,
+            "minimum_longitude": -82.2149838264316,
+            "maximum_longitude": -82.115519,
+            "extracted_on": "2022-03-15T17:43:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bristol-va-us/bristol-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-bristol-virginia-transit-gtfs-238.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-apple-line-gtfs-245.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-apple-line-gtfs-245.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 245,
+    "data_type": "gtfs",
+    "provider": "Apple Line",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Wenatchee",
+        "bounding_box": {
+            "minimum_latitude": 47.00766572,
+            "maximum_latitude": 48.61034629,
+            "minimum_longitude": -120.5861511,
+            "maximum_longitude": -117.4069488,
+            "extracted_on": "2022-03-15T17:43:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://business.wsdot.wa.gov/Transit/csv_files/InterCityBus/WSDOT_GTFS_Intercity.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-apple-line-gtfs-245.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-ben-franklin-transit-gtfs-273.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-ben-franklin-transit-gtfs-273.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 273,
+    "data_type": "gtfs",
+    "provider": "Ben Franklin Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Richland",
+        "bounding_box": {
+            "minimum_latitude": 46.169261,
+            "maximum_latitude": 46.348378,
+            "minimum_longitude": -119.771253,
+            "maximum_longitude": -119.049636,
+            "extracted_on": "2022-03-15T17:45:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bft.org/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-ben-franklin-transit-gtfs-273.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-c-tran-gtfs-258.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-c-tran-gtfs-258.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 258,
+    "data_type": "gtfs",
+    "provider": "C-TRAN",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Vancouver",
+        "bounding_box": {
+            "minimum_latitude": 45.496521,
+            "maximum_latitude": 45.866879,
+            "minimum_longitude": -122.708252,
+            "maximum_longitude": -122.321617,
+            "extracted_on": "2022-03-15T17:44:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.c-tran.com/images/Google/GoogleTransitUpload.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-c-tran-gtfs-258.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-grays-harbor-transit-gtfs-263.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-grays-harbor-transit-gtfs-263.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 263,
+    "data_type": "gtfs",
+    "provider": "Grays Harbor Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Aberdeen",
+        "bounding_box": {
+            "minimum_latitude": 46.7172576515543,
+            "maximum_latitude": 47.474577,
+            "minimum_longitude": -124.293883,
+            "maximum_longitude": -122.900592684745,
+            "extracted_on": "2022-03-15T17:44:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/graysharbor_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-grays-harbor-transit-gtfs-263.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-intercity-transit-gtfs-266.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-intercity-transit-gtfs-266.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 266,
+    "data_type": "gtfs",
+    "provider": "Intercity Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Olympia",
+        "bounding_box": {
+            "minimum_latitude": 46.933117,
+            "maximum_latitude": 47.160919,
+            "minimum_longitude": -122.977127,
+            "maximum_longitude": -122.483109,
+            "extracted_on": "2022-03-15T17:44:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.sound.obaweb.org/prod/19_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-intercity-transit-gtfs-266.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-link-transit-gtfs-275.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-link-transit-gtfs-275.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 275,
+    "data_type": "gtfs",
+    "provider": "Link Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Wenatchee ",
+        "bounding_box": {
+            "minimum_latitude": 47.2921153198261,
+            "maximum_latitude": 47.8850234593722,
+            "minimum_longitude": -120.674893575413,
+            "maximum_longitude": -119.980455199371,
+            "extracted_on": "2022-03-15T17:45:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/linktransit-wa-us/linktransit-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-link-transit-gtfs-275.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-mason-transit-authority-gtfs-264.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-mason-transit-authority-gtfs-264.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 264,
+    "data_type": "gtfs",
+    "provider": "Mason Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.046298,
+            "maximum_latitude": 47.608458,
+            "minimum_longitude": -123.230174,
+            "maximum_longitude": -122.626062,
+            "extracted_on": "2022-03-15T17:44:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/mason-wa-us/mason-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-mason-transit-authority-gtfs-264.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-microsoft-shuttles-gtfs-269.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-microsoft-shuttles-gtfs-269.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 269,
+    "data_type": "gtfs",
+    "provider": "Microsoft Shuttles",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Seattle",
+        "bounding_box": {
+            "minimum_latitude": 47.555579,
+            "maximum_latitude": 47.676876,
+            "minimum_longitude": -122.338378,
+            "maximum_longitude": -122.049752,
+            "extracted_on": "2022-03-15T17:45:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/cookieguru/microsoft-gtfs/releases/download/20150518150359/gtfs_20150518150359.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-microsoft-shuttles-gtfs-269.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-pacific-transit-gtfs-242.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-pacific-transit-gtfs-242.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 242,
+    "data_type": "gtfs",
+    "provider": "Pacific Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Aberdeen",
+        "bounding_box": {
+            "minimum_latitude": 46.19019607,
+            "maximum_latitude": 46.97647798,
+            "minimum_longitude": -124.05531183,
+            "maximum_longitude": -123.73147396,
+            "extracted_on": "2022-03-15T17:43:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/pacific_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-pacific-transit-gtfs-242.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-people-for-people-community-connector-gtfs-271.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-people-for-people-community-connector-gtfs-271.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 271,
+    "data_type": "gtfs",
+    "provider": "People for People (Community Connector)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 46.198738,
+            "maximum_latitude": 47.966069,
+            "minimum_longitude": -120.69641,
+            "maximum_longitude": -117.4058,
+            "extracted_on": "2022-03-15T17:45:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/pfp-wa-us/pfp-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-people-for-people-community-connector-gtfs-271.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-pierce-transit-gtfs-265.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-pierce-transit-gtfs-265.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 265,
+    "data_type": "gtfs",
+    "provider": "Pierce Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.071828,
+            "maximum_latitude": 47.663345,
+            "minimum_longitude": -122.640023,
+            "maximum_longitude": -122.133359,
+            "extracted_on": "2022-03-15T17:44:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.sound.obaweb.org/prod/3_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-pierce-transit-gtfs-265.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-rivercities-transit-rct-gtfs-259.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-rivercities-transit-rct-gtfs-259.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 259,
+    "data_type": "gtfs",
+    "provider": "RiverCities Transit (RCT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Longview",
+        "bounding_box": {
+            "minimum_latitude": 46.1171342383932,
+            "maximum_latitude": 46.17482997,
+            "minimum_longitude": -123.023364220386,
+            "maximum_longitude": -122.8794183,
+            "extracted_on": "2022-03-15T17:44:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/rivercitiestransit-wa-us/rivercitiestransit-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-rivercities-transit-rct-gtfs-259.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-seattle-childrens-hospital-shuttle-gtfs-270.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-seattle-childrens-hospital-shuttle-gtfs-270.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 270,
+    "data_type": "gtfs",
+    "provider": "Seattle Children's Hospital Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.650082,
+            "maximum_latitude": 47.678731,
+            "minimum_longitude": -122.317474,
+            "maximum_longitude": -122.256796,
+            "extracted_on": "2022-03-15T17:45:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.sound.obaweb.org/prod/98_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-seattle-childrens-hospital-shuttle-gtfs-270.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-skamania-county-transit-gtfs-262.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-skamania-county-transit-gtfs-262.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 262,
+    "data_type": "gtfs",
+    "provider": "Skamania County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 45.533467,
+            "maximum_latitude": 45.741076,
+            "minimum_longitude": -122.650095,
+            "maximum_longitude": -121.19185,
+            "extracted_on": "2022-03-15T17:44:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/skamaniacounty-wa-us/skamaniacounty-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-skamania-county-transit-gtfs-262.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-sound-transit-gtfs-268.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-sound-transit-gtfs-268.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 268,
+    "data_type": "gtfs",
+    "provider": "Sound Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Seattle",
+        "bounding_box": {
+            "minimum_latitude": 47.153189,
+            "maximum_latitude": 47.974947,
+            "minimum_longitude": -122.499103,
+            "maximum_longitude": -122.197257,
+            "extracted_on": "2022-03-15T17:45:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.sound.obaweb.org/prod/40_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-sound-transit-gtfs-268.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-sound-transit-metro-transit-city-of-seattle---king-county-metro-gtfs-267.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-sound-transit-metro-transit-city-of-seattle---king-county-metro-gtfs-267.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 267,
+    "data_type": "gtfs",
+    "provider": "Sound Transit, Metro Transit, City of Seattle - King County Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.1891174,
+            "maximum_latitude": 47.8710632,
+            "minimum_longitude": -122.506622,
+            "maximum_longitude": -121.785835,
+            "extracted_on": "2022-03-15T17:45:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://metro.kingcounty.gov/GTFS/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-sound-transit-metro-transit-city-of-seattle---king-county-metro-gtfs-267.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-sound-transit-metro-transit-city-of-seattle-king-county-metro-gtfs-267.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-sound-transit-metro-transit-city-of-seattle-king-county-metro-gtfs-267.json
@@ -16,6 +16,6 @@
     },
     "urls": {
         "direct_download": "http://metro.kingcounty.gov/GTFS/google_transit.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-sound-transit-metro-transit-city-of-seattle---king-county-metro-gtfs-267.zip?alt=media"
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-sound-transit-metro-transit-city-of-seattle-king-county-metro-gtfs-267.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-washington-union-gap-gtfs-277.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-union-gap-gtfs-277.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 277,
+    "data_type": "gtfs",
+    "provider": "Union Gap",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Yakima",
+        "bounding_box": {
+            "minimum_latitude": 46.536388,
+            "maximum_latitude": 46.577649,
+            "minimum_longitude": -120.520256,
+            "maximum_longitude": -120.475399,
+            "extracted_on": "2022-03-15T17:45:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/uniongap-wa-us/uniongap-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-union-gap-gtfs-277.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-yakima-transit-gtfs-276.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-yakima-transit-gtfs-276.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 276,
+    "data_type": "gtfs",
+    "provider": "Yakima Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Yakima",
+        "bounding_box": {
+            "minimum_latitude": 46.56293,
+            "maximum_latitude": 46.623763978,
+            "minimum_longitude": -120.635949,
+            "maximum_longitude": -120.47735,
+            "extracted_on": "2022-03-15T17:45:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://yakimatransit.org/gtfs/yakima_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-yakima-transit-gtfs-276.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-eau-claire-transit-gtfs-208.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-eau-claire-transit-gtfs-208.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 208,
+    "data_type": "gtfs",
+    "provider": "Eau Claire Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Eau Claire",
+        "bounding_box": {
+            "minimum_latitude": 44.76862,
+            "maximum_latitude": 44.87229,
+            "minimum_longitude": -91.548513,
+            "maximum_longitude": -91.42714,
+            "extracted_on": "2022-03-15T17:42:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www-ecbus-org.site.atfni.com/build_data_feed.phtml",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-eau-claire-transit-gtfs-208.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #89: Second data import

This PR adds the second part of the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 97 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~