### PR TITLE
feat: Third import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-alabama-birmingham-jefferson-county-transit-authority-gtfs-339.json
+++ b/catalogs/sources/gtfs/schedule/us-alabama-birmingham-jefferson-county-transit-authority-gtfs-339.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 339,
+    "data_type": "gtfs",
+    "provider": "Birmingham Jefferson County Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alabama",
+        "municipality": "Birmingham",
+        "bounding_box": {
+            "minimum_latitude": 33.33396,
+            "maximum_latitude": 33.66285,
+            "minimum_longitude": -87.00786,
+            "maximum_longitude": -86.67696,
+            "extracted_on": "2022-03-15T21:16:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://maxtransit.org/wp-content/uploads/2017/05/BJCTA_GTFS_0317.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alabama-birmingham-jefferson-county-transit-authority-gtfs-339.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alabama-huntsville-shuttle-gtfs-353.json
+++ b/catalogs/sources/gtfs/schedule/us-alabama-huntsville-shuttle-gtfs-353.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 353,
+    "data_type": "gtfs",
+    "provider": "Huntsville Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alabama",
+        "municipality": "Huntsville",
+        "bounding_box": {
+            "minimum_latitude": 34.665653,
+            "maximum_latitude": 34.793232,
+            "minimum_longitude": -86.678083,
+            "maximum_longitude": -86.540532,
+            "extracted_on": "2022-03-15T21:17:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://maps.hsvcity.com/GoogleTransit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alabama-huntsville-shuttle-gtfs-353.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alabama-montgomery-transit-gtfs-338.json
+++ b/catalogs/sources/gtfs/schedule/us-alabama-montgomery-transit-gtfs-338.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 338,
+    "data_type": "gtfs",
+    "provider": "Montgomery Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alabama",
+        "municipality": "Montgomery",
+        "bounding_box": {
+            "minimum_latitude": 32.293826,
+            "maximum_latitude": 32.4342702556604,
+            "minimum_longitude": -86.4007303,
+            "maximum_longitude": -86.128268729575,
+            "extracted_on": "2022-03-15T21:16:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/montgomerytransit-al-us/montgomerytransit-al-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alabama-montgomery-transit-gtfs-338.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alaska-capital-transit-gtfs-294.json
+++ b/catalogs/sources/gtfs/schedule/us-alaska-capital-transit-gtfs-294.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 294,
+    "data_type": "gtfs",
+    "provider": "Capital Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alaska",
+        "municipality": "Juneau",
+        "bounding_box": {
+            "minimum_latitude": 58.274981,
+            "maximum_latitude": 58.40536,
+            "minimum_longitude": -134.64429287,
+            "maximum_longitude": -134.390063,
+            "extracted_on": "2022-03-15T21:14:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cityandboroughofjuneau-ak-us/cityandboroughofjuneau-ak-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alaska-capital-transit-gtfs-294.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-calabasas-transit-system-gtfs-296.json
+++ b/catalogs/sources/gtfs/schedule/us-california-calabasas-transit-system-gtfs-296.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 296,
+    "data_type": "gtfs",
+    "provider": "Calabasas Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 34.1267823551685,
+            "maximum_latitude": 34.1646773952993,
+            "minimum_longitude": -118.714712146685,
+            "maximum_longitude": -118.609714786109,
+            "extracted_on": "2022-03-15T21:14:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/calabasas-ca-us/calabasas-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-calabasas-transit-system-gtfs-296.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-camarillo-area-transit-gtfs-297.json
+++ b/catalogs/sources/gtfs/schedule/us-california-camarillo-area-transit-gtfs-297.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 297,
+    "data_type": "gtfs",
+    "provider": "Camarillo Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Camarillo",
+        "bounding_box": {
+            "minimum_latitude": 34.2160754754535,
+            "maximum_latitude": 34.243015,
+            "minimum_longitude": -119.074177,
+            "maximum_longitude": -118.974631,
+            "extracted_on": "2022-03-15T21:14:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/camarillo-ca-us/camarillo-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-camarillo-area-transit-gtfs-297.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-carson-circuit-gtfs-298.json
+++ b/catalogs/sources/gtfs/schedule/us-california-carson-circuit-gtfs-298.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 298,
+    "data_type": "gtfs",
+    "provider": "Carson Circuit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Carson",
+        "bounding_box": {
+            "minimum_latitude": 33.8082344204378,
+            "maximum_latitude": 33.8860288636595,
+            "minimum_longitude": -118.2859241618,
+            "maximum_longitude": -118.21192070155,
+            "extracted_on": "2022-03-15T21:14:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/carson-ca-us/carson-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-carson-circuit-gtfs-298.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-catalina-express-gtfs-299.json
+++ b/catalogs/sources/gtfs/schedule/us-california-catalina-express-gtfs-299.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 299,
+    "data_type": "gtfs",
+    "provider": "Catalina Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Long Beach",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-15T21:14:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gitlab.com/LACMTA/gtfs_lax/-/archive/master/gtfs_lax-master.zip?path=catalina_express",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-catalina-express-gtfs-299.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-catalina-flyer-gtfs-300.json
+++ b/catalogs/sources/gtfs/schedule/us-california-catalina-flyer-gtfs-300.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 300,
+    "data_type": "gtfs",
+    "provider": "Catalina Flyer",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 33.3447667724262,
+            "maximum_latitude": 33.6028311986186,
+            "minimum_longitude": -118.322060998279,
+            "maximum_longitude": -117.899246237566,
+            "extracted_on": "2022-03-15T21:14:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/catalinaflyer-ca-us/catalinaflyer-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-catalina-flyer-gtfs-300.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-compton-renaissance-gtfs-314.json
+++ b/catalogs/sources/gtfs/schedule/us-california-compton-renaissance-gtfs-314.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 314,
+    "data_type": "gtfs",
+    "provider": "Compton Renaissance",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Compton",
+        "bounding_box": {
+            "minimum_latitude": 33.8668373372485,
+            "maximum_latitude": 33.9232688805322,
+            "minimum_longitude": -118.255090151507,
+            "maximum_longitude": -118.181491014396,
+            "extracted_on": "2022-03-15T21:14:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/compton-ca-us/compton-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-compton-renaissance-gtfs-314.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-cudahy-area-rapid-transit-gtfs-318.json
+++ b/catalogs/sources/gtfs/schedule/us-california-cudahy-area-rapid-transit-gtfs-318.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 318,
+    "data_type": "gtfs",
+    "provider": "Cudahy Area Rapid Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Cudahy",
+        "bounding_box": {
+            "minimum_latitude": 33.9579518395426,
+            "maximum_latitude": 33.9677414111609,
+            "minimum_longitude": -118.194687121803,
+            "maximum_longitude": -118.174558102071,
+            "extracted_on": "2022-03-15T21:14:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cudahy-ca-us/cudahy-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-cudahy-area-rapid-transit-gtfs-318.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-delano-area-rapid-transit-gtfs-320.json
+++ b/catalogs/sources/gtfs/schedule/us-california-delano-area-rapid-transit-gtfs-320.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 320,
+    "data_type": "gtfs",
+    "provider": "Delano Area Rapid Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Delano",
+        "bounding_box": {
+            "minimum_latitude": 35.745704086606,
+            "maximum_latitude": 35.79040964,
+            "minimum_longitude": -119.27176604545,
+            "maximum_longitude": -119.2231118,
+            "extracted_on": "2022-03-15T21:14:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/delano-ca-us/delano-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-delano-area-rapid-transit-gtfs-320.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-ridgerunner-gtfs-311.json
+++ b/catalogs/sources/gtfs/schedule/us-california-ridgerunner-gtfs-311.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 311,
+    "data_type": "gtfs",
+    "provider": "Ridgerunner",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Ridgecrest",
+        "bounding_box": {
+            "minimum_latitude": 35.5659778499683,
+            "maximum_latitude": 35.6518073226256,
+            "minimum_longitude": -117.816944,
+            "maximum_longitude": -117.652284,
+            "extracted_on": "2022-03-15T21:14:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cityofridgecrest-ca-us/cityofridgecrest-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-ridgerunner-gtfs-311.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-city-of-fountain-transit-gtfs-309.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-city-of-fountain-transit-gtfs-309.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 309,
+    "data_type": "gtfs",
+    "provider": "City of Fountain Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Colorado Springs",
+        "bounding_box": {
+            "minimum_latitude": 38.6644033378998,
+            "maximum_latitude": 38.8956100585436,
+            "minimum_longitude": -104.859622660021,
+            "maximum_longitude": -104.681221924795,
+            "extracted_on": "2022-03-15T21:14:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cityoffountaintransit-co-us/cityoffountaintransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-city-of-fountain-transit-gtfs-309.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-clear-creek-county-transit-gtfs-313.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-clear-creek-county-transit-gtfs-313.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 313,
+    "data_type": "gtfs",
+    "provider": "Clear Creek County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Georgetown",
+        "bounding_box": {
+            "minimum_latitude": 39.6932238397198,
+            "maximum_latitude": 39.766353,
+            "minimum_longitude": -105.728448,
+            "maximum_longitude": -105.328169,
+            "extracted_on": "2022-03-15T21:14:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/clearcreek-co-us/clearcreek-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-clear-creek-county-transit-gtfs-313.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-cripple-creek-transportation-gtfs-317.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-cripple-creek-transportation-gtfs-317.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 317,
+    "data_type": "gtfs",
+    "provider": "Cripple Creek Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Cripple Creek",
+        "bounding_box": {
+            "minimum_latitude": 38.710403,
+            "maximum_latitude": 38.996448,
+            "minimum_longitude": -105.178926,
+            "maximum_longitude": -105.054586,
+            "extracted_on": "2022-03-15T21:14:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cripplecreek-co-us/cripplecreek-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-cripple-creek-transportation-gtfs-317.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-bay-town-trolley-gtfs-337.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-bay-town-trolley-gtfs-337.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 337,
+    "data_type": "gtfs",
+    "provider": "Bay Town Trolley",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Panama City",
+        "bounding_box": {
+            "minimum_latitude": 30.13101132,
+            "maximum_latitude": 30.26271371,
+            "minimum_longitude": -85.97463998,
+            "maximum_longitude": -85.59096956,
+            "extracted_on": "2022-03-15T21:16:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/baytowntrolley-fl-us/baytowntrolley-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-bay-town-trolley-gtfs-337.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-broward-county-transit-gtfs-330.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-broward-county-transit-gtfs-330.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 330,
+    "data_type": "gtfs",
+    "provider": "Broward County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Fort Lauderdale",
+        "bounding_box": {
+            "minimum_latitude": 25.761776,
+            "maximum_latitude": 26.350899,
+            "minimum_longitude": -80.428505,
+            "maximum_longitude": -80.075905,
+            "extracted_on": "2022-03-15T21:15:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.broward.org/bct/documents/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-broward-county-transit-gtfs-330.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-central-florida-regional-transit-authority-lynx-gtfs-347.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-central-florida-regional-transit-authority-lynx-gtfs-347.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 347,
+    "data_type": "gtfs",
+    "provider": "Central Florida Regional Transit Authority (LYNX)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Orlando",
+        "bounding_box": {
+            "minimum_latitude": 28.10932,
+            "maximum_latitude": 28.814992,
+            "minimum_longitude": -81.67681,
+            "maximum_longitude": -81.205343,
+            "extracted_on": "2022-03-15T21:16:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfsrt.golynx.com/gtfsrt/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-central-florida-regional-transit-authority-lynx-gtfs-347.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-collier-area-transit-cat-gtfs-323.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-collier-area-transit-cat-gtfs-323.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 323,
+    "data_type": "gtfs",
+    "provider": "Collier Area Transit (CAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Naples",
+        "bounding_box": {
+            "minimum_latitude": 25.91208645,
+            "maximum_latitude": 26.44474102,
+            "minimum_longitude": -81.828441,
+            "maximum_longitude": -81.38958483,
+            "extracted_on": "2022-03-15T21:14:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=396A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-collier-area-transit-cat-gtfs-323.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-emerald-coast-rider-ecr-gtfs-336.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-emerald-coast-rider-ecr-gtfs-336.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 336,
+    "data_type": "gtfs",
+    "provider": "Emerald Coast Rider (ECR)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Crestview",
+        "bounding_box": {
+            "minimum_latitude": 30.37921667,
+            "maximum_latitude": 30.75746667,
+            "minimum_longitude": -86.66665,
+            "maximum_longitude": -86.3504333333,
+            "extracted_on": "2022-03-15T21:16:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/okaloosacountytransit-fl-us/okaloosacountytransit-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-emerald-coast-rider-ecr-gtfs-336.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-escambia-county-area-transit-ecat-gtfs-335.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-escambia-county-area-transit-ecat-gtfs-335.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 335,
+    "data_type": "gtfs",
+    "provider": "Escambia County Area Transit (ECAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Pensacola",
+        "bounding_box": {
+            "minimum_latitude": 30.3260277505244,
+            "maximum_latitude": 30.970248,
+            "minimum_longitude": -87.359577,
+            "maximum_longitude": -87.0600450545759,
+            "extracted_on": "2022-03-15T21:16:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ecat-fl-us/ecat-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-escambia-county-area-transit-ecat-gtfs-335.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-gainesville-regional-transit-system-gtfs-345.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-gainesville-regional-transit-system-gtfs-345.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 345,
+    "data_type": "gtfs",
+    "provider": "Gainesville Regional Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Gainesville",
+        "bounding_box": {
+            "minimum_latitude": 29.6001677847958,
+            "maximum_latitude": 29.7150360778361,
+            "minimum_longitude": -82.4422097140819,
+            "maximum_longitude": -82.2639662041154,
+            "extracted_on": "2022-03-15T21:16:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=468A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-gainesville-regional-transit-system-gtfs-345.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-hernando-county-transit-thebus-gtfs-341.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-hernando-county-transit-thebus-gtfs-341.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 341,
+    "data_type": "gtfs",
+    "provider": "Hernando County Transit (TheBus)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Brooksville",
+        "bounding_box": {
+            "minimum_latitude": 28.40039824,
+            "maximum_latitude": 28.595345,
+            "minimum_longitude": -82.66114094,
+            "maximum_longitude": -82.37722793,
+            "extracted_on": "2022-03-15T21:16:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/thehernandoexpress-fl-us/thehernandoexpress-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-hernando-county-transit-thebus-gtfs-341.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-hillsborough-area-regional-transit-hart-gtfs-325.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-hillsborough-area-regional-transit-hart-gtfs-325.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 325,
+    "data_type": "gtfs",
+    "provider": "Hillsborough Area Regional Transit (HART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Tampa",
+        "bounding_box": {
+            "minimum_latitude": 27.70568,
+            "maximum_latitude": 28.195743,
+            "minimum_longitude": -82.584777,
+            "maximum_longitude": -82.210817,
+            "extracted_on": "2022-03-15T21:15:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.gohart.org/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-hillsborough-area-regional-transit-hart-gtfs-325.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-jacksonville-transportation-authority-jta-gtfs-346.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-jacksonville-transportation-authority-jta-gtfs-346.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 346,
+    "data_type": "gtfs",
+    "provider": "Jacksonville Transportation Authority (JTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Jacksonville",
+        "bounding_box": {
+            "minimum_latitude": 29.935837,
+            "maximum_latitude": 30.624756,
+            "minimum_longitude": -81.890433,
+            "maximum_longitude": -81.337585,
+            "extracted_on": "2022-03-15T21:16:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://schedules.jtafla.com/schedulesgtfs/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-jacksonville-transportation-authority-jta-gtfs-346.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-key-west-transit-gtfs-322.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-key-west-transit-gtfs-322.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 322,
+    "data_type": "gtfs",
+    "provider": "Key West Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Key West",
+        "bounding_box": {
+            "minimum_latitude": 24.5477227066457,
+            "maximum_latitude": 24.732427,
+            "minimum_longitude": -81.806246,
+            "maximum_longitude": -81.018977,
+            "extracted_on": "2022-03-15T21:14:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/keywest-fl-us/keywest-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-key-west-transit-gtfs-322.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-lakeland-area-mass-transit-district-citrus-connection-gtfs-321.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-lakeland-area-mass-transit-district-citrus-connection-gtfs-321.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 321,
+    "data_type": "gtfs",
+    "provider": "Lakeland Area Mass Transit District (Citrus Connection)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "bounding_box": {
+            "minimum_latitude": 27.732109,
+            "maximum_latitude": 28.15007,
+            "minimum_longitude": -82.05611899999998,
+            "maximum_longitude": -81.527123,
+            "extracted_on": "2022-03-15T21:14:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=313A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-lakeland-area-mass-transit-district-citrus-connection-gtfs-321.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-lakexpress-gtfs-342.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-lakexpress-gtfs-342.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 342,
+    "data_type": "gtfs",
+    "provider": "LakeXpress",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Leesburg",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-15T21:16:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=450A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-lakexpress-gtfs-342.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-leetran-gtfs-324.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-leetran-gtfs-324.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 324,
+    "data_type": "gtfs",
+    "provider": "LeeTran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Fort Myers",
+        "bounding_box": {
+            "minimum_latitude": 26.272102,
+            "maximum_latitude": 26.723837,
+            "minimum_longitude": -82.017588,
+            "maximum_longitude": -81.597666,
+            "extracted_on": "2022-03-15T21:15:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.leegov.com/leetran/Documents/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-leetran-gtfs-324.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-manatee-county-area-transit-gtfs-328.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-manatee-county-area-transit-gtfs-328.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 328,
+    "data_type": "gtfs",
+    "provider": "Manatee County Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "bounding_box": {
+            "minimum_latitude": 27.337532,
+            "maximum_latitude": 27.811755,
+            "minimum_longitude": -82.780151,
+            "maximum_longitude": -82.451716,
+            "extracted_on": "2022-03-15T21:15:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=342A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-manatee-county-area-transit-gtfs-328.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-miami-dade-transit-gtfs-331.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-miami-dade-transit-gtfs-331.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 331,
+    "data_type": "gtfs",
+    "provider": "Miami-Dade Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Miami",
+        "bounding_box": {
+            "minimum_latitude": 24.71614,
+            "maximum_latitude": 26.123095,
+            "minimum_longitude": -81.075723,
+            "maximum_longitude": -80.12016,
+            "extracted_on": "2022-03-15T21:16:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.miamidade.gov/transit/googletransit/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-miami-dade-transit-gtfs-331.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-palm-tran-gtfs-332.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-palm-tran-gtfs-332.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 332,
+    "data_type": "gtfs",
+    "provider": "Palm Tran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Palm Beach",
+        "bounding_box": {
+            "minimum_latitude": 26.314874,
+            "maximum_latitude": 26.93437,
+            "minimum_longitude": -80.720899,
+            "maximum_longitude": -80.033635,
+            "extracted_on": "2022-03-15T21:16:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.palmtran.org/feed/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-palm-tran-gtfs-332.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-pasco-county-public-transportation-gtfs-340.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-pasco-county-public-transportation-gtfs-340.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 340,
+    "data_type": "gtfs",
+    "provider": "Pasco County Public Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Spring Hill",
+        "bounding_box": {
+            "minimum_latitude": 28.14146,
+            "maximum_latitude": 28.465932,
+            "minimum_longitude": -82.758257,
+            "maximum_longitude": -82.170562,
+            "extracted_on": "2022-03-15T21:16:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/pascocountypublictransit-fl-us/pascocountypublictransit-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-pasco-county-public-transportation-gtfs-340.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-pinellas-suncoast-transit-authority-psta-gtfs-326.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-pinellas-suncoast-transit-authority-psta-gtfs-326.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 326,
+    "data_type": "gtfs",
+    "provider": "Pinellas Suncoast Transit Authority (PSTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Pinellas",
+        "bounding_box": {
+            "minimum_latitude": 27.70473,
+            "maximum_latitude": 28.15529,
+            "minimum_longitude": -82.850532,
+            "maximum_longitude": -82.453755,
+            "extracted_on": "2022-03-15T21:15:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.psta.net/latest/Google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-pinellas-suncoast-transit-authority-psta-gtfs-326.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-sarasota-county-area-transit-gtfs-327.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-sarasota-county-area-transit-gtfs-327.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 327,
+    "data_type": "gtfs",
+    "provider": "Sarasota County Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Sarasota",
+        "bounding_box": {
+            "minimum_latitude": 27.038871,
+            "maximum_latitude": 27.493355,
+            "minimum_longitude": -82.587857,
+            "maximum_longitude": -82.205356,
+            "extracted_on": "2022-03-15T21:15:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=457A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-sarasota-county-area-transit-gtfs-327.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-sarasota-county-area-transit-scat-gtfs-348.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-sarasota-county-area-transit-scat-gtfs-348.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 348,
+    "data_type": "gtfs",
+    "provider": "Sarasota County Area Transit (SCAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Sarasota",
+        "bounding_box": {
+            "minimum_latitude": 27.951516,
+            "maximum_latitude": 28.755067,
+            "minimum_longitude": -80.873802,
+            "maximum_longitude": -80.566966,
+            "extracted_on": "2022-03-15T21:16:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/spacecoast-fl-us/spacecoast-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-sarasota-county-area-transit-scat-gtfs-348.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-starmetro-gtfs-344.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-starmetro-gtfs-344.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 344,
+    "data_type": "gtfs",
+    "provider": "StarMetro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Tallahassee",
+        "bounding_box": {
+            "minimum_latitude": 30.376031971848,
+            "maximum_latitude": 30.54344948,
+            "minimum_longitude": -84.36447298,
+            "maximum_longitude": -84.20215136,
+            "extracted_on": "2022-03-15T21:16:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/starmetro-fl-us/starmetro-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-starmetro-gtfs-344.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-sunshine-bus-company-gtfs-350.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-sunshine-bus-company-gtfs-350.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 350,
+    "data_type": "gtfs",
+    "provider": "Sunshine Bus Company",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Saint Augustine",
+        "bounding_box": {
+            "minimum_latitude": 29.6378981415515,
+            "maximum_latitude": 30.18280175,
+            "minimum_longitude": -81.6059567468163,
+            "maximum_longitude": -81.2547616730411,
+            "extracted_on": "2022-03-15T21:16:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sunshinebuscompany-fl-us/sunshinebuscompany-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-sunshine-bus-company-gtfs-350.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-suntran-gtfs-343.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-suntran-gtfs-343.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 343,
+    "data_type": "gtfs",
+    "provider": "SunTran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Ocala",
+        "bounding_box": {
+            "minimum_latitude": 29.080028,
+            "maximum_latitude": 29.2235704574326,
+            "minimum_longitude": -82.1875092501465,
+            "maximum_longitude": -81.980081,
+            "extracted_on": "2022-03-15T21:16:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/suntran-fl-us/suntran-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-suntran-gtfs-343.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-tri-rail-gtfs-333.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-tri-rail-gtfs-333.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 333,
+    "data_type": "gtfs",
+    "provider": "Tri-Rail",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Pompano Beach",
+        "bounding_box": {
+            "minimum_latitude": 25.7959403992,
+            "maximum_latitude": 26.7587432861,
+            "minimum_longitude": -80.2596206665,
+            "maximum_longitude": -80.062538147,
+            "extracted_on": "2022-03-15T21:16:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.tri-rail.com/GTDF/Current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-tri-rail-gtfs-333.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-usf-bull-runner-gtfs-329.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-usf-bull-runner-gtfs-329.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 329,
+    "data_type": "gtfs",
+    "provider": "USF Bull Runner",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Tampa",
+        "bounding_box": {
+            "minimum_latitude": 28.0434346203,
+            "maximum_latitude": 28.0803911041,
+            "minimum_longitude": -82.4349528551,
+            "maximum_longitude": -82.401586175,
+            "extracted_on": "2022-03-15T21:15:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/CUTR-at-USF/bullrunner-gtfs-realtime-generator/raw/master/bullrunner-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-usf-bull-runner-gtfs-329.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-votran-gtfs-349.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-votran-gtfs-349.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 349,
+    "data_type": "gtfs",
+    "provider": "Votran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Daytona Beach",
+        "bounding_box": {
+            "minimum_latitude": 28.856002,
+            "maximum_latitude": 29.383995,
+            "minimum_longitude": -81.506774,
+            "maximum_longitude": -80.847351,
+            "extracted_on": "2022-03-15T21:16:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=425A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-votran-gtfs-349.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-atlanta-streetcar-gtfs-356.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-atlanta-streetcar-gtfs-356.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 356,
+    "data_type": "gtfs",
+    "provider": "Atlanta Streetcar",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.7542955,
+            "maximum_latitude": 33.7595003,
+            "minimum_longitude": -84.3919955,
+            "maximum_longitude": -84.3746846,
+            "extracted_on": "2022-03-15T21:17:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://documents.atlantaregional.com/transitdata/gtfs_ASC.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-atlanta-streetcar-gtfs-356.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-atlantic-regional-commission-gtfs-357.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-atlantic-regional-commission-gtfs-357.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 357,
+    "data_type": "gtfs",
+    "provider": "Atlantic Regional Commission",
+    "name": "Atlantic Station Shuttle (FREE RIDE)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.788910953901,
+            "maximum_latitude": 33.791448582308,
+            "minimum_longitude": -84.402861650688,
+            "maximum_longitude": -84.38680267356139,
+            "extracted_on": "2022-03-15T21:17:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://documents.atlantaregional.com/transitdata/gtfs_Atlantic.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-atlantic-regional-commission-gtfs-357.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-buc-shuttle-gtfs-371.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-buc-shuttle-gtfs-371.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 371,
+    "data_type": "gtfs",
+    "provider": "Buc Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.845189225652,
+            "maximum_latitude": 33.852441312646,
+            "minimum_longitude": -84.37951760612631,
+            "maximum_longitude": -84.344229214656,
+            "extracted_on": "2022-03-15T21:18:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://documents.atlantaregional.com/transitdata/gtfs_Buc.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-buc-shuttle-gtfs-371.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-chatham-area-transit-cat-gtfs-351.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-chatham-area-transit-cat-gtfs-351.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 351,
+    "data_type": "gtfs",
+    "provider": "Chatham Area Transit (CAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Savannah",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-15T21:17:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.catchacat.org/wp-content/uploads/2019/07/cat_gtfs_06-07-2021.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-chatham-area-transit-cat-gtfs-351.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-cherokee-area-transportation-system-cats-gtfs-358.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-cherokee-area-transportation-system-cats-gtfs-358.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 358,
+    "data_type": "gtfs",
+    "provider": "Cherokee Area Transportation System (CATS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Marietta",
+        "bounding_box": {
+            "minimum_latitude": 34.19131495077687,
+            "maximum_latitude": 34.25758321919467,
+            "minimum_longitude": -84.51003782185032,
+            "maximum_longitude": -84.458359898787,
+            "extracted_on": "2022-03-15T21:17:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://documents.atlantaregional.com/transitdata/gtfs_CATS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-cherokee-area-transportation-system-cats-gtfs-358.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-cobb-community-transit-cct-gtfs-354.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-cobb-community-transit-cct-gtfs-354.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 354,
+    "data_type": "gtfs",
+    "provider": "Cobb Community Transit (CCT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Marietta",
+        "bounding_box": {
+            "minimum_latitude": 33.75039,
+            "maximum_latitude": 34.077357,
+            "minimum_longitude": -84.656428,
+            "maximum_longitude": -84.384289,
+            "extracted_on": "2022-03-15T21:17:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.arcgis.com/sharing/rest/content/items/1ce8e370a12c41b5854d8baa21f8451c/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-cobb-community-transit-cct-gtfs-354.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-emory-university-cliff-shuttles-gtfs-370.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-emory-university-cliff-shuttles-gtfs-370.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 370,
+    "data_type": "gtfs",
+    "provider": "Emory University Cliff Shuttles",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.774499558823095,
+            "maximum_latitude": 33.80119548687,
+            "minimum_longitude": -84.325291336459,
+            "maximum_longitude": -84.29636358836,
+            "extracted_on": "2022-03-15T21:18:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://documents.atlantaregional.com/transitdata/gtfs_CCTMA.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-emory-university-cliff-shuttles-gtfs-370.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-georgia-tech-trolley-stinger-shuttles-gtfs-355.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-georgia-tech-trolley-stinger-shuttles-gtfs-355.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 355,
+    "data_type": "gtfs",
+    "provider": "Georgia Tech Trolley & Stinger Shuttles",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.768747771068,
+            "maximum_latitude": 33.797183312467,
+            "minimum_longitude": -84.40593699999998,
+            "maximum_longitude": -84.317129413001,
+            "extracted_on": "2022-03-15T21:17:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://documents.atlantaregional.com/transitdata/gtfs_GT.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-georgia-tech-trolley-stinger-shuttles-gtfs-355.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-gwinnett-county-transit-gtfs-369.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-gwinnett-county-transit-gtfs-369.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 369,
+    "data_type": "gtfs",
+    "provider": "Gwinnett County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.74891,
+            "maximum_latitude": 34.085081,
+            "minimum_longitude": -84.39396,
+            "maximum_longitude": -83.983106,
+            "extracted_on": "2022-03-15T21:18:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/gwinnettcountytransit-ga-us/gwinnettcountytransit-ga-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-gwinnett-county-transit-gtfs-369.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-metropolitan-atlanta-rapid-transit-authority-marta-gtfs-368.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-metropolitan-atlanta-rapid-transit-authority-marta-gtfs-368.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 368,
+    "data_type": "gtfs",
+    "provider": "Metropolitan Atlanta Rapid Transit Authority (MARTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.432372,
+            "maximum_latitude": 34.105822,
+            "minimum_longitude": -84.669803,
+            "maximum_longitude": -84.083398,
+            "extracted_on": "2022-03-15T21:18:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.itsmarta.com/google_transit_feed/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-metropolitan-atlanta-rapid-transit-authority-marta-gtfs-368.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-chicago-water-taxi-gtfs-306.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-chicago-water-taxi-gtfs-306.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 306,
+    "data_type": "gtfs",
+    "provider": "Chicago Water Taxi",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Chicago",
+        "bounding_box": {
+            "minimum_latitude": 41.8571416575835,
+            "maximum_latitude": 41.910022,
+            "minimum_longitude": -87.655758,
+            "maximum_longitude": -87.625214,
+            "extracted_on": "2022-03-15T21:14:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/chicagowatertaxi-il-us/chicagowatertaxi-il-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-chicago-water-taxi-gtfs-306.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-dekalb-public-transit-gtfs-308.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-dekalb-public-transit-gtfs-308.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 308,
+    "data_type": "gtfs",
+    "provider": "DeKalb Public Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "DeKalb",
+        "bounding_box": {
+            "minimum_latitude": 41.8905359658401,
+            "maximum_latitude": 42.01576022315,
+            "minimum_longitude": -88.87970567,
+            "maximum_longitude": -88.464325984766,
+            "extracted_on": "2022-03-15T21:14:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cityofdekalb-il-us/cityofdekalb-il-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-dekalb-public-transit-gtfs-308.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-bloomington-transit-gtfs-363.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-bloomington-transit-gtfs-363.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 363,
+    "data_type": "gtfs",
+    "provider": "Bloomington Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "Bloomington",
+        "bounding_box": {
+            "minimum_latitude": 39.1213376974018,
+            "maximum_latitude": 39.208469,
+            "minimum_longitude": -86.5918779373169,
+            "maximum_longitude": -86.471773982048,
+            "extracted_on": "2022-03-15T21:17:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.bloomington.in.gov/dataset/5aca3228-b81b-4572-a45c-b05a30053949/resource/16145a82-0959-4922-93ae-14dcee02950c/download/googletransitfeed.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-bloomington-transit-gtfs-363.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-corridorrides-gtfs-316.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-corridorrides-gtfs-316.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 316,
+    "data_type": "gtfs",
+    "provider": "CorridorRides",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Iowa City",
+        "bounding_box": {
+            "minimum_latitude": 41.656704417947,
+            "maximum_latitude": 41.9757669985156,
+            "minimum_longitude": -91.6662139695366,
+            "maximum_longitude": -91.533491920496,
+            "extracted_on": "2022-03-15T21:14:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/corridorrides-ia-us/corridorrides-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-corridorrides-gtfs-316.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-kentucky-blue-grass-community-action-partnership-gtfs-362.json
+++ b/catalogs/sources/gtfs/schedule/us-kentucky-blue-grass-community-action-partnership-gtfs-362.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 362,
+    "data_type": "gtfs",
+    "provider": "Blue Grass Community Action Partnership",
+    "name": "Bluegrass Ultra-Transit Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Kentucky",
+        "bounding_box": {
+            "minimum_latitude": 37.615264,
+            "maximum_latitude": 38.2321,
+            "minimum_longitude": -84.8984452721203,
+            "maximum_longitude": -84.4789953029549,
+            "extracted_on": "2022-03-15T21:17:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bgcap-ky-us/bgcap-ky-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-kentucky-blue-grass-community-action-partnership-gtfs-362.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-kentucky-lextran-gtfs-365.json
+++ b/catalogs/sources/gtfs/schedule/us-kentucky-lextran-gtfs-365.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 365,
+    "data_type": "gtfs",
+    "provider": "Lextran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Kentucky",
+        "municipality": "Lexington",
+        "bounding_box": {
+            "minimum_latitude": 37.97065,
+            "maximum_latitude": 38.108089,
+            "minimum_longitude": -84.604828,
+            "maximum_longitude": -84.40544099999998,
+            "extracted_on": "2022-03-15T21:17:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://lextran.com/wp-content/uploads/2021/05/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-kentucky-lextran-gtfs-365.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-kentucky-transit-authority-of-northern-kentucky-tank-gtfs-367.json
+++ b/catalogs/sources/gtfs/schedule/us-kentucky-transit-authority-of-northern-kentucky-tank-gtfs-367.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 367,
+    "data_type": "gtfs",
+    "provider": "Transit Authority of Northern Kentucky (TANK)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Kentucky",
+        "municipality": "Fort Wright",
+        "bounding_box": {
+            "minimum_latitude": 38.9554999983947,
+            "maximum_latitude": 39.116476000458,
+            "minimum_longitude": -84.728163998601,
+            "maximum_longitude": -84.4007943982551,
+            "extracted_on": "2022-03-15T21:17:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.tankbus.org/Portals/tankbus/gtfs/tank-google-transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-kentucky-transit-authority-of-northern-kentucky-tank-gtfs-367.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-kentucky-transit-authority-of-river-city-tarc-gtfs-364.json
+++ b/catalogs/sources/gtfs/schedule/us-kentucky-transit-authority-of-river-city-tarc-gtfs-364.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 364,
+    "data_type": "gtfs",
+    "provider": "Transit Authority of River City (TARC)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Kentucky",
+        "municipality": "Louisville",
+        "bounding_box": {
+            "minimum_latitude": 38.056361,
+            "maximum_latitude": 38.383253,
+            "minimum_longitude": -85.904275,
+            "maximum_longitude": -85.502994,
+            "extracted_on": "2022-03-15T21:17:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://googletransit.ridetarc.org/feed/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-kentucky-transit-authority-of-river-city-tarc-gtfs-364.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-minnesota-duluth-transit-gtfs-301.json
+++ b/catalogs/sources/gtfs/schedule/us-minnesota-duluth-transit-gtfs-301.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 301,
+    "data_type": "gtfs",
+    "provider": "Duluth Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Minnesota",
+        "municipality": "Duluth",
+        "bounding_box": {
+            "minimum_latitude": 46.654703,
+            "maximum_latitude": 46.855417,
+            "minimum_longitude": -92.290788,
+            "maximum_longitude": -92.009608,
+            "extracted_on": "2022-03-15T21:14:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://duluthtransit.com/gtf/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-minnesota-duluth-transit-gtfs-301.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-montana-butte-silver-bow-gtfs-291.json
+++ b/catalogs/sources/gtfs/schedule/us-montana-butte-silver-bow-gtfs-291.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 291,
+    "data_type": "gtfs",
+    "provider": "Butte-Silver Bow",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Montana",
+        "municipality": "Butte",
+        "bounding_box": {
+            "minimum_latitude": 45.937727,
+            "maximum_latitude": 46.029995,
+            "minimum_longitude": -112.561443,
+            "maximum_longitude": -112.477421,
+            "extracted_on": "2022-03-15T21:13:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/butte-mt-us/butte-mt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-montana-butte-silver-bow-gtfs-291.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-montana-capital-transit-gtfs-310.json
+++ b/catalogs/sources/gtfs/schedule/us-montana-capital-transit-gtfs-310.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 310,
+    "data_type": "gtfs",
+    "provider": "Capital Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Montana",
+        "municipality": "Helena",
+        "bounding_box": {
+            "minimum_latitude": 46.582315,
+            "maximum_latitude": 46.621897,
+            "minimum_longitude": -112.060643,
+            "maximum_longitude": -111.893681,
+            "extracted_on": "2022-03-15T21:14:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/cityofhelena-mt-us/cityofhelena-mt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-montana-capital-transit-gtfs-310.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-montana-mountain-line-gtfs-292.json
+++ b/catalogs/sources/gtfs/schedule/us-montana-mountain-line-gtfs-292.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 292,
+    "data_type": "gtfs",
+    "provider": "Mountain Line",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Montana",
+        "municipality": "Missoula",
+        "bounding_box": {
+            "minimum_latitude": 46.819737,
+            "maximum_latitude": 46.924217,
+            "minimum_longitude": -114.08799,
+            "maximum_longitude": -113.862706,
+            "extracted_on": "2022-03-15T21:13:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.mountainline.com/files/MUTD_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-montana-mountain-line-gtfs-292.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-montana-streamline-gtfs-295.json
+++ b/catalogs/sources/gtfs/schedule/us-montana-streamline-gtfs-295.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 295,
+    "data_type": "gtfs",
+    "provider": "Streamline",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Montana",
+        "municipality": "Bozeman",
+        "bounding_box": {
+            "minimum_latitude": 45.6541275,
+            "maximum_latitude": 45.7826988079724,
+            "minimum_longitude": -111.184985360032,
+            "maximum_longitude": -110.571949822501,
+            "extracted_on": "2022-03-15T21:14:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/streamlinetransit-mt-us/streamlinetransit-mt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-montana-streamline-gtfs-295.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-montana-university-of-montana-udash-gtfs-293.json
+++ b/catalogs/sources/gtfs/schedule/us-montana-university-of-montana-udash-gtfs-293.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 293,
+    "data_type": "gtfs",
+    "provider": "University of Montana (UDASH)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Montana",
+        "municipality": "Missoula",
+        "bounding_box": {
+            "minimum_latitude": 46.845,
+            "maximum_latitude": 46.871871,
+            "minimum_longitude": -114.022311,
+            "maximum_longitude": -113.975603,
+            "extracted_on": "2022-03-15T21:14:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/udash-mt-us/udash-mt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-montana-university-of-montana-udash-gtfs-293.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-c-tran-gtfs-305.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-c-tran-gtfs-305.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 305,
+    "data_type": "gtfs",
+    "provider": "C TRAN",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Elmira",
+        "bounding_box": {
+            "minimum_latitude": 41.980677,
+            "maximum_latitude": 42.447267,
+            "minimum_longitude": -77.072697,
+            "maximum_longitude": -76.226975,
+            "extracted_on": "2022-03-15T21:14:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Chemung_C_Tran.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-c-tran-gtfs-305.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-chautauqua-area-regional-transit-system-carts-gtfs-304.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-chautauqua-area-regional-transit-system-carts-gtfs-304.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 304,
+    "data_type": "gtfs",
+    "provider": "Chautauqua Area Regional Transit System (CARTS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Jamestown",
+        "bounding_box": {
+            "minimum_latitude": 42.052686,
+            "maximum_latitude": 42.497036,
+            "minimum_longitude": -79.57648,
+            "maximum_longitude": -79.060006,
+            "extracted_on": "2022-03-15T21:14:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/CARTS_Chautauqua_Area_Regional_Transit_System_-_City_Routes.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-chautauqua-area-regional-transit-system-carts-gtfs-304.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-corning-erwin-area-transit-system-ceats-gtfs-302.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-corning-erwin-area-transit-system-ceats-gtfs-302.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 302,
+    "data_type": "gtfs",
+    "provider": "Corning Erwin Area Transit System (CEATS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Elmira",
+        "bounding_box": {
+            "minimum_latitude": 42.11544,
+            "maximum_latitude": 42.182297,
+            "minimum_longitude": -77.14164,
+            "maximum_longitude": -76.97059,
+            "extracted_on": "2022-03-15T21:14:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Corning_Erwin_Area_Transit_System_CEATS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-corning-erwin-area-transit-system-ceats-gtfs-302.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-cincinnati-metro-gtfs-307.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-cincinnati-metro-gtfs-307.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 307,
+    "data_type": "gtfs",
+    "provider": "Cincinnati Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Cincinnati",
+        "bounding_box": {
+            "minimum_latitude": 39.06428,
+            "maximum_latitude": 39.35716,
+            "minimum_longitude": -84.793912,
+            "maximum_longitude": -84.259938,
+            "extracted_on": "2022-03-15T21:14:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.go-metro.com/uploads/GTFS/google_transit_info.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-cincinnati-metro-gtfs-307.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-southwest-ohio-regional-transit-authority-sorta-metro-gtfs-366.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-southwest-ohio-regional-transit-authority-sorta-metro-gtfs-366.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 366,
+    "data_type": "gtfs",
+    "provider": "Southwest Ohio Regional Transit Authority (SORTA Metro)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Cincinnati",
+        "bounding_box": {
+            "minimum_latitude": 39.06428,
+            "maximum_latitude": 39.35716,
+            "minimum_longitude": -84.793912,
+            "maximum_longitude": -84.259938,
+            "extracted_on": "2022-03-15T21:17:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.go-metro.com/uploads/GTFS/google_transit_info.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-southwest-ohio-regional-transit-authority-sorta-metro-gtfs-366.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-clackamas-county-social-services-gtfs-312.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-clackamas-county-social-services-gtfs-312.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 312,
+    "data_type": "gtfs",
+    "provider": "Clackamas County Social Services",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "bounding_box": {
+            "minimum_latitude": 45.319669179261,
+            "maximum_latitude": 45.4356681764732,
+            "minimum_longitude": -122.625608199924,
+            "maximum_longitude": -122.537945796067,
+            "extracted_on": "2022-03-15T21:14:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.trilliumtransit.com/gtfs_data/clackamascounty-or-us/clackamascounty-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-clackamas-county-social-services-gtfs-312.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-wallowa-community-connection-wcc-gtfs-289.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-wallowa-community-connection-wcc-gtfs-289.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 289,
+    "data_type": "gtfs",
+    "provider": "Wallowa Community Connection (WCC)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Wallowa",
+        "bounding_box": {
+            "minimum_latitude": 44.7619984867002,
+            "maximum_latitude": 45.570984,
+            "minimum_longitude": -118.1063098,
+            "maximum_longitude": -117.190035,
+            "extracted_on": "2022-03-15T21:13:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/northeast-or-us/northeast-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-wallowa-community-connection-wcc-gtfs-289.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-south-carolina-charleston-area-regional-transportation-authority-carta-gtfs-352.json
+++ b/catalogs/sources/gtfs/schedule/us-south-carolina-charleston-area-regional-transportation-authority-carta-gtfs-352.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 352,
+    "data_type": "gtfs",
+    "provider": "Charleston Area Regional Transportation Authority (CARTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "South Carolina",
+        "municipality": "Charleston",
+        "bounding_box": {
+            "minimum_latitude": 32.569305235571,
+            "maximum_latitude": 33.581350752655,
+            "minimum_longitude": -80.5739342489342,
+            "maximum_longitude": -79.4640023086412,
+            "extracted_on": "2022-03-15T21:17:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/carta-sc-us/carta-sc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-south-carolina-charleston-area-regional-transportation-authority-carta-gtfs-352.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-tennessee-chattanooga-area-regional-transportation-authority-carta-gtfs-359.json
+++ b/catalogs/sources/gtfs/schedule/us-tennessee-chattanooga-area-regional-transportation-authority-carta-gtfs-359.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 359,
+    "data_type": "gtfs",
+    "provider": "Chattanooga Area Regional Transportation Authority (CARTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Tennessee",
+        "municipality": "Chattanooga",
+        "bounding_box": {
+            "minimum_latitude": 34.984097,
+            "maximum_latitude": 35.13868,
+            "minimum_longitude": -85.327397,
+            "maximum_longitude": -85.127349,
+            "extracted_on": "2022-03-15T21:17:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.gocarta.org/wp-content/uploads/2020/10/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-tennessee-chattanooga-area-regional-transportation-authority-carta-gtfs-359.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-tennessee-franklin-transit-authority-gtfs-361.json
+++ b/catalogs/sources/gtfs/schedule/us-tennessee-franklin-transit-authority-gtfs-361.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 361,
+    "data_type": "gtfs",
+    "provider": "Franklin Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Tennessee",
+        "municipality": "Nashville",
+        "bounding_box": {
+            "minimum_latitude": 35.9078724841778,
+            "maximum_latitude": 35.96416,
+            "minimum_longitude": -86.9029807269204,
+            "maximum_longitude": -86.803567350104,
+            "extracted_on": "2022-03-15T21:17:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/tma-tn-us/tma-tn-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-tennessee-franklin-transit-authority-gtfs-361.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-360.json
+++ b/catalogs/sources/gtfs/schedule/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-360.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 360,
+    "data_type": "gtfs",
+    "provider": "Nashville Metropolitan Transit Authority (Nashville MTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Tennessee",
+        "municipality": "Nashville",
+        "bounding_box": {
+            "minimum_latitude": 35.7416,
+            "maximum_latitude": 36.525005,
+            "minimum_longitude": -87.379122,
+            "maximum_longitude": -86.29724,
+            "extracted_on": "2022-03-15T21:17:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.nashvillemta.org/GoogleExport/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-360.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-corpus-christi-regional-transportation-authority-gtfs-315.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-corpus-christi-regional-transportation-authority-gtfs-315.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 315,
+    "data_type": "gtfs",
+    "provider": "Corpus Christi Regional Transportation Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Corpus Christi",
+        "bounding_box": {
+            "minimum_latitude": 27.602014,
+            "maximum_latitude": 27.914794,
+            "minimum_longitude": -97.685155,
+            "maximum_longitude": -97.051109,
+            "extracted_on": "2022-03-15T21:14:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.ccrta.org/gtfs/ccrta-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-corpus-christi-regional-transportation-authority-gtfs-315.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-unknown-groome-transportation-gtfs-319.json
+++ b/catalogs/sources/gtfs/schedule/us-unknown-groome-transportation-gtfs-319.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 319,
+    "data_type": "gtfs",
+    "provider": "Groome Transportation",
+    "location": {
+        "country_code": "US",
+        "bounding_box": {
+            "minimum_latitude": 28.4302277239586,
+            "maximum_latitude": 46.826389,
+            "minimum_longitude": -123.278540458715,
+            "maximum_longitude": -81.0321279743193,
+            "extracted_on": "2022-03-15T21:14:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/groometransportation-us/groometransportation-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-unknown-groome-transportation-gtfs-319.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-mountain-lynx-transit-gtfs-334.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-mountain-lynx-transit-gtfs-334.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 334,
+    "data_type": "gtfs",
+    "provider": "Mountain Lynx Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "bounding_box": {
+            "minimum_latitude": 36.6497004348102,
+            "maximum_latitude": 36.9609541491302,
+            "minimum_longitude": -82.0005662230066,
+            "maximum_longitude": -80.8818893697272,
+            "extracted_on": "2022-03-15T21:16:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/districtthree-va-us/districtthree-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-mountain-lynx-transit-gtfs-334.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-black-ball-ferry-line-gtfs-286.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-black-ball-ferry-line-gtfs-286.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 286,
+    "data_type": "gtfs",
+    "provider": "Black Ball Ferry Line",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 48.1208906384423,
+            "maximum_latitude": 48.421646665529,
+            "minimum_longitude": -123.431745171546,
+            "maximum_longitude": -123.372253775596,
+            "extracted_on": "2022-03-15T21:13:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/blackball_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-black-ball-ferry-line-gtfs-286.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-central-transit-ellensburg-gtfs-303.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-central-transit-ellensburg-gtfs-303.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 303,
+    "data_type": "gtfs",
+    "provider": "Central Transit Ellensburg",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 46.98130558,
+            "maximum_latitude": 47.233944,
+            "minimum_longitude": -121.024028,
+            "maximum_longitude": -120.522715,
+            "extracted_on": "2022-03-15T21:14:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/centraltransit_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-central-transit-ellensburg-gtfs-303.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-clallam-transit-system-gtfs-279.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-clallam-transit-system-gtfs-279.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 279,
+    "data_type": "gtfs",
+    "provider": "Clallam Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.623688,
+            "maximum_latitude": 48.370108,
+            "minimum_longitude": -124.636859,
+            "maximum_longitude": -122.511536,
+            "extracted_on": "2022-03-15T21:13:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/clallam_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-clallam-transit-system-gtfs-279.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-community-transit-ct-gtfs-287.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-community-transit-ct-gtfs-287.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 287,
+    "data_type": "gtfs",
+    "provider": "Community Transit (CT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.592129,
+            "maximum_latitude": 48.278539,
+            "minimum_longitude": -122.38471,
+            "maximum_longitude": -121.601001,
+            "extracted_on": "2022-03-15T21:13:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.communitytransit.org/docs/default-source/open-data/gtfs/current.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-community-transit-ct-gtfs-287.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-everett-transit-gtfs-288.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-everett-transit-gtfs-288.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 288,
+    "data_type": "gtfs",
+    "provider": "Everett Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Everett",
+        "bounding_box": {
+            "minimum_latitude": 47.879951,
+            "maximum_latitude": 48.009836,
+            "minimum_longitude": -122.306381,
+            "maximum_longitude": -122.184499,
+            "extracted_on": "2022-03-15T21:13:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.sound.obaweb.org/prod/97_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-everett-transit-gtfs-288.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-island-transit-gtfs-280.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-island-transit-gtfs-280.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 280,
+    "data_type": "gtfs",
+    "provider": "Island Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.9232804750302,
+            "maximum_latitude": 48.463003,
+            "minimum_longitude": -122.751929,
+            "maximum_longitude": -122.196879,
+            "extracted_on": "2022-03-15T21:13:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/islandtransit-wa-us/islandtransit-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-island-transit-gtfs-280.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-jamestown-sklallam-gtfs-285.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-jamestown-sklallam-gtfs-285.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 285,
+    "data_type": "gtfs",
+    "provider": "Jamestown S'klallam",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 48.0221659224985,
+            "maximum_latitude": 48.1131634362126,
+            "minimum_longitude": -123.434959128499,
+            "maximum_longitude": -123.010568618774,
+            "extracted_on": "2022-03-15T21:13:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/sevencedars_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-jamestown-sklallam-gtfs-285.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-puget-sound-express-gtfs-281.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-puget-sound-express-gtfs-281.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 281,
+    "data_type": "gtfs",
+    "provider": "Puget Sound Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 48.1170139763824,
+            "maximum_latitude": 48.5356985322927,
+            "minimum_longitude": -123.015597760677,
+            "maximum_longitude": -122.751901745796,
+            "extracted_on": "2022-03-15T21:13:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/pse_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-puget-sound-express-gtfs-281.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-selah-transit-gtfs-278.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-selah-transit-gtfs-278.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 278,
+    "data_type": "gtfs",
+    "provider": "Selah Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Selah",
+        "bounding_box": {
+            "minimum_latitude": 46.5616046,
+            "maximum_latitude": 46.6771065,
+            "minimum_longitude": -120.5622804,
+            "maximum_longitude": -120.4793143,
+            "extracted_on": "2022-03-15T21:13:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://trilliumtransit.com/transit_feeds/selah-wa-us/selah-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-selah-transit-gtfs-278.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-spokane-transit-authority-sta-gtfs-290.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-spokane-transit-authority-sta-gtfs-290.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 290,
+    "data_type": "gtfs",
+    "provider": "Spokane Transit Authority (STA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Spokane",
+        "bounding_box": {
+            "minimum_latitude": 47.476671,
+            "maximum_latitude": 47.768898,
+            "minimum_longitude": -117.705755,
+            "maximum_longitude": -117.075949,
+            "extracted_on": "2022-03-15T21:13:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.spokanetransit.com/gtfs",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-spokane-transit-authority-sta-gtfs-290.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-the-victoria-clipper-gtfs-282.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-the-victoria-clipper-gtfs-282.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 282,
+    "data_type": "gtfs",
+    "provider": "The Victoria Clipper",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Seattle",
+        "bounding_box": {
+            "minimum_latitude": 47.61356252137029,
+            "maximum_latitude": 48.535661235575695,
+            "minimum_longitude": -123.37359488010404,
+            "maximum_longitude": -122.35349714756012,
+            "extracted_on": "2022-03-15T21:13:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://addtransit.com/gtfsfile/42017/TheVictoriaClipper.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-the-victoria-clipper-gtfs-282.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-washington-state-ferries-gtfs-283.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-washington-state-ferries-gtfs-283.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 283,
+    "data_type": "gtfs",
+    "provider": "Washington State Ferries",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Seattle",
+        "bounding_box": {
+            "minimum_latitude": 47.30555,
+            "maximum_latitude": 48.643641,
+            "minimum_longitude": -123.398411,
+            "maximum_longitude": -122.304313,
+            "extracted_on": "2022-03-15T21:13:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://business.wsdot.wa.gov/Transit/csv_files/wsf/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-washington-state-ferries-gtfs-283.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-whatcom-transportation-authority-gtfs-284.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-whatcom-transportation-authority-gtfs-284.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 284,
+    "data_type": "gtfs",
+    "provider": "Whatcom Transportation Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Bellingham",
+        "bounding_box": {
+            "minimum_latitude": 48.418167,
+            "maximum_latitude": 48.998659,
+            "minimum_longitude": -122.763933,
+            "maximum_longitude": -122.13584,
+            "extracted_on": "2022-03-15T21:13:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/whatcomtrans/publicwtadata/raw/master/GTFS/wta_gtfs_latest.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-whatcom-transportation-authority-gtfs-284.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the third part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 94 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~