### PR TITLE
feat: Sixth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
+++ b/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
@@ -17,4 +17,4 @@
         "direct_download": "http://data.trilliumtransit.com/gtfs/downey-ca-us/downey-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-downeylink-gtfs-383.zip?alt=media"
     }
-}
+} 

--- a/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
+++ b/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
@@ -17,4 +17,4 @@
         "direct_download": "http://data.trilliumtransit.com/gtfs/downey-ca-us/downey-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-downeylink-gtfs-383.zip?alt=media"
     }
-} 
+}

--- a/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
+++ b/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 383,
+    "data_type": "gtfs",
+    "provider": "DowneyLINK",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 33.9068190625008,
+            "maximum_latitude": 33.9667896649685,
+            "minimum_longitude": -118.15607158901,
+            "maximum_longitude": -118.102802806934,
+            "extracted_on": "2022-03-16T15:27:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/downey-ca-us/downey-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-downeylink-gtfs-383.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-el-segundo-transportation-gtfs-458.json
+++ b/catalogs/sources/gtfs/schedule/us-california-el-segundo-transportation-gtfs-458.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 458,
+    "data_type": "gtfs",
+    "provider": "El Segundo Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "El Segundo",
+        "bounding_box": {
+            "minimum_latitude": 33.9046426047857,
+            "maximum_latitude": 33.9309324789624,
+            "minimum_longitude": -118.421993344071,
+            "maximum_longitude": -118.380819763092,
+            "extracted_on": "2022-03-16T15:34:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/elsegundo-ca-us/elsegundo-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-el-segundo-transportation-gtfs-458.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-durango-transit-gtfs-456.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-durango-transit-gtfs-456.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 456,
+    "data_type": "gtfs",
+    "provider": "Durango Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 37.231543,
+            "maximum_latitude": 37.322395,
+            "minimum_longitude": -107.883134,
+            "maximum_longitude": -107.848634,
+            "extracted_on": "2022-03-16T15:34:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://durangogov.org/DocumentCenter/View/17688/Durango-Transit-GTFS-Data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-durango-transit-gtfs-456.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-envida-gtfs-455.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-envida-gtfs-455.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 455,
+    "data_type": "gtfs",
+    "provider": "Envida",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Colorado Springs",
+        "bounding_box": {
+            "minimum_latitude": 38.826282,
+            "maximum_latitude": 39.034927,
+            "minimum_longitude": -104.816347,
+            "maximum_longitude": -104.092275,
+            "extracted_on": "2022-03-16T15:34:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/dsi-co-us/dsi-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-envida-gtfs-455.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-estes-transit-gtfs-459.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-estes-transit-gtfs-459.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 459,
+    "data_type": "gtfs",
+    "provider": "Estes Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 40.360063,
+            "maximum_latitude": 40.40197,
+            "minimum_longitude": -105.586547,
+            "maximum_longitude": -105.481515508361,
+            "extracted_on": "2022-03-16T15:35:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/estestransit-co-us/estestransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-estes-transit-gtfs-459.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-champaign-urbana-mass-transit-district-mtd-gtfs-388.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-champaign-urbana-mass-transit-district-mtd-gtfs-388.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 388,
+    "data_type": "gtfs",
+    "provider": "Champaign Urbana Mass Transit District (MTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Urbana",
+        "bounding_box": {
+            "minimum_latitude": 40.04806518554688,
+            "maximum_latitude": 40.152786,
+            "minimum_longitude": -88.322875,
+            "maximum_longitude": -88.159994,
+            "extracted_on": "2022-03-16T15:28:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://developer.cumtd.com/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-champaign-urbana-mass-transit-district-mtd-gtfs-388.zip?alt=media",
+        "license": "https://developer.cumtd.com/terms-of-use/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-chicago-transit-authority-cta-gtfs-389.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-chicago-transit-authority-cta-gtfs-389.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 389,
+    "data_type": "gtfs",
+    "provider": "Chicago Transit Authority (CTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Chicago",
+        "bounding_box": {
+            "minimum_latitude": 41.6441576,
+            "maximum_latitude": 42.073153,
+            "minimum_longitude": -87.90422307,
+            "maximum_longitude": -87.52569948,
+            "extracted_on": "2022-03-16T15:29:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.transitchicago.com/downloads/sch_data/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-chicago-transit-authority-cta-gtfs-389.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-greater-peoria-mass-transit-citylink-gtfs-386.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-greater-peoria-mass-transit-citylink-gtfs-386.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 386,
+    "data_type": "gtfs",
+    "provider": "Greater Peoria Mass Transit (CityLink)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Peoria",
+        "bounding_box": {
+            "minimum_latitude": 40.5385321,
+            "maximum_latitude": 40.925506,
+            "minimum_longitude": -89.694888,
+            "maximum_longitude": -89.4816969907029,
+            "extracted_on": "2022-03-16T15:27:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ridecitylink-il-us/ridecitylink-il-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-greater-peoria-mass-transit-citylink-gtfs-386.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-pace-bus-gtfs-390.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-pace-bus-gtfs-390.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 390,
+    "data_type": "gtfs",
+    "provider": "Pace Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Chicago",
+        "bounding_box": {
+            "minimum_latitude": 41.4039756,
+            "maximum_latitude": 42.4574028,
+            "minimum_longitude": -88.6210093,
+            "maximum_longitude": -87.5226126,
+            "extracted_on": "2022-03-16T15:29:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://public.pacebus.com/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-pace-bus-gtfs-390.zip?alt=media",
+        "license": "http://www.pacebus.com/sub/about/data_services.asp"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-springfield-mass-transit-district-smtd-gtfs-385.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-springfield-mass-transit-district-smtd-gtfs-385.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 385,
+    "data_type": "gtfs",
+    "provider": "Springfield Mass Transit District (SMTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Springfield",
+        "bounding_box": {
+            "minimum_latitude": 39.667827,
+            "maximum_latitude": 39.898621,
+            "minimum_longitude": -89.75837,
+            "maximum_longitude": -89.527032,
+            "extracted_on": "2022-03-16T15:27:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.smtd.org/gtfs/smtd_gtfs_feed.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-springfield-mass-transit-district-smtd-gtfs-385.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-citybus-of-greater-lafayette-indiana-citybus-gtfs-391.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-citybus-of-greater-lafayette-indiana-citybus-gtfs-391.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 391,
+    "data_type": "gtfs",
+    "provider": "CityBus of Greater Lafayette Indiana (CityBus)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "Lafayette",
+        "bounding_box": {
+            "minimum_latitude": 40.365249515011,
+            "maximum_latitude": 40.480772346952,
+            "minimum_longitude": -86.962072751944,
+            "maximum_longitude": -86.804833883377,
+            "extracted_on": "2022-03-16T15:29:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/citybus-lafayette-in-us/citybus-lafayette-in-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-citybus-of-greater-lafayette-indiana-citybus-gtfs-391.zip?alt=media",
+        "license": "https://gocitybus.com/gtfs-gis-data-download"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-terre-haute-transit-utility-gtfs-387.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-terre-haute-transit-utility-gtfs-387.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 387,
+    "data_type": "gtfs",
+    "provider": "Terre Haute Transit Utility",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "Terre Haute",
+        "bounding_box": {
+            "minimum_latitude": 39.343986233746,
+            "maximum_latitude": 39.52053,
+            "minimum_longitude": -87.4559616112519,
+            "maximum_longitude": -87.33167,
+            "extracted_on": "2022-03-16T15:27:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/terrehautetransit-in-us/terrehautetransit-in-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-terre-haute-transit-utility-gtfs-387.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maine-greater-portland-metro-bus-gtfs-454.json
+++ b/catalogs/sources/gtfs/schedule/us-maine-greater-portland-metro-bus-gtfs-454.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 454,
+    "data_type": "gtfs",
+    "provider": "Greater Portland Metro Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maine",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 43.630787,
+            "maximum_latitude": 43.913791,
+            "minimum_longitude": -70.448168,
+            "maximum_longitude": -69.96248,
+            "extracted_on": "2022-03-16T15:34:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://smttracker.com/downloads/gtfs/greater-portland-me.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maine-greater-portland-metro-bus-gtfs-454.zip?alt=media",
+        "license": "http://smttracker.com/developer-terms-of-use/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maine-lakes-region-explorer-gtfs-452.json
+++ b/catalogs/sources/gtfs/schedule/us-maine-lakes-region-explorer-gtfs-452.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 452,
+    "data_type": "gtfs",
+    "provider": "Lakes Region Explorer",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maine",
+        "bounding_box": {
+            "minimum_latitude": 43.6584,
+            "maximum_latitude": 44.0533,
+            "minimum_longitude": -70.7135435945,
+            "maximum_longitude": -70.2595,
+            "extracted_on": "2022-03-16T15:34:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://trilliumtransit.com/transit_feeds/rtp-me-us/rtp-me-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maine-lakes-region-explorer-gtfs-452.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maine-south-portland-gtfs-453.json
+++ b/catalogs/sources/gtfs/schedule/us-maine-south-portland-gtfs-453.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 453,
+    "data_type": "gtfs",
+    "provider": "South Portland",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maine",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 43.61424,
+            "maximum_latitude": 43.657989,
+            "minimum_longitude": -70.357592,
+            "maximum_longitude": -70.230007,
+            "extracted_on": "2022-03-16T15:34:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://smttracker.com/downloads/gtfs/south-portland-me-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maine-south-portland-gtfs-453.zip?alt=media",
+        "license": "http://smttracker.com/developer-terms-of-use/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-allegany-county-transit-gtfs-408.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-allegany-county-transit-gtfs-408.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 408,
+    "data_type": "gtfs",
+    "provider": "Allegany County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Allegany",
+        "bounding_box": {
+            "minimum_latitude": 39.480576,
+            "maximum_latitude": 39.70507,
+            "minimum_longitude": -79.045373,
+            "maximum_longitude": -78.71361,
+            "extracted_on": "2022-03-16T15:32:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Allegany_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-allegany-county-transit-gtfs-408.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-128-business-council-gtfs-440.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-128-business-council-gtfs-440.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 440,
+    "data_type": "gtfs",
+    "provider": "128 Business Council",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 42.294494670222,
+            "maximum_latitude": 42.48272184,
+            "minimum_longitude": -71.2814072379742,
+            "maximum_longitude": -71.14260077,
+            "extracted_on": "2022-03-16T15:34:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/route128corridor-ma-us/route128corridor-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-128-business-council-gtfs-440.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-bay-state-cruise-company-gtfs-435.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-bay-state-cruise-company-gtfs-435.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 435,
+    "data_type": "gtfs",
+    "provider": "Bay State Cruise Company",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 42.0491174432191,
+            "maximum_latitude": 42.3512795450525,
+            "minimum_longitude": -71.0397913869914,
+            "maximum_longitude": -70.1819217022952,
+            "extracted_on": "2022-03-16T15:34:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/baystatecruisecompany-ma-us/baystatecruisecompany-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-bay-state-cruise-company-gtfs-435.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-boston-harbor-islands-ferries-gtfs-446.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-boston-harbor-islands-ferries-gtfs-446.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 446,
+    "data_type": "gtfs",
+    "provider": "Boston Harbor Islands Ferries",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 42.254056,
+            "maximum_latitude": 42.3604543,
+            "minimum_longitude": -71.0505213,
+            "maximum_longitude": -70.9016389,
+            "extracted_on": "2022-03-16T15:34:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://nationalparkservice.github.io/nps-gtfs/boha/ferries/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-boston-harbor-islands-ferries-gtfs-446.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-brockton-area-transit-authority-bat-gtfs-422.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-brockton-area-transit-authority-bat-gtfs-422.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 422,
+    "data_type": "gtfs",
+    "provider": "Brockton Area Transit Authority (BAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Brockton",
+        "bounding_box": {
+            "minimum_latitude": 41.984266,
+            "maximum_latitude": 42.2844370483635,
+            "minimum_longitude": -71.148856,
+            "maximum_longitude": -70.907489,
+            "extracted_on": "2022-03-16T15:33:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/brockton-ma-us/brockton-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-brockton-area-transit-authority-bat-gtfs-422.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-cape-ann-transportation-authority-cata-gtfs-447.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-cape-ann-transportation-authority-cata-gtfs-447.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 447,
+    "data_type": "gtfs",
+    "provider": "Cape Ann Transportation Authority (CATA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 42.5419781,
+            "maximum_latitude": 42.68462803,
+            "minimum_longitude": -70.9430737,
+            "maximum_longitude": -70.5986306,
+            "extracted_on": "2022-03-16T15:34:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/capeann-ma-us/capeann-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-cape-ann-transportation-authority-cata-gtfs-447.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-coach-company-gtfs-436.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-coach-company-gtfs-436.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 436,
+    "data_type": "gtfs",
+    "provider": "Coach Company",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 40.756546,
+            "maximum_latitude": 43.086979,
+            "minimum_longitude": -73.991028,
+            "maximum_longitude": -70.803995,
+            "extracted_on": "2022-03-16T15:34:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/coachcompany-ma-us/coachcompany-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-coach-company-gtfs-436.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-cuttyhunk-ferry-company-gtfs-423.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-cuttyhunk-ferry-company-gtfs-423.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 423,
+    "data_type": "gtfs",
+    "provider": "Cuttyhunk Ferry Company",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 41.4242219874925,
+            "maximum_latitude": 41.6337519346306,
+            "minimum_longitude": -70.9230147120056,
+            "maximum_longitude": -70.9185246941147,
+            "extracted_on": "2022-03-16T15:33:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cuttyhunkferryco-ma-us/cuttyhunkferryco-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-cuttyhunk-ferry-company-gtfs-423.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-franklin-regional-transit-authority-frta-gtfs-429.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-franklin-regional-transit-authority-frta-gtfs-429.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 429,
+    "data_type": "gtfs",
+    "provider": "Franklin Regional Transit Authority (FRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Franklin",
+        "bounding_box": {
+            "minimum_latitude": 42.3176604081528,
+            "maximum_latitude": 42.6280840552401,
+            "minimum_longitude": -72.8769354295876,
+            "maximum_longitude": -72.2627100720056,
+            "extracted_on": "2022-03-16T15:33:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/frta-ma-us/frta-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-franklin-regional-transit-authority-frta-gtfs-429.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-freedom-cruise-line-gtfs-425.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-freedom-cruise-line-gtfs-425.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 425,
+    "data_type": "gtfs",
+    "provider": "Freedom Cruise Line",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 41.2847266932657,
+            "maximum_latitude": 41.6674902432958,
+            "minimum_longitude": -70.0927389231024,
+            "maximum_longitude": -70.0595848080215,
+            "extracted_on": "2022-03-16T15:33:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/freedomcruiseline-ma-us/freedomcruiseline-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-freedom-cruise-line-gtfs-425.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-greater-attleboro-taunton-regional-transit-authority-gatra-gtfs-418.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-greater-attleboro-taunton-regional-transit-authority-gatra-gtfs-418.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 418,
+    "data_type": "gtfs",
+    "provider": "Greater Attleboro Taunton Regional Transit Authority (GATRA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Attleboro",
+        "bounding_box": {
+            "minimum_latitude": 41.635806,
+            "maximum_latitude": 42.221068,
+            "minimum_longitude": -71.493822,
+            "maximum_longitude": -70.5398689895493,
+            "extracted_on": "2022-03-16T15:33:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/gatra-ma-us/gatra-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-greater-attleboro-taunton-regional-transit-authority-gatra-gtfs-418.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-hy-line-cruises-gtfs-427.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-hy-line-cruises-gtfs-427.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 427,
+    "data_type": "gtfs",
+    "provider": "Hy-Line Cruises",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "New Bedford",
+        "bounding_box": {
+            "minimum_latitude": 41.2846768091449,
+            "maximum_latitude": 41.6482986856447,
+            "minimum_longitude": -70.5587982204256,
+            "maximum_longitude": -70.0947968479691,
+            "extracted_on": "2022-03-16T15:33:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/hylinecruises-ma-us/hylinecruises-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-hy-line-cruises-gtfs-427.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-limoliner-gtfs-438.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-limoliner-gtfs-438.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 438,
+    "data_type": "gtfs",
+    "provider": "LimoLiner",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 42.29195,
+            "maximum_latitude": 42.351074,
+            "minimum_longitude": -71.49106,
+            "maximum_longitude": -71.070511,
+            "extracted_on": "2022-03-16T15:34:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/limoliner-ma-us/limoliner-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-limoliner-gtfs-438.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-lowell-regional-transit-authority-lrta-gtfs-444.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-lowell-regional-transit-authority-lrta-gtfs-444.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 444,
+    "data_type": "gtfs",
+    "provider": "Lowell Regional Transit Authority (LRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Lowell",
+        "bounding_box": {
+            "minimum_latitude": 42.480542,
+            "maximum_latitude": 42.699281,
+            "minimum_longitude": -71.46796401,
+            "maximum_longitude": -71.1743667754631,
+            "extracted_on": "2022-03-16T15:34:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lowell-ma-us/lowell-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-lowell-regional-transit-authority-lrta-gtfs-444.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-marthas-vineyard-transit-authority-gtfs-420.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-marthas-vineyard-transit-authority-gtfs-420.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 420,
+    "data_type": "gtfs",
+    "provider": "Martha's Vineyard Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "New Bedford",
+        "bounding_box": {
+            "minimum_latitude": 41.3235,
+            "maximum_latitude": 41.48053,
+            "minimum_longitude": -70.83645,
+            "maximum_longitude": -70.51051,
+            "extracted_on": "2022-03-16T15:33:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/marthasvineyard-ma-us/marthasvineyard-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-marthas-vineyard-transit-authority-gtfs-420.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-area-express-max-gtfs-431.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-area-express-max-gtfs-431.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 431,
+    "data_type": "gtfs",
+    "provider": "Massachusetts Area Express (MAX)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T15:33:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/truenorthtransit-ma-us/truenorthtransit-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-massachusetts-area-express-max-gtfs-431.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-bay-transportation-authority-mbta-gtfs-437.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-bay-transportation-authority-mbta-gtfs-437.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 437,
+    "data_type": "gtfs",
+    "provider": "Massachusetts Bay Transportation Authority (MBTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 41.581289,
+            "maximum_latitude": 42.797837,
+            "minimum_longitude": -71.848488,
+            "maximum_longitude": -70.276583,
+            "extracted_on": "2022-03-16T15:34:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://cdn.mbta.com/MBTA_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-massachusetts-bay-transportation-authority-mbta-gtfs-437.zip?alt=media",
+        "license": "https://www.mass.gov/files/documents/2017/10/27/develop_license_agree_0.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-massport-gtfs-441.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-massport-gtfs-441.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 441,
+    "data_type": "gtfs",
+    "provider": "Massport",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 42.217363,
+            "maximum_latitude": 42.5413002813199,
+            "minimum_longitude": -71.397808,
+            "maximum_longitude": -70.9488375344756,
+            "extracted_on": "2022-03-16T15:34:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/massport-ma-us/massport-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-massport-gtfs-441.zip?alt=media",
+        "license": "http://www.massport.com/media/1651/massportdatalicenseagreement.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-merrimack-valley-regional-transit-authority-mvrta-gtfs-445.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-merrimack-valley-regional-transit-authority-mvrta-gtfs-445.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 445,
+    "data_type": "gtfs",
+    "provider": "Merrimack Valley Regional Transit Authority (MVRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 42.349565,
+            "maximum_latitude": 42.9102540306502,
+            "minimum_longitude": -71.313978406335,
+            "maximum_longitude": -70.8103630809593,
+            "extracted_on": "2022-03-16T15:34:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/merrimackvalley-ma-us/merrimackvalley-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-merrimack-valley-regional-transit-authority-mvrta-gtfs-445.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-metrowest-regional-transit-authority-mwrta-gtfs-439.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-metrowest-regional-transit-authority-mwrta-gtfs-439.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 439,
+    "data_type": "gtfs",
+    "provider": "MetroWest Regional Transit Authority (MWRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 42.1274170057426,
+            "maximum_latitude": 42.4000957548676,
+            "minimum_longitude": -71.61249,
+            "maximum_longitude": -71.2431033696594,
+            "extracted_on": "2022-03-16T15:34:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://vc.mwrta.com/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-metrowest-regional-transit-authority-mwrta-gtfs-439.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-middlesex-3-tma-gtfs-442.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-middlesex-3-tma-gtfs-442.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 442,
+    "data_type": "gtfs",
+    "provider": "Middlesex 3 TMA",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Billerica",
+        "bounding_box": {
+            "minimum_latitude": 42.3630156894176,
+            "maximum_latitude": 42.530488,
+            "minimum_longitude": -71.277932,
+            "maximum_longitude": -71.0583318073749,
+            "extracted_on": "2022-03-16T15:34:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/middlesex-ma-us/middlesex-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-middlesex-3-tma-gtfs-442.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-montachusett-regional-transit-authority-mart-gtfs-433.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-montachusett-regional-transit-authority-mart-gtfs-433.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 433,
+    "data_type": "gtfs",
+    "provider": "Montachusett Regional Transit Authority (MART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 42.261459,
+            "maximum_latitude": 42.68395858,
+            "minimum_longitude": -72.31539171,
+            "maximum_longitude": -71.273123,
+            "extracted_on": "2022-03-16T15:34:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/montachusett-ma-us/montachusett-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-montachusett-regional-transit-authority-mart-gtfs-433.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-nantucket-regional-transit-authority-wave-gtfs-426.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-nantucket-regional-transit-authority-wave-gtfs-426.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 426,
+    "data_type": "gtfs",
+    "provider": "Nantucket Regional Transit Authority (WAVE)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Nantucket",
+        "bounding_box": {
+            "minimum_latitude": 41.24403,
+            "maximum_latitude": 41.3009283,
+            "minimum_longitude": -70.20033,
+            "maximum_longitude": -69.96379,
+            "extracted_on": "2022-03-16T15:33:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/nantucket-ma-us/nantucket-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-nantucket-regional-transit-authority-wave-gtfs-426.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-patriots-party-boats-gtfs-424.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-patriots-party-boats-gtfs-424.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 424,
+    "data_type": "gtfs",
+    "provider": "Patriots Party Boats",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 41.4586245799043,
+            "maximum_latitude": 41.543803470417,
+            "minimum_longitude": -70.6070370790062,
+            "maximum_longitude": -70.5544496890602,
+            "extracted_on": "2022-03-16T15:33:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/patriotpartyboats-ma-us/patriotpartyboats-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-patriots-party-boats-gtfs-424.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-southeastern-regional-transit-authority-srta-gtfs-421.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-southeastern-regional-transit-authority-srta-gtfs-421.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 421,
+    "data_type": "gtfs",
+    "provider": "Southeastern Regional Transit Authority (SRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 41.596421,
+            "maximum_latitude": 41.781218,
+            "minimum_longitude": -71.220374,
+            "maximum_longitude": -70.879291,
+            "extracted_on": "2022-03-16T15:33:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/srta-ma-us/srta-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-southeastern-regional-transit-authority-srta-gtfs-421.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-worcester-regional-transit-authority-wrta-gtfs-432.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-worcester-regional-transit-authority-wrta-gtfs-432.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 432,
+    "data_type": "gtfs",
+    "provider": "Worcester Regional Transit Authority (WRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Worcester",
+        "bounding_box": {
+            "minimum_latitude": 42.02741795,
+            "maximum_latitude": 42.355472,
+            "minimum_longitude": -72.102675,
+            "maximum_longitude": -71.57,
+            "extracted_on": "2022-03-16T15:33:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/wrta-ma-us/wrta-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-worcester-regional-transit-authority-wrta-gtfs-432.zip?alt=media",
+        "license": "https://www.massdot.state.ma.us/Portals/0/docs/developers/develop_license_agree.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-yankee-line-gtfs-443.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-yankee-line-gtfs-443.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 443,
+    "data_type": "gtfs",
+    "provider": "Yankee Line",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 42.349848,
+            "maximum_latitude": 42.477762,
+            "minimum_longitude": -71.411371,
+            "maximum_longitude": -71.075101,
+            "extracted_on": "2022-03-16T15:34:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/yankeeline-ma-us/yankeeline-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-yankee-line-gtfs-443.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-ann-arbor-area-transportation-authority-theride-gtfs-415.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-ann-arbor-area-transportation-authority-theride-gtfs-415.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 415,
+    "data_type": "gtfs",
+    "provider": "Ann Arbor Area Transportation Authority (TheRide)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Ann Arbor",
+        "bounding_box": {
+            "minimum_latitude": 42.189301,
+            "maximum_latitude": 42.317717,
+            "minimum_longitude": -83.843184,
+            "maximum_longitude": -83.553954,
+            "extracted_on": "2022-03-16T15:33:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.theride.org/sites/default/files/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-ann-arbor-area-transportation-authority-theride-gtfs-415.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-capital-area-transportation-authority-cata-gtfs-402.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-capital-area-transportation-authority-cata-gtfs-402.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 402,
+    "data_type": "gtfs",
+    "provider": "Capital Area Transportation Authority (CATA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Lansing",
+        "bounding_box": {
+            "minimum_latitude": 42.565736,
+            "maximum_latitude": 42.774685,
+            "minimum_longitude": -84.630626,
+            "maximum_longitude": -84.174003,
+            "extracted_on": "2022-03-16T15:32:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://developers.cata.org/gtfsdownload.ashx?key=5b4690ed-0a69-4320-897b-7d92def4b96f&data=base",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-capital-area-transportation-authority-cata-gtfs-402.zip?alt=media",
+        "license": "https://www.cata.org/Portals/0/CATAGTFSLicenseAgreement20150323.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-detroit-people-mover-gtfs-417.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-detroit-people-mover-gtfs-417.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 417,
+    "data_type": "gtfs",
+    "provider": "Detroit People Mover",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Detroit",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T15:33:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.detroitmi.gov/Portals/0/docs/deptoftransportation/pdfs/PeopleMoverGTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-detroit-people-mover-gtfs-417.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-indian-trails-detroit-ann-arbor-express-gtfs-384.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-indian-trails-detroit-ann-arbor-express-gtfs-384.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 384,
+    "data_type": "gtfs",
+    "provider": "Indian Trails, Detroit Ann Arbor Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "bounding_box": {
+            "minimum_latitude": 41.60434849,
+            "maximum_latitude": 47.1269625,
+            "minimum_longitude": -92.1007644,
+            "maximum_longitude": -83.052111,
+            "extracted_on": "2022-03-16T15:27:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/indiantrails-mi-us/indiantrails-mi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-indian-trails-detroit-ann-arbor-express-gtfs-384.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-kalamazoo-metro-transit-gtfs-401.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-kalamazoo-metro-transit-gtfs-401.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 401,
+    "data_type": "gtfs",
+    "provider": "Kalamazoo Metro Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "bounding_box": {
+            "minimum_latitude": 42.164711,
+            "maximum_latitude": 42.332886,
+            "minimum_longitude": -85.681808,
+            "maximum_longitude": -85.51024599999998,
+            "extracted_on": "2022-03-16T15:32:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.kmetro.com/sites/default/files/public/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-kalamazoo-metro-transit-gtfs-401.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-michigan-flyer-gtfs-413.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-michigan-flyer-gtfs-413.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 413,
+    "data_type": "gtfs",
+    "provider": "Michigan Flyer",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Detroit",
+        "bounding_box": {
+            "minimum_latitude": 42.2078480306562,
+            "maximum_latitude": 42.7353459492649,
+            "minimum_longitude": -84.4802281279614,
+            "maximum_longitude": -83.3462025983948,
+            "extracted_on": "2022-03-16T15:33:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/michiganflyer-mi-us/michiganflyer-mi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-michigan-flyer-gtfs-413.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-suburban-mobility-authority-for-regional-transit-smart-gtfs-414.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-suburban-mobility-authority-for-regional-transit-smart-gtfs-414.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 414,
+    "data_type": "gtfs",
+    "provider": "Suburban Mobility Authority for Regional Transit (SMART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "bounding_box": {
+            "minimum_latitude": 42.116304,
+            "maximum_latitude": 42.70713,
+            "minimum_longitude": -83.436741,
+            "maximum_longitude": -82.832411,
+            "extracted_on": "2022-03-16T15:33:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://apps1.smartbus.org/gtfs/smart_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-suburban-mobility-authority-for-regional-transit-smart-gtfs-414.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-the-rapid-gtfs-400.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-the-rapid-gtfs-400.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 400,
+    "data_type": "gtfs",
+    "provider": "The Rapid",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Grand Rapids",
+        "bounding_box": {
+            "minimum_latitude": 42.8408508301,
+            "maximum_latitude": 43.6899757385,
+            "minimum_longitude": -85.909981,
+            "maximum_longitude": -85.481773,
+            "extracted_on": "2022-03-16T15:32:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://connect.ridetherapid.org/InfoPoint/gtfs-zip.ashx",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-the-rapid-gtfs-400.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-university-of-michigan-transit-services-gtfs-416.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-university-of-michigan-transit-services-gtfs-416.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 416,
+    "data_type": "gtfs",
+    "provider": "University of Michigan Transit Services",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Ann Arbor",
+        "bounding_box": {
+            "minimum_latitude": 42.264134,
+            "maximum_latitude": 47.76395,
+            "minimum_longitude": -96.62663,
+            "maximum_longitude": -83.673986,
+            "extracted_on": "2022-03-16T15:33:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://ltp.umich.edu/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-university-of-michigan-transit-services-gtfs-416.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-hampshire-advance-transit-at-gtfs-451.json
+++ b/catalogs/sources/gtfs/schedule/us-new-hampshire-advance-transit-at-gtfs-451.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 451,
+    "data_type": "gtfs",
+    "provider": "Advance Transit (AT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Hampshire",
+        "municipality": "New Hampshire",
+        "bounding_box": {
+            "minimum_latitude": 43.6245117188,
+            "maximum_latitude": 43.729133606,
+            "minimum_longitude": -72.343536377,
+            "maximum_longitude": -72.0132064819,
+            "extracted_on": "2022-03-16T15:34:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://whereismybus.advancetransit.com/GTFS/feed.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-hampshire-advance-transit-at-gtfs-451.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-gallup-express-gtfs-462.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-gallup-express-gtfs-462.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 462,
+    "data_type": "gtfs",
+    "provider": "Gallup Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "municipality": "Gallup",
+        "bounding_box": {
+            "minimum_latitude": 35.502151,
+            "maximum_latitude": 35.628107,
+            "minimum_longitude": -108.837665,
+            "maximum_longitude": -108.606142,
+            "extracted_on": "2022-03-16T15:35:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/gallupexpress_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-gallup-express-gtfs-462.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-dutchess-county-gtfs-457.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-dutchess-county-gtfs-457.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 457,
+    "data_type": "gtfs",
+    "provider": "Dutchess County",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Poughkeepsie",
+        "bounding_box": {
+            "minimum_latitude": 41.494007,
+            "maximum_latitude": 42.059944,
+            "minimum_longitude": -73.984616,
+            "maximum_longitude": -73.557752,
+            "extracted_on": "2022-03-16T15:34:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Dutchess_County_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-dutchess-county-gtfs-457.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-chapel-hill-transit-cht-gtfs-376.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-chapel-hill-transit-cht-gtfs-376.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 376,
+    "data_type": "gtfs",
+    "provider": "Chapel Hill Transit (CHT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Chapel Hill",
+        "bounding_box": {
+            "minimum_latitude": 35.8540611778005,
+            "maximum_latitude": 35.9760638362239,
+            "minimum_longitude": -79.1016391513517,
+            "maximum_longitude": -78.996655130862,
+            "extracted_on": "2022-03-16T15:27:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/chapel-hill-transit-nc-us/chapel-hill-transit-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-chapel-hill-transit-cht-gtfs-376.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-concord-kannapolis-area-transit-rider-transit-gtfs-372.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-concord-kannapolis-area-transit-rider-transit-gtfs-372.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 372,
+    "data_type": "gtfs",
+    "provider": "Concord Kannapolis Area Transit (Rider Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Concord",
+        "bounding_box": {
+            "minimum_latitude": 35.311442261538,
+            "maximum_latitude": 35.5339389,
+            "minimum_longitude": -80.745853381315,
+            "maximum_longitude": -80.5786545,
+            "extracted_on": "2022-03-16T15:26:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ckrider-nc-us/ckrider-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-concord-kannapolis-area-transit-rider-transit-gtfs-372.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-duke-university-gtfs-378.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-duke-university-gtfs-378.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 378,
+    "data_type": "gtfs",
+    "provider": "Duke University",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Durham",
+        "bounding_box": {
+            "minimum_latitude": 35.994104,
+            "maximum_latitude": 36.021022,
+            "minimum_longitude": -78.95535554,
+            "maximum_longitude": -78.9037367360214,
+            "extracted_on": "2022-03-16T15:27:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/duke-nc-us/duke-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-duke-university-gtfs-378.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-gocary-gtfs-375.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-gocary-gtfs-375.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 375,
+    "data_type": "gtfs",
+    "provider": "GoCary",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Cary",
+        "bounding_box": {
+            "minimum_latitude": 35.72651,
+            "maximum_latitude": 35.831618,
+            "minimum_longitude": -78.871823,
+            "maximum_longitude": -78.719564777377,
+            "extracted_on": "2022-03-16T15:27:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/cary-transit-nc-us/cary-transit-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-gocary-gtfs-375.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-godurham-gtfs-377.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-godurham-gtfs-377.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 377,
+    "data_type": "gtfs",
+    "provider": "GoDurham",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Durham",
+        "bounding_box": {
+            "minimum_latitude": 35.793469,
+            "maximum_latitude": 36.101322,
+            "minimum_longitude": -78.996621,
+            "maximum_longitude": -78.70905,
+            "extracted_on": "2022-03-16T15:27:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/durham-area-transit-authority-nc-us/durham-area-transit-authority-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-godurham-gtfs-377.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-gotriangle-gtfs-374.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-gotriangle-gtfs-374.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 374,
+    "data_type": "gtfs",
+    "provider": "GoTriangle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Durham",
+        "bounding_box": {
+            "minimum_latitude": 35.573104,
+            "maximum_latitude": 36.095597,
+            "minimum_longitude": -79.2699127,
+            "maximum_longitude": -78.323486,
+            "extracted_on": "2022-03-16T15:27:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/tta-regionalbus-nc-us/tta-regionalbus-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-gotriangle-gtfs-374.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-piedmont-authority-for-regional-transportation-part-gtfs-373.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-piedmont-authority-for-regional-transportation-part-gtfs-373.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 373,
+    "data_type": "gtfs",
+    "provider": "Piedmont Authority for Regional Transportation (PART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Greensboro",
+        "bounding_box": {
+            "minimum_latitude": 35.670612,
+            "maximum_latitude": 36.480516,
+            "minimum_longitude": -80.605425,
+            "maximum_longitude": -79.051249,
+            "extracted_on": "2022-03-16T15:26:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/5137/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-piedmont-authority-for-regional-transportation-part-gtfs-373.zip?alt=media",
+        "license": "https://creativecommons.org/licenses/by/4.0/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-akron-metro-regional-transit-authority-metro-gtfs-411.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-akron-metro-regional-transit-authority-metro-gtfs-411.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 411,
+    "data_type": "gtfs",
+    "provider": "Akron Metro Regional Transit Authority (METRO)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Akron",
+        "bounding_box": {
+            "minimum_latitude": 40.915395,
+            "maximum_latitude": 41.513944,
+            "minimum_longitude": -81.697065,
+            "maximum_longitude": -81.403724,
+            "extracted_on": "2022-03-16T15:32:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.akronmetro.org/Data/Sites/2/gtfs-data/akronmetrogtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-akron-metro-regional-transit-authority-metro-gtfs-411.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-central-ohio-transit-authority-cota-gtfs-404.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-central-ohio-transit-authority-cota-gtfs-404.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 404,
+    "data_type": "gtfs",
+    "provider": "Central Ohio Transit Authority (COTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Columbus",
+        "bounding_box": {
+            "minimum_latitude": 39.830132,
+            "maximum_latitude": 40.150499,
+            "minimum_longitude": -83.162655,
+            "maximum_longitude": -82.771726,
+            "extracted_on": "2022-03-16T15:32:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.cota.com/data/cota.gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-central-ohio-transit-authority-cota-gtfs-404.zip?alt=media",
+        "license": "http://www.cota.com/data"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-greater-cleveland-regional-transit-authority-gtfs-406.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-greater-cleveland-regional-transit-authority-gtfs-406.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 406,
+    "data_type": "gtfs",
+    "provider": "Greater Cleveland Regional Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Cleveland",
+        "bounding_box": {
+            "minimum_latitude": 41.227828,
+            "maximum_latitude": 41.637051,
+            "minimum_longitude": -81.96736,
+            "maximum_longitude": -81.437811,
+            "extracted_on": "2022-03-16T15:32:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.riderta.com/sites/default/files/gtfs/latest/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-greater-cleveland-regional-transit-authority-gtfs-406.zip?alt=media",
+        "license": "http://www.riderta.com/developers"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-greater-dayton-regional-transit-authority-greater-dayton-rta-gtfs-403.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-greater-dayton-regional-transit-authority-greater-dayton-rta-gtfs-403.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 403,
+    "data_type": "gtfs",
+    "provider": "Greater Dayton Regional Transit Authority (Greater Dayton RTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Dayton",
+        "bounding_box": {
+            "minimum_latitude": 39.60158,
+            "maximum_latitude": 39.922275,
+            "minimum_longitude": -84.330089,
+            "maximum_longitude": -84.05722,
+            "extracted_on": "2022-03-16T15:32:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://proc.greaterdaytonrta.org/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-greater-dayton-regional-transit-authority-greater-dayton-rta-gtfs-403.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-laketran-gtfs-410.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-laketran-gtfs-410.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 410,
+    "data_type": "gtfs",
+    "provider": "Laketran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Cleveland",
+        "bounding_box": {
+            "minimum_latitude": 41.4969731269463,
+            "maximum_latitude": 41.8417784065152,
+            "minimum_longitude": -81.7001491308301,
+            "maximum_longitude": -81.008756071851,
+            "extracted_on": "2022-03-16T15:32:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lakecounty-oh-us/lakecounty-oh-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-laketran-gtfs-410.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-national-park-service-gtfs-405.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-national-park-service-gtfs-405.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 405,
+    "data_type": "gtfs",
+    "provider": "National Park Service ",
+    "name": "Cuyahoga Valley Scenic Railroad",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Brecksville",
+        "bounding_box": {
+            "minimum_latitude": 41.089484,
+            "maximum_latitude": 41.392676,
+            "minimum_longitude": -81.630857,
+            "maximum_longitude": -81.514958,
+            "extracted_on": "2022-03-16T15:32:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://nationalparkservice.github.io/nps-gtfs/cuva/scenic-rail/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-national-park-service-gtfs-405.zip?alt=media",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-erie-metropolitan-transit-authority-gtfs-412.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-erie-metropolitan-transit-authority-gtfs-412.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 412,
+    "data_type": "gtfs",
+    "provider": "Erie Metropolitan Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Erie",
+        "bounding_box": {
+            "minimum_latitude": 41.871983,
+            "maximum_latitude": 42.21981,
+            "minimum_longitude": -80.368614,
+            "maximum_longitude": -79.611465,
+            "extracted_on": "2022-03-16T15:32:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/eriemta-pa-us/eriemta-pa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-erie-metropolitan-transit-authority-gtfs-412.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-port-authority-of-allegheny-county-gtfs-409.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-port-authority-of-allegheny-county-gtfs-409.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 409,
+    "data_type": "gtfs",
+    "provider": "Port Authority of Allegheny County",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Pittsburgh",
+        "bounding_box": {
+            "minimum_latitude": 40.273078,
+            "maximum_latitude": 40.667597,
+            "minimum_longitude": -80.258865,
+            "maximum_longitude": -79.70545,
+            "extracted_on": "2022-03-16T15:32:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.portauthority.org/developerresources/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-port-authority-of-allegheny-county-gtfs-409.zip?alt=media",
+        "license": "https://www.portauthority.org/business-center/developer-resources/developer-license-agreement/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-rhode-island-vineyard-fast-ferry-gtfs-419.json
+++ b/catalogs/sources/gtfs/schedule/us-rhode-island-vineyard-fast-ferry-gtfs-419.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 419,
+    "data_type": "gtfs",
+    "provider": "Vineyard Fast Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Rhode Island",
+        "municipality": "North Kingstown",
+        "bounding_box": {
+            "minimum_latitude": 41.4587850841284,
+            "maximum_latitude": 41.5866697425203,
+            "minimum_longitude": -71.412781177771,
+            "maximum_longitude": -70.5543602749786,
+            "extracted_on": "2022-03-16T15:33:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/vineyardfastferry-ri-us/vineyardfastferry-ri-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-rhode-island-vineyard-fast-ferry-gtfs-419.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-unknown-express-arrow-gtfs-460.json
+++ b/catalogs/sources/gtfs/schedule/us-unknown-express-arrow-gtfs-460.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 460,
+    "data_type": "gtfs",
+    "provider": "Express Arrow",
+    "location": {
+        "country_code": "US",
+        "bounding_box": {
+            "minimum_latitude": 39.750401,
+            "maximum_latitude": 45.790281,
+            "minimum_longitude": -109.060475,
+            "maximum_longitude": -95.899628,
+            "extracted_on": "2022-03-16T15:35:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/expressarrow_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-unknown-express-arrow-gtfs-460.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-marble-valley-regional-transit-district-mvrtd-gtfs-430.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-marble-valley-regional-transit-district-mvrtd-gtfs-430.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 430,
+    "data_type": "gtfs",
+    "provider": "Marble Valley Regional Transit District (MVRTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Rutland",
+        "bounding_box": {
+            "minimum_latitude": 43.16363,
+            "maximum_latitude": 44.0107548649426,
+            "minimum_longitude": -73.27599,
+            "maximum_longitude": -72.70519444,
+            "extracted_on": "2022-03-16T15:33:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/thebus-vt-us/thebus-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-marble-valley-regional-transit-district-mvrtd-gtfs-430.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-moover-gtfs-434.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-moover-gtfs-434.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 434,
+    "data_type": "gtfs",
+    "provider": "MOOver",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Wilmington",
+        "bounding_box": {
+            "minimum_latitude": 42.7664048,
+            "maximum_latitude": 43.704185,
+            "minimum_longitude": -73.1980097605743,
+            "maximum_longitude": -72.227364677934,
+            "extracted_on": "2022-03-16T15:34:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/dvtamoover-vt-us/dvtamoover-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-moover-gtfs-434.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-rural-community-transportation-rct-gtfs-448.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-rural-community-transportation-rct-gtfs-448.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 448,
+    "data_type": "gtfs",
+    "provider": "Rural Community Transportation (RCT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "bounding_box": {
+            "minimum_latitude": 44.141096561202,
+            "maximum_latitude": 45.004295166893,
+            "minimum_longitude": -73.1211839,
+            "maximum_longitude": -71.7685947,
+            "extracted_on": "2022-03-16T15:34:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ruralcommunity-vt-us/ruralcommunity-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-rural-community-transportation-rct-gtfs-448.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-stagecoach-transportation-services-sts-gtfs-449.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-stagecoach-transportation-services-sts-gtfs-449.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 449,
+    "data_type": "gtfs",
+    "provider": "Stagecoach Transportation Services (STS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Orange County",
+        "bounding_box": {
+            "minimum_latitude": 43.586506,
+            "maximum_latitude": 44.2601842,
+            "minimum_longitude": -72.841917,
+            "maximum_longitude": -72.023504,
+            "extracted_on": "2022-03-16T15:34:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/stagecoach-vt-us/stagecoach-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-stagecoach-transportation-services-sts-gtfs-449.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-the-current-gtfs-428.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-the-current-gtfs-428.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 428,
+    "data_type": "gtfs",
+    "provider": "The Current",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Rockingham",
+        "bounding_box": {
+            "minimum_latitude": 42.7664048,
+            "maximum_latitude": 43.704185,
+            "minimum_longitude": -73.1980097605743,
+            "maximum_longitude": -72.227364677934,
+            "extracted_on": "2022-03-16T15:33:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/crtransit-vt-us/crtransit-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-the-current-gtfs-428.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-vermont-translines-gtfs-450.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-vermont-translines-gtfs-450.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 450,
+    "data_type": "gtfs",
+    "provider": "Vermont Translines",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "bounding_box": {
+            "minimum_latitude": 42.641635,
+            "maximum_latitude": 44.59499685,
+            "minimum_longitude": -73.8091885,
+            "maximum_longitude": -72.27192866,
+            "extracted_on": "2022-03-16T15:34:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/vttranslines-vt-us/vttranslines-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-vermont-translines-gtfs-450.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-farmville-area-bus-gtfs-461.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-farmville-area-bus-gtfs-461.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 461,
+    "data_type": "gtfs",
+    "provider": "Farmville Area Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "bounding_box": {
+            "minimum_latitude": 37.0880984473502,
+            "maximum_latitude": 37.3181906185174,
+            "minimum_longitude": -78.6811734495777,
+            "maximum_longitude": -78.3386927157542,
+            "extracted_on": "2022-03-16T15:35:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/farmville-va-us/farmville-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-farmville-area-bus-gtfs-461.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-greater-lynchburg-transit-co-gtfs-381.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-greater-lynchburg-transit-co-gtfs-381.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 381,
+    "data_type": "gtfs",
+    "provider": "Greater Lynchburg Transit Co.",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Lynchburg",
+        "bounding_box": {
+            "minimum_latitude": 37.329569,
+            "maximum_latitude": 37.4665797618095,
+            "minimum_longitude": -79.252715,
+            "maximum_longitude": -79.085086434555,
+            "extracted_on": "2022-03-16T15:27:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/gltc-lynchburg-va-us/gltc-lynchburg-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-greater-lynchburg-transit-co-gtfs-381.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-greensville-emporia-transit-gtfs-463.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-greensville-emporia-transit-gtfs-463.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 463,
+    "data_type": "gtfs",
+    "provider": "Greensville Emporia Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Greensville",
+        "bounding_box": {
+            "minimum_latitude": 36.6780173514517,
+            "maximum_latitude": 36.7364475332836,
+            "minimum_longitude": -77.5642245870908,
+            "maximum_longitude": -77.5147472038461,
+            "extracted_on": "2022-03-16T15:35:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/get-va-us/get-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-greensville-emporia-transit-gtfs-463.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-harrisonburg-department-of-public-transportation-hdpt-gtfs-382.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-harrisonburg-department-of-public-transportation-hdpt-gtfs-382.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 382,
+    "data_type": "gtfs",
+    "provider": "Harrisonburg Department of Public Transportation (HDPT)",
+    "name": "HDPT",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Harrisonburg",
+        "bounding_box": {
+            "minimum_latitude": 38.403775,
+            "maximum_latitude": 38.481533,
+            "minimum_longitude": -78.91079999999998,
+            "maximum_longitude": -78.8378,
+            "extracted_on": "2022-03-16T15:27:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://harrisonburgva.gov/sites/default/files/Transit/files/gtfs/google_transit_Working%20%281%29.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-harrisonburg-department-of-public-transportation-hdpt-gtfs-382.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-pulaski-area-transit-pat-gtfs-379.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-pulaski-area-transit-pat-gtfs-379.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 379,
+    "data_type": "gtfs",
+    "provider": "Pulaski Area Transit (PAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Pulaski",
+        "bounding_box": {
+            "minimum_latitude": 37.0389235602136,
+            "maximum_latitude": 37.0682116663451,
+            "minimum_longitude": -80.7822820685722,
+            "maximum_longitude": -80.7493873998037,
+            "extracted_on": "2022-03-16T15:27:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ridesolutions.org/gtfs/pulaski-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-pulaski-area-transit-pat-gtfs-379.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-radford-transit-gtfs-380.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-radford-transit-gtfs-380.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 380,
+    "data_type": "gtfs",
+    "provider": "Radford Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Radford",
+        "bounding_box": {
+            "minimum_latitude": 37.1057438,
+            "maximum_latitude": 37.230850967,
+            "minimum_longitude": -80.6963474,
+            "maximum_longitude": -80.400214,
+            "extracted_on": "2022-03-16T15:27:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://passio3.com/radford/passioTransit/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-radford-transit-gtfs-380.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-west-virginia-mountain-line-transit-authority-gtfs-407.json
+++ b/catalogs/sources/gtfs/schedule/us-west-virginia-mountain-line-transit-authority-gtfs-407.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 407,
+    "data_type": "gtfs",
+    "provider": "Mountain Line Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "West Virginia",
+        "municipality": "Morgantown",
+        "bounding_box": {
+            "minimum_latitude": 39.33224485,
+            "maximum_latitude": 40.49581962,
+            "minimum_longitude": -80.33817757,
+            "maximum_longitude": -79.83257174,
+            "extracted_on": "2022-03-16T15:32:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://site.busride.org/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-west-virginia-mountain-line-transit-authority-gtfs-407.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-belle-urban-system-gtfs-395.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-belle-urban-system-gtfs-395.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 395,
+    "data_type": "gtfs",
+    "provider": "Belle Urban System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Racine",
+        "bounding_box": {
+            "minimum_latitude": 42.68181,
+            "maximum_latitude": 42.786498,
+            "minimum_longitude": -87.959563,
+            "maximum_longitude": -87.781806,
+            "extracted_on": "2022-03-16T15:31:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/racine-wi-us/racine-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-belle-urban-system-gtfs-395.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-beloit-transit-gtfs-392.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-beloit-transit-gtfs-392.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 392,
+    "data_type": "gtfs",
+    "provider": "Beloit Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Janesville",
+        "bounding_box": {
+            "minimum_latitude": 42.4901036755054,
+            "maximum_latitude": 42.72832282,
+            "minimum_longitude": -89.0706385252087,
+            "maximum_longitude": -88.9648258265126,
+            "extracted_on": "2022-03-16T15:29:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/beloittransit-wi-us/beloittransit-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-beloit-transit-gtfs-392.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-go-transit-gtfs-397.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-go-transit-gtfs-397.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 397,
+    "data_type": "gtfs",
+    "provider": "GO Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Oshkosh",
+        "bounding_box": {
+            "minimum_latitude": 43.981736,
+            "maximum_latitude": 44.1866,
+            "minimum_longitude": -88.61613,
+            "maximum_longitude": -88.463707,
+            "extracted_on": "2022-03-16T15:31:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/oshkosh-wi-us/oshkosh-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-go-transit-gtfs-397.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-janesville-transit-system-gtfs-393.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-janesville-transit-system-gtfs-393.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 393,
+    "data_type": "gtfs",
+    "provider": "Janesville Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Janesville",
+        "bounding_box": {
+            "minimum_latitude": 42.4970909,
+            "maximum_latitude": 42.72933096,
+            "minimum_longitude": -89.065752,
+            "maximum_longitude": -88.962477,
+            "extracted_on": "2022-03-16T15:29:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/jts-wi-us/jts-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-janesville-transit-system-gtfs-393.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-metro-transit-gtfs-394.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-metro-transit-gtfs-394.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 394,
+    "data_type": "gtfs",
+    "provider": "Metro Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Madison",
+        "bounding_box": {
+            "minimum_latitude": 42.987718,
+            "maximum_latitude": 43.176537,
+            "minimum_longitude": -89.563863,
+            "maximum_longitude": -89.244818,
+            "extracted_on": "2022-03-16T15:30:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://transitdata.cityofmadison.com/GTFS/mmt_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-metro-transit-gtfs-394.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-shoreline-metro-gtfs-399.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-shoreline-metro-gtfs-399.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 399,
+    "data_type": "gtfs",
+    "provider": "Shoreline Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Sheboygan",
+        "bounding_box": {
+            "minimum_latitude": 43.7019726454334,
+            "maximum_latitude": 43.7830422,
+            "minimum_longitude": -87.82449695,
+            "maximum_longitude": -87.7010930156421,
+            "extracted_on": "2022-03-16T15:31:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sheboygan-wi-us/sheboygan-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-shoreline-metro-gtfs-399.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-valley-transit-wi-gtfs-398.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-valley-transit-wi-gtfs-398.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 398,
+    "data_type": "gtfs",
+    "provider": "Valley Transit (WI)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Appleton",
+        "bounding_box": {
+            "minimum_latitude": 44.15416046,
+            "maximum_latitude": 44.31200921,
+            "minimum_longitude": -88.495233167,
+            "maximum_longitude": -88.26613093,
+            "extracted_on": "2022-03-16T15:31:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gis.appleton.org/DataDownload/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-valley-transit-wi-gtfs-398.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-waukesha-metro-transit-gtfs-396.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-waukesha-metro-transit-gtfs-396.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 396,
+    "data_type": "gtfs",
+    "provider": "Waukesha Metro Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Waukesha",
+        "bounding_box": {
+            "minimum_latitude": 42.969112,
+            "maximum_latitude": 43.11177011,
+            "minimum_longitude": -88.49764196,
+            "maximum_longitude": -87.87801014,
+            "extracted_on": "2022-03-16T15:31:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/waukeshacounty-wi-us/waukeshacounty-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-waukesha-metro-transit-gtfs-396.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the sixth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 92 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~