### PR TITLE
feat: Seventh import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-connecticut-9-town-transit-gtfs-551.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-9-town-transit-gtfs-551.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 551,
+    "data_type": "gtfs",
+    "provider": "9 Town Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "municipality": "Centerbrook",
+        "bounding_box": {
+            "minimum_latitude": 41.2614311359534,
+            "maximum_latitude": 41.5612866,
+            "minimum_longitude": -72.657961881914,
+            "maximum_longitude": -72.0934518,
+            "extracted_on": "2022-03-16T17:28:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ninetown-connecticut-us/ninetown-connecticut-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-9-town-transit-gtfs-551.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-connecticut-transit-gtfs-553.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-connecticut-transit-gtfs-553.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 553,
+    "data_type": "gtfs",
+    "provider": "Connecticut Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "bounding_box": {
+            "minimum_latitude": 40.997976,
+            "maximum_latitude": 42.02084,
+            "minimum_longitude": -73.773703,
+            "maximum_longitude": -71.794509,
+            "extracted_on": "2022-03-16T17:28:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.cttransit.com/sites/default/files/gtfs/googlect_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-connecticut-transit-gtfs-553.zip?alt=media",
+        "license": "https://www.cttransit.com/about/developers/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-greater-bridgeport-transit-gtfs-530.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-greater-bridgeport-transit-gtfs-530.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 530,
+    "data_type": "gtfs",
+    "provider": "Greater Bridgeport Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "municipality": "Bridgeport",
+        "bounding_box": {
+            "minimum_latitude": 41.117939,
+            "maximum_latitude": 41.320393,
+            "minimum_longitude": -73.415092,
+            "maximum_longitude": -73.032364,
+            "extracted_on": "2022-03-16T17:27:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/gbt-ct-us/gbt-ct-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-greater-bridgeport-transit-gtfs-530.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-norwalk-transit-district-gtfs-529.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-norwalk-transit-district-gtfs-529.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 529,
+    "data_type": "gtfs",
+    "provider": "Norwalk Transit District",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "municipality": "Stamford",
+        "bounding_box": {
+            "minimum_latitude": 41.021576,
+            "maximum_latitude": 41.236248,
+            "minimum_longitude": -73.63086699999998,
+            "maximum_longitude": -73.036446,
+            "extracted_on": "2022-03-16T17:27:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.norwalktransit.com/s/GTFS_Data.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-norwalk-transit-district-gtfs-529.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-shore-line-east-gtfs-550.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-shore-line-east-gtfs-550.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 550,
+    "data_type": "gtfs",
+    "provider": "Shore Line East",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "bounding_box": {
+            "minimum_latitude": 40.753165,
+            "maximum_latitude": 41.354158032583534,
+            "minimum_longitude": -73.977379,
+            "maximum_longitude": -72.0930764079094,
+            "extracted_on": "2022-03-16T17:28:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.shorelineeast.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-shore-line-east-gtfs-550.zip?alt=media",
+        "license": "http://www.cttransit.com/about/developers/gtfsdata/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-southeast-area-transit-district-gtfs-552.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-southeast-area-transit-district-gtfs-552.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 552,
+    "data_type": "gtfs",
+    "provider": "Southeast Area Transit District",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "municipality": "Preston",
+        "bounding_box": {
+            "minimum_latitude": 41.3099310659131,
+            "maximum_latitude": 41.6137083625167,
+            "minimum_longitude": -72.210556,
+            "maximum_longitude": -71.8349448409511,
+            "extracted_on": "2022-03-16T17:28:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/seatbus-ct-us/seatbus-ct-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-southeast-area-transit-district-gtfs-552.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-district-of-columbia-dc-circulator-gtfs-486.json
+++ b/catalogs/sources/gtfs/schedule/us-district-of-columbia-dc-circulator-gtfs-486.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 486,
+    "data_type": "gtfs",
+    "provider": "DC Circulator",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "District of Columbia",
+        "municipality": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 38.845883,
+            "maximum_latitude": 38.928722,
+            "minimum_longitude": -77.071558,
+            "maximum_longitude": -76.975457,
+            "extracted_on": "2022-03-16T17:24:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://extranet.ddot.dc.gov/ddot_data/gtfs/dc-circulator.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-district-of-columbia-dc-circulator-gtfs-486.zip?alt=media",
+        "license": "https://octo.dc.gov/page/district-columbia-data-policy"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-district-of-columbia-dc-streetcar-gtfs-487.json
+++ b/catalogs/sources/gtfs/schedule/us-district-of-columbia-dc-streetcar-gtfs-487.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 487,
+    "data_type": "gtfs",
+    "provider": "DC Streetcar",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "District of Columbia",
+        "municipality": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 38.897421983202,
+            "maximum_latitude": 38.90030625,
+            "minimum_longitude": -77.00466218,
+            "maximum_longitude": -76.9667291977875,
+            "extracted_on": "2022-03-16T17:24:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/dcstreetcar-dc-us/dcstreetcar-dc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-district-of-columbia-dc-streetcar-gtfs-487.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-district-of-columbia-delmarva-community-transit-gtfs-475.json
+++ b/catalogs/sources/gtfs/schedule/us-district-of-columbia-delmarva-community-transit-gtfs-475.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 475,
+    "data_type": "gtfs",
+    "provider": "Delmarva Community Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "District of Columbia",
+        "municipality": "Kent",
+        "bounding_box": {
+            "minimum_latitude": 38.366366,
+            "maximum_latitude": 39.281552,
+            "minimum_longitude": -76.23424,
+            "maximum_longitude": -75.596215,
+            "extracted_on": "2022-03-16T17:23:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Delmarva_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-district-of-columbia-delmarva-community-transit-gtfs-475.zip?alt=media",
+        "license": "https://github.com/mobilityequity/maryland-local-gtfs/blob/master/README.md"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-annapolis-transit-gtfs-491.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-annapolis-transit-gtfs-491.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 491,
+    "data_type": "gtfs",
+    "provider": "Annapolis Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Annapolis",
+        "bounding_box": {
+            "minimum_latitude": 38.92884,
+            "maximum_latitude": 39.0486949672717,
+            "minimum_longitude": -76.5673055566884,
+            "maximum_longitude": -76.481211,
+            "extracted_on": "2022-03-16T17:24:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Annapolis_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-annapolis-transit-gtfs-491.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-bwi-thurgood-marshall-airport-bwi-shuttle-gtfs-490.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-bwi-thurgood-marshall-airport-bwi-shuttle-gtfs-490.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 490,
+    "data_type": "gtfs",
+    "provider": "BWI Thurgood Marshall Airport (BWI) Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Baltimore",
+        "bounding_box": {
+            "minimum_latitude": 39.1792093971593,
+            "maximum_latitude": 39.1925816967402,
+            "minimum_longitude": -76.6942399031105,
+            "maximum_longitude": -76.658497,
+            "extracted_on": "2022-03-16T17:24:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/BWI_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-bwi-thurgood-marshall-airport-bwi-shuttle-gtfs-490.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-calvert-county-public-transportation-gtfs-480.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-calvert-county-public-transportation-gtfs-480.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 480,
+    "data_type": "gtfs",
+    "provider": "Calvert County Public Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.322869,
+            "maximum_latitude": 38.725993,
+            "minimum_longitude": -76.78077042,
+            "maximum_longitude": -76.406352,
+            "extracted_on": "2022-03-16T17:24:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Calvert_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-calvert-county-public-transportation-gtfs-480.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-carroll-transit-system-gtfs-500.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-carroll-transit-system-gtfs-500.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 500,
+    "data_type": "gtfs",
+    "provider": "Carroll Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 39.364997,
+            "maximum_latitude": 39.6641419422349,
+            "minimum_longitude": -77.176526,
+            "maximum_longitude": -76.8368470581853,
+            "extracted_on": "2022-03-16T17:24:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Carroll_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-carroll-transit-system-gtfs-500.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-cecil-transit-gtfs-504.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-cecil-transit-gtfs-504.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 504,
+    "data_type": "gtfs",
+    "provider": "Cecil Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 39.549919,
+            "maximum_latitude": 39.6832,
+            "minimum_longitude": -76.0763,
+            "maximum_longitude": -75.7435,
+            "extracted_on": "2022-03-16T17:25:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Cecil_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-cecil-transit-gtfs-504.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-charles-county-vango-gtfs-479.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-charles-county-vango-gtfs-479.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 479,
+    "data_type": "gtfs",
+    "provider": "Charles County VanGo",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "St. Charles",
+        "bounding_box": {
+            "minimum_latitude": 38.365716,
+            "maximum_latitude": 38.676048,
+            "minimum_longitude": -77.220834,
+            "maximum_longitude": -76.772132,
+            "extracted_on": "2022-03-16T17:24:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Charles_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-charles-county-vango-gtfs-479.zip?alt=media",
+        "license": "http://www.mdtrip.org/commuter-tools/developer-resources/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-charm-city-circulator-gtfs-493.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-charm-city-circulator-gtfs-493.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 493,
+    "data_type": "gtfs",
+    "provider": "Charm City Circulator",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 39.265901,
+            "maximum_latitude": 39.328029,
+            "minimum_longitude": -76.634951,
+            "maximum_longitude": -76.584145,
+            "extracted_on": "2022-03-16T17:24:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/CCC_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-charm-city-circulator-gtfs-493.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-frederick-county-transit-gtfs-498.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-frederick-county-transit-gtfs-498.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 498,
+    "data_type": "gtfs",
+    "provider": "Frederick County TransIT",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Frederick",
+        "bounding_box": {
+            "minimum_latitude": 39.27394213,
+            "maximum_latitude": 39.70535974,
+            "minimum_longitude": -77.66505541,
+            "maximum_longitude": -77.31736153,
+            "extracted_on": "2022-03-16T17:24:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://maps.frederickcountymd.gov/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-frederick-county-transit-gtfs-498.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-harford-transit-link-gtfs-501.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-harford-transit-link-gtfs-501.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 501,
+    "data_type": "gtfs",
+    "provider": "Harford Transit LINK",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Aberdeen",
+        "bounding_box": {
+            "minimum_latitude": 39.411194,
+            "maximum_latitude": 39.596325,
+            "minimum_longitude": -76.369804,
+            "maximum_longitude": -76.004269,
+            "extracted_on": "2022-03-16T17:24:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Harford_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-harford-transit-link-gtfs-501.zip?alt=media",
+        "license": "http://mdtrip.org/About/DeveloperResources.aspx"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-466.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-466.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 466,
+    "data_type": "gtfs",
+    "provider": "Maryland Transit Administration",
+    "name": "Local Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.978294,
+            "maximum_latitude": 39.502231,
+            "minimum_longitude": -76.889459,
+            "maximum_longitude": -76.379313,
+            "extracted_on": "2022-03-16T17:23:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mdotmta-gtfs.s3.amazonaws.com/mdotmta_gtfs_localbus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-maryland-transit-administration-gtfs-466.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-467.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-467.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 467,
+    "data_type": "gtfs",
+    "provider": "Maryland Transit Administration",
+    "name": "Commuter Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.349762,
+            "maximum_latitude": 39.601879,
+            "minimum_longitude": -77.732109,
+            "maximum_longitude": -76.091627,
+            "extracted_on": "2022-03-16T17:23:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mdotmta-gtfs.s3.amazonaws.com/mdotmta_gtfs_commuterbus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-maryland-transit-administration-gtfs-467.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-468.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-468.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 468,
+    "data_type": "gtfs",
+    "provider": "Maryland Transit Administration",
+    "name": "MARC Train",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Baltimore",
+        "bounding_box": {
+            "minimum_latitude": 38.899036,
+            "maximum_latitude": 39.558089,
+            "minimum_longitude": -77.961655,
+            "maximum_longitude": -76.07318,
+            "extracted_on": "2022-03-16T17:23:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mdotmta-gtfs.s3.amazonaws.com/mdotmta_gtfs_marc.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-maryland-transit-administration-gtfs-468.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-469.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-gtfs-469.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 469,
+    "data_type": "gtfs",
+    "provider": "Maryland Transit Administration",
+    "name": "Light Rail",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 39.171932,
+            "maximum_latitude": 39.496307,
+            "minimum_longitude": -76.673208,
+            "maximum_longitude": -76.61611,
+            "extracted_on": "2022-03-16T17:23:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mdotmta-gtfs.s3.amazonaws.com/mdotmta_gtfs_lightrail.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-maryland-transit-administration-gtfs-469.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-metro-subway-gtfs-470.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-maryland-transit-administration-metro-subway-gtfs-470.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 470,
+    "data_type": "gtfs",
+    "provider": "Maryland Transit Administration Metro Subway",
+    "name": "Metro SubwayLink",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 39.2893568,
+            "maximum_latitude": 39.4081468,
+            "minimum_longitude": -76.780768,
+            "maximum_longitude": -76.594107,
+            "extracted_on": "2022-03-16T17:23:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mdotmta-gtfs.s3.amazonaws.com/mdotmta_gtfs_metro.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-maryland-transit-administration-metro-subway-gtfs-470.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-ocean-city-transportation-gtfs-495.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-ocean-city-transportation-gtfs-495.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 495,
+    "data_type": "gtfs",
+    "provider": "Ocean City Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Ocean City",
+        "bounding_box": {
+            "minimum_latitude": 38.32724616,
+            "maximum_latitude": 38.44946992,
+            "minimum_longitude": -75.10640766,
+            "maximum_longitude": -75.05239703,
+            "extracted_on": "2022-03-16T17:24:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/OC_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-ocean-city-transportation-gtfs-495.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-prince-georges-county-the-bus-gtfs-477.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-prince-georges-county-the-bus-gtfs-477.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 477,
+    "data_type": "gtfs",
+    "provider": "Prince George's County (The Bus)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.6716394992679,
+            "maximum_latitude": 39.02222,
+            "minimum_longitude": -77.016687,
+            "maximum_longitude": -76.7089410933423,
+            "extracted_on": "2022-03-16T17:24:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/princegeorgescounty-md-us/princegeorgescounty-md-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-prince-georges-county-the-bus-gtfs-477.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-queen-annes-county-ride-gtfs-492.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-queen-annes-county-ride-gtfs-492.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 492,
+    "data_type": "gtfs",
+    "provider": "Queen Anne's County Ride",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.763999,
+            "maximum_latitude": 39.046898,
+            "minimum_longitude": -76.543942,
+            "maximum_longitude": -76.055024,
+            "extracted_on": "2022-03-16T17:24:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/QA_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-queen-annes-county-ride-gtfs-492.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-regional-transportation-agency-of-central-maryland-rta-gtfs-489.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-regional-transportation-agency-of-central-maryland-rta-gtfs-489.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 489,
+    "data_type": "gtfs",
+    "provider": "Regional Transportation Agency of Central Maryland (RTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.999445,
+            "maximum_latitude": 39.29077,
+            "minimum_longitude": -76.91581,
+            "maximum_longitude": -76.724395,
+            "extracted_on": "2022-03-16T17:24:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/centralmarylandrta-md-us/centralmarylandrta-md-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-regional-transportation-agency-of-central-maryland-rta-gtfs-489.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-ride-on-gtfs-488.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-ride-on-gtfs-488.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 488,
+    "data_type": "gtfs",
+    "provider": "Ride On",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Montgomery",
+        "bounding_box": {
+            "minimum_latitude": 38.93569,
+            "maximum_latitude": 39.288508,
+            "minimum_longitude": -77.418659,
+            "maximum_longitude": -76.930802,
+            "extracted_on": "2022-03-16T17:24:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.montgomerycountymd.gov/DOT-Transit/Resources/Files/GTFS/RideOnGTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-ride-on-gtfs-488.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-shore-transit-gtfs-494.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-shore-transit-gtfs-494.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 494,
+    "data_type": "gtfs",
+    "provider": "Shore Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Salisbury",
+        "bounding_box": {
+            "minimum_latitude": 37.977740882,
+            "maximum_latitude": 38.455257807,
+            "minimum_longitude": -75.863656417,
+            "maximum_longitude": -75.088711755,
+            "extracted_on": "2022-03-16T17:24:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/Shore_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-shore-transit-gtfs-494.zip?alt=media",
+        "license": "https://github.com/mobilityequity/maryland-local-gtfs/blob/master/README.md"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-st-marys-transit-system-sts-gtfs-476.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-st-marys-transit-system-sts-gtfs-476.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 476,
+    "data_type": "gtfs",
+    "provider": "St. Mary's Transit System (STS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.108913,
+            "maximum_latitude": 38.500123,
+            "minimum_longitude": -76.832048,
+            "maximum_longitude": -76.365933,
+            "extracted_on": "2022-03-16T17:23:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/SM_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-st-marys-transit-system-sts-gtfs-476.zip?alt=media",
+        "license": "https://github.com/mobilityequity/maryland-local-gtfs/blob/master/README.md"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-washington-county-transit-gtfs-497.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-washington-county-transit-gtfs-497.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 497,
+    "data_type": "gtfs",
+    "provider": "Washington County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 39.5997022863592,
+            "maximum_latitude": 39.719788562,
+            "minimum_longitude": -77.821214,
+            "maximum_longitude": -77.57312,
+            "extracted_on": "2022-03-16T17:24:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/mobilityequity/maryland-local-gtfs/raw/master/WC_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-washington-county-transit-gtfs-497.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-berkshire-regional-transit-authority-brta-gtfs-537.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-berkshire-regional-transit-authority-brta-gtfs-537.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 537,
+    "data_type": "gtfs",
+    "provider": "Berkshire Regional Transit Authority (BRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Berkshire",
+        "bounding_box": {
+            "minimum_latitude": 42.1741759759195,
+            "maximum_latitude": 42.717058,
+            "minimum_longitude": -73.3809157013355,
+            "maximum_longitude": -73.091904220562,
+            "extracted_on": "2022-03-16T17:27:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/berkshire-ma-us/berkshire-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-berkshire-regional-transit-authority-brta-gtfs-537.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-dattco-motorcoach-gtfs-555.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-dattco-motorcoach-gtfs-555.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 555,
+    "data_type": "gtfs",
+    "provider": "DATTCO Motorcoach",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 41.632089,
+            "maximum_latitude": 42.350314,
+            "minimum_longitude": -71.075101,
+            "maximum_longitude": -70.91187,
+            "extracted_on": "2022-03-16T17:28:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/dattco-ma-us/dattco-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-dattco-motorcoach-gtfs-555.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-peter-pan-gtfs-496.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-peter-pan-gtfs-496.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 496,
+    "data_type": "gtfs",
+    "provider": "Peter Pan",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 38.89758,
+            "maximum_latitude": 42.732892537699,
+            "minimum_longitude": -77.030038,
+            "maximum_longitude": -69.9736910800041,
+            "extracted_on": "2022-03-16T17:24:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/peterpan-ma-us/peterpan-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-peter-pan-gtfs-496.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-seastreak-ferry-gtfs-549.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-seastreak-ferry-gtfs-549.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 549,
+    "data_type": "gtfs",
+    "provider": "Seastreak Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 40.409395,
+            "maximum_latitude": 41.815975,
+            "minimum_longitude": -74.034889,
+            "maximum_longitude": -70.096322,
+            "extracted_on": "2022-03-16T17:28:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://seastreak.com/api/transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-seastreak-ferry-gtfs-549.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-detroit-department-of-transportation-ddot-gtfs-464.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-detroit-department-of-transportation-ddot-gtfs-464.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 464,
+    "data_type": "gtfs",
+    "provider": "Detroit Department of Transportation (DDOT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Detroit",
+        "bounding_box": {
+            "minimum_latitude": 42.26179,
+            "maximum_latitude": 42.473734,
+            "minimum_longitude": -83.33294,
+            "maximum_longitude": -82.911558,
+            "extracted_on": "2022-03-16T17:23:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.detroitmi.gov/Portals/0/docs/deptoftransportation/pdfs/ddot_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-detroit-department-of-transportation-ddot-gtfs-464.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-new-jersey-transit-nj-transit-gtfs-508.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-new-jersey-transit-nj-transit-gtfs-508.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 508,
+    "data_type": "gtfs",
+    "provider": "New Jersey Transit (NJ Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Jersey",
+        "bounding_box": {
+            "minimum_latitude": 38.933898,
+            "maximum_latitude": 41.254809,
+            "minimum_longitude": -75.520963,
+            "maximum_longitude": -73.939143,
+            "extracted_on": "2022-03-16T17:25:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.njtransit.com/bus_data.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-jersey-new-jersey-transit-nj-transit-gtfs-508.zip?alt=media",
+        "license": "https://www.njtransit.com/developer-tools"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-new-jersey-transit-nj-transit-gtfs-509.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-new-jersey-transit-nj-transit-gtfs-509.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 509,
+    "data_type": "gtfs",
+    "provider": "New Jersey Transit (NJ Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Jersey",
+        "bounding_box": {
+            "minimum_latitude": 39.363299,
+            "maximum_latitude": 41.471784,
+            "minimum_longitude": -75.182327,
+            "maximum_longitude": -73.988331,
+            "extracted_on": "2022-03-16T17:25:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.njtransit.com/rail_data.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-jersey-new-jersey-transit-nj-transit-gtfs-509.zip?alt=media",
+        "license": "https://www.njtransit.com/developer-tools"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-patco-speedline-gtfs-505.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-patco-speedline-gtfs-505.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 505,
+    "data_type": "gtfs",
+    "provider": "PATCO Speedline",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Jersey",
+        "bounding_box": {
+            "minimum_latitude": 39.833809,
+            "maximum_latitude": 39.951152,
+            "minimum_longitude": -75.167792,
+            "maximum_longitude": -75.000325,
+            "extracted_on": "2022-03-16T17:25:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.ridepatco.org/developers/PortAuthorityTransitCorporation.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-jersey-patco-speedline-gtfs-505.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-port-authority-trans-hudson-path-gtfs-517.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-port-authority-trans-hudson-path-gtfs-517.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 517,
+    "data_type": "gtfs",
+    "provider": "Port Authority Trans-Hudson (PATH)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Jersey",
+        "municipality": "Jersey City",
+        "bounding_box": {
+            "minimum_latitude": 40.7118,
+            "maximum_latitude": 40.7495,
+            "minimum_longitude": -74.1649,
+            "maximum_longitude": -73.9876,
+            "extracted_on": "2022-03-16T17:26:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/path-nj-us/path-nj-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-jersey-port-authority-trans-hudson-path-gtfs-517.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-access-allegany-gtfs-531.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-access-allegany-gtfs-531.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 531,
+    "data_type": "gtfs",
+    "provider": "Access Allegany",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 42.000082,
+            "maximum_latitude": 42.462679,
+            "minimum_longitude": -78.467724,
+            "maximum_longitude": -77.764518,
+            "extracted_on": "2022-03-16T17:27:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Access_Allegany.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-access-allegany-gtfs-531.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-capital-district-transportation-authority-cdta-gtfs-538.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-capital-district-transportation-authority-cdta-gtfs-538.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 538,
+    "data_type": "gtfs",
+    "provider": "Capital District Transportation Authority (CDTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Albany",
+        "bounding_box": {
+            "minimum_latitude": 42.467067,
+            "maximum_latitude": 43.10706,
+            "minimum_longitude": -74.010109,
+            "maximum_longitude": -73.614608,
+            "extracted_on": "2022-03-16T17:27:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.cdta.org/schedules/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-capital-district-transportation-authority-cdta-gtfs-538.zip?alt=media",
+        "license": "https://www.cdta.org/developer-license-agreement/169"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-centro-gtfs-534.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-centro-gtfs-534.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 534,
+    "data_type": "gtfs",
+    "provider": "Centro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Syracuse",
+        "bounding_box": {
+            "minimum_latitude": 42.791042,
+            "maximum_latitude": 43.479595,
+            "minimum_longitude": -76.611483,
+            "maximum_longitude": -75.164539,
+            "extracted_on": "2022-03-16T17:27:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.centro.org/CentroGTFS/CentroGTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-centro-gtfs-534.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-chenango-first-transit-gtfs-536.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-chenango-first-transit-gtfs-536.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 536,
+    "data_type": "gtfs",
+    "provider": "Chenango First Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Norwich",
+        "bounding_box": {
+            "minimum_latitude": 42.22937,
+            "maximum_latitude": 42.739931,
+            "minimum_longitude": -75.78323,
+            "maximum_longitude": -75.331977,
+            "extracted_on": "2022-03-16T17:27:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Chenango_First_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-chenango-first-transit-gtfs-536.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-city-of-mechanicville-public-transit-gtfs-541.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-city-of-mechanicville-public-transit-gtfs-541.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 541,
+    "data_type": "gtfs",
+    "provider": "City of Mechanicville Public Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Mechanicville",
+        "bounding_box": {
+            "minimum_latitude": 42.896694,
+            "maximum_latitude": 42.910148,
+            "minimum_longitude": -73.693199,
+            "maximum_longitude": -73.682921,
+            "extracted_on": "2022-03-16T17:28:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/City_of_Mechanicville_Public_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-city-of-mechanicville-public-transit-gtfs-541.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-clinton-county-public-transit-ccpt-gtfs-544.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-clinton-county-public-transit-ccpt-gtfs-544.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 544,
+    "data_type": "gtfs",
+    "provider": "Clinton County Public Transit (CCPT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Plattsburgh",
+        "bounding_box": {
+            "minimum_latitude": 44.440577,
+            "maximum_latitude": 45.002481,
+            "minimum_longitude": -73.913698,
+            "maximum_longitude": -73.363424,
+            "extracted_on": "2022-03-16T17:28:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Clinton_County_Public_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-clinton-county-public-transit-ccpt-gtfs-544.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-downtown-alliance-gtfs-519.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-downtown-alliance-gtfs-519.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 519,
+    "data_type": "gtfs",
+    "provider": "Downtown Alliance",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.7023239883,
+            "maximum_latitude": 40.717257,
+            "minimum_longitude": -74.0180646256,
+            "maximum_longitude": -74.001689,
+            "extracted_on": "2022-03-16T17:26:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/downtown_nyc_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-downtown-alliance-gtfs-519.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-franklin-county-public-transportation-gtfs-545.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-franklin-county-public-transportation-gtfs-545.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 545,
+    "data_type": "gtfs",
+    "provider": "Franklin County Public Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "North Malone",
+        "bounding_box": {
+            "minimum_latitude": 44.219766,
+            "maximum_latitude": 44.989507,
+            "minimum_longitude": -74.567492,
+            "maximum_longitude": -73.468206,
+            "extracted_on": "2022-03-16T17:28:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Franklin_County_Public_Transportation.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-franklin-county-public-transportation-gtfs-545.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-gloversville-transit-services-gtfs-540.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-gloversville-transit-services-gtfs-540.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 540,
+    "data_type": "gtfs",
+    "provider": "Gloversville Transit Services",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Schenectady",
+        "bounding_box": {
+            "minimum_latitude": 42.935495,
+            "maximum_latitude": 43.071231,
+            "minimum_longitude": -74.399364,
+            "maximum_longitude": -74.184569,
+            "extracted_on": "2022-03-16T17:28:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Gloversville_Transit_Services.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-gloversville-transit-services-gtfs-540.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-greater-glens-falls-transit-gtfs-542.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-greater-glens-falls-transit-gtfs-542.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 542,
+    "data_type": "gtfs",
+    "provider": "Greater Glens Falls Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Saratoga Springs",
+        "bounding_box": {
+            "minimum_latitude": 43.24191,
+            "maximum_latitude": 43.557696,
+            "minimum_longitude": -73.720295,
+            "maximum_longitude": -73.580627,
+            "extracted_on": "2022-03-16T17:28:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Greater_Glens_Falls_Transit_System.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-greater-glens-falls-transit-gtfs-542.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-hornell-area-transit-gtfs-532.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-hornell-area-transit-gtfs-532.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 532,
+    "data_type": "gtfs",
+    "provider": "Hornell Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 42.252687,
+            "maximum_latitude": 42.567922,
+            "minimum_longitude": -77.794357,
+            "maximum_longitude": -77.318001,
+            "extracted_on": "2022-03-16T17:27:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Hornell_Area_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-hornell-area-transit-gtfs-532.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-jfk-airtrain-gtfs-522.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-jfk-airtrain-gtfs-522.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 522,
+    "data_type": "gtfs",
+    "provider": "JFK Airtrain",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.642004,
+            "maximum_latitude": 40.698942,
+            "minimum_longitude": -73.829638,
+            "maximum_longitude": -73.780067,
+            "extracted_on": "2022-03-16T17:26:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Airtrain_JFK.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-jfk-airtrain-gtfs-522.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-long-island-rail-road-gtfs-507.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-long-island-rail-road-gtfs-507.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 507,
+    "data_type": "gtfs",
+    "provider": "MTA Long Island Rail Road",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Long Island",
+        "bounding_box": {
+            "minimum_latitude": 40.590181700395,
+            "maximum_latitude": 41.099709911981,
+            "minimum_longitude": -73.993584084919,
+            "maximum_longitude": -71.953881026163,
+            "extracted_on": "2022-03-16T17:25:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/lirr/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-long-island-rail-road-gtfs-507.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-gtfs-512.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-gtfs-512.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 512,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.572635,
+            "maximum_latitude": 40.762524,
+            "minimum_longitude": -74.040876,
+            "maximum_longitude": -73.779519,
+            "extracted_on": "2022-03-16T17:26:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/nyct/bus/google_transit_brooklyn.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-gtfs-512.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-510.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-510.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 510,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit (MTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.566123,
+            "maximum_latitude": 40.933637,
+            "minimum_longitude": -74.016284,
+            "maximum_longitude": -73.701761,
+            "extracted_on": "2022-03-16T17:25:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/busco/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-mta-gtfs-510.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-511.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-511.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 511,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit (MTA)",
+    "name": "NYC Subway Supplemented",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.512764,
+            "maximum_latitude": 40.903125,
+            "minimum_longitude": -74.251961,
+            "maximum_longitude": -73.755405,
+            "extracted_on": "2022-03-16T17:26:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/files/google_transit_supplemented.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-mta-gtfs-511.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-513.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-513.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 513,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit (MTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.701536,
+            "maximum_latitude": 40.865644,
+            "minimum_longitude": -74.018088,
+            "maximum_longitude": -73.862388,
+            "extracted_on": "2022-03-16T17:26:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/nyct/bus/google_transit_manhattan.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-mta-gtfs-513.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-514.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-514.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 514,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit (MTA) ",
+    "name": "Staten Island Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.502981,
+            "maximum_latitude": 40.766314,
+            "minimum_longitude": -74.252016,
+            "maximum_longitude": -73.968693,
+            "extracted_on": "2022-03-16T17:26:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/nyct/bus/google_transit_staten_island.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-mta-gtfs-514.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-516.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-516.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 516,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit (MTA)",
+    "name": "Subway",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.512764,
+            "maximum_latitude": 40.903125,
+            "minimum_longitude": -74.251961,
+            "maximum_longitude": -73.755405,
+            "extracted_on": "2022-03-16T17:26:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/nyct/subway/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-mta-gtfs-516.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-520.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-520.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 520,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit (MTA) ",
+    "name": "Queens Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.647137,
+            "maximum_latitude": 40.842561,
+            "minimum_longitude": -73.991082,
+            "maximum_longitude": -73.70123,
+            "extracted_on": "2022-03-16T17:26:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/nyct/bus/google_transit_queens.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-mta-gtfs-520.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-528.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-mta-new-york-city-transit-mta-gtfs-528.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 528,
+    "data_type": "gtfs",
+    "provider": "MTA New York City Transit (MTA)",
+    "name": "Bronx Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.79965,
+            "maximum_latitude": 40.912377,
+            "minimum_longitude": -73.960168,
+            "maximum_longitude": -73.783366,
+            "extracted_on": "2022-03-16T17:27:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/nyct/bus/google_transit_bronx.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-mta-new-york-city-transit-mta-gtfs-528.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-nassau-inter-county-express-nice-bus-gtfs-521.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-nassau-inter-county-express-nice-bus-gtfs-521.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 521,
+    "data_type": "gtfs",
+    "provider": "Nassau Inter-County Express (NICE Bus)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Nassau",
+        "bounding_box": {
+            "minimum_latitude": 40.585956,
+            "maximum_latitude": 40.863322,
+            "minimum_longitude": -73.829537,
+            "maximum_longitude": -73.408864,
+            "extracted_on": "2022-03-16T17:26:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nicebus.com/NICE/media/nicebus-gtfs/NICE_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-nassau-inter-county-express-nice-bus-gtfs-521.zip?alt=media",
+        "license": "http://www.nicebus.com/NiceBus/media/NiceBus-Images/131030_Legal-Agreements.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-niagara-frontier-transportation-authority-nfta-gtfs-465.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-niagara-frontier-transportation-authority-nfta-gtfs-465.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 465,
+    "data_type": "gtfs",
+    "provider": "Niagara Frontier Transportation Authority (NFTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Buffalo",
+        "bounding_box": {
+            "minimum_latitude": 42.570072,
+            "maximum_latitude": 43.17006,
+            "minimum_longitude": -79.117122,
+            "maximum_longitude": -78.607822,
+            "extracted_on": "2022-03-16T17:23:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.nfta.com/metro/__googletransit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-niagara-frontier-transportation-authority-nfta-gtfs-465.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-north-country-express-transit-gtfs-546.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-north-country-express-transit-gtfs-546.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 546,
+    "data_type": "gtfs",
+    "provider": "North Country Express Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Plattsburg",
+        "bounding_box": {
+            "minimum_latitude": 44.662523,
+            "maximum_latitude": 44.933975,
+            "minimum_longitude": -74.989121,
+            "maximum_longitude": -73.435809,
+            "extracted_on": "2022-03-16T17:28:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/North_Country_Express.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-north-country-express-transit-gtfs-546.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-ny-waterway-gtfs-525.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-ny-waterway-gtfs-525.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 525,
+    "data_type": "gtfs",
+    "provider": "NY Waterway",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 40.433258,
+            "maximum_latitude": 41.505781,
+            "minimum_longitude": -74.078826,
+            "maximum_longitude": -73.870225,
+            "extracted_on": "2022-03-16T17:27:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/data.bytemark.co/nywaterway/nywaterway.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-ny-waterway-gtfs-525.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-ny-waterway-shore-line-east-metro-north-railroad-mnr-hudson-rail-link-gtfs-524.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-ny-waterway-shore-line-east-metro-north-railroad-mnr-hudson-rail-link-gtfs-524.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 524,
+    "data_type": "gtfs",
+    "provider": "NY Waterway, Shore Line East, Metro-North Railroad, MNR Hudson Rail Link",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.752998,
+            "maximum_latitude": 41.814722,
+            "minimum_longitude": -74.005419,
+            "maximum_longitude": -72.093229,
+            "extracted_on": "2022-03-16T17:27:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://web.mta.info/developers/data/mnr/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-ny-waterway-shore-line-east-metro-north-railroad-mnr-hudson-rail-link-gtfs-524.zip?alt=media",
+        "license": "http://web.mta.info/developers/developer-data-terms.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-nyc-ferry-gtfs-515.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-nyc-ferry-gtfs-515.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 515,
+    "data_type": "gtfs",
+    "provider": "NYC Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.566157,
+            "maximum_latitude": 40.805455,
+            "minimum_longitude": -74.074171,
+            "maximum_longitude": -73.769134,
+            "extracted_on": "2022-03-16T17:26:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://nycferry.connexionz.net/rtt/public/utility/gtfs.aspx",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-nyc-ferry-gtfs-515.zip?alt=media",
+        "license": "https://www.ferry.nyc/developer-tools/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-rochester-genesee-regional-transportation-authority-rgrta-gtfs-533.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-rochester-genesee-regional-transportation-authority-rgrta-gtfs-533.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 533,
+    "data_type": "gtfs",
+    "provider": "Rochester-Genesee Regional Transportation Authority (RGRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Rochester",
+        "bounding_box": {
+            "minimum_latitude": 42.526438,
+            "maximum_latitude": 43.297343,
+            "minimum_longitude": -78.141093,
+            "maximum_longitude": -76.99341,
+            "extracted_on": "2022-03-16T17:27:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://scheduledata.rgrta.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-rochester-genesee-regional-transportation-authority-rgrta-gtfs-533.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-staten-island-ferry-gtfs-518.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-staten-island-ferry-gtfs-518.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 518,
+    "data_type": "gtfs",
+    "provider": "Staten Island Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.644169,
+            "maximum_latitude": 40.70136,
+            "minimum_longitude": -74.072201,
+            "maximum_longitude": -74.012666,
+            "extracted_on": "2022-03-16T17:26:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.nyc.gov/html/dot/downloads/misc/siferry-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-staten-island-ferry-gtfs-518.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-suffolk-county-transit-gtfs-548.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-suffolk-county-transit-gtfs-548.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 548,
+    "data_type": "gtfs",
+    "provider": "Suffolk County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 40.623699,
+            "maximum_latitude": 41.155227,
+            "minimum_longitude": -73.437479,
+            "maximum_longitude": -71.859667,
+            "extracted_on": "2022-03-16T17:28:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.suffolkcountyny.gov/Portals/0/formsdocs/publicworks/Zip/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-suffolk-county-transit-gtfs-548.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-tompkins-consolidated-area-transit-inc-gtfs-535.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-tompkins-consolidated-area-transit-inc-gtfs-535.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 535,
+    "data_type": "gtfs",
+    "provider": "Tompkins Consolidated Area Transit Inc",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Ithaca",
+        "bounding_box": {
+            "minimum_latitude": 42.3278999329,
+            "maximum_latitude": 42.590713501,
+            "minimum_longitude": -76.678131,
+            "maximum_longitude": -76.280907,
+            "extracted_on": "2022-03-16T17:27:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/tcat-gtfs/tcat-ny-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-tompkins-consolidated-area-transit-inc-gtfs-535.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-ulster-county-area-transit-gtfs-526.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-ulster-county-area-transit-gtfs-526.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 526,
+    "data_type": "gtfs",
+    "provider": "Ulster County Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Poughkeepsie",
+        "bounding_box": {
+            "minimum_latitude": 41.49979,
+            "maximum_latitude": 42.14243,
+            "minimum_longitude": -74.50313,
+            "maximum_longitude": -73.9284,
+            "extracted_on": "2022-03-16T17:27:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/UCAT_Ulster_County_Area_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-ulster-county-area-transit-gtfs-526.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-westchester-county-bee-line-system-wcdot-gtfs-527.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-westchester-county-bee-line-system-wcdot-gtfs-527.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 527,
+    "data_type": "gtfs",
+    "provider": "Westchester County Bee-Line System (WCDOT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "White Plains",
+        "bounding_box": {
+            "minimum_latitude": 40.74128,
+            "maximum_latitude": 41.421923,
+            "minimum_longitude": -73.989067,
+            "maximum_longitude": -73.659724,
+            "extracted_on": "2022-03-16T17:27:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Westchester_County_Bee-Line_System.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-westchester-county-bee-line-system-wcdot-gtfs-527.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-capital-area-transit-goraleigh-gtfs-471.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-capital-area-transit-goraleigh-gtfs-471.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 471,
+    "data_type": "gtfs",
+    "provider": "Capital Area Transit (GoRaleigh)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Raleigh",
+        "bounding_box": {
+            "minimum_latitude": 35.573104,
+            "maximum_latitude": 35.990455,
+            "minimum_longitude": -78.80199,
+            "maximum_longitude": -78.323486,
+            "extracted_on": "2022-03-16T17:23:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/capital-area-transit-nc-us/capital-area-transit-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-capital-area-transit-goraleigh-gtfs-471.zip?alt=media",
+        "license": "https://goraleigh.org/developer-terms-and-conditions"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-tar-river-transit-gtfs-472.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-tar-river-transit-gtfs-472.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 472,
+    "data_type": "gtfs",
+    "provider": "Tar River Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Rocky Mount",
+        "bounding_box": {
+            "minimum_latitude": 35.9165111341703,
+            "maximum_latitude": 36.0626996354895,
+            "minimum_longitude": -77.8990993389975,
+            "maximum_longitude": -77.745024054245,
+            "extracted_on": "2022-03-16T17:23:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/tarriver-nc-us/tarriver-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-tar-river-transit-gtfs-472.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-lehigh-and-northampton-transportation-authority-lanta-gtfs-506.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-lehigh-and-northampton-transportation-authority-lanta-gtfs-506.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 506,
+    "data_type": "gtfs",
+    "provider": "Lehigh and Northampton Transportation Authority (LANTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Allentown",
+        "bounding_box": {
+            "minimum_latitude": 40.527096,
+            "maximum_latitude": 40.884444,
+            "minimum_longitude": -75.659283,
+            "maximum_longitude": -75.204932,
+            "extracted_on": "2022-03-16T17:25:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/LANTA-Transportation-Authority/GTFS-data/raw/master/lanta_gtfs_feed.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-lehigh-and-northampton-transportation-authority-lanta-gtfs-506.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-monroe-county-transportation-authority-mcta-gtfs-523.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-monroe-county-transportation-authority-mcta-gtfs-523.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 523,
+    "data_type": "gtfs",
+    "provider": "Monroe County Transportation Authority (MCTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "bounding_box": {
+            "minimum_latitude": 40.9825553894,
+            "maximum_latitude": 41.2190895081,
+            "minimum_longitude": -75.427269,
+            "maximum_longitude": -75.155083,
+            "extracted_on": "2022-03-16T17:27:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.gomcta.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-monroe-county-transportation-authority-mcta-gtfs-523.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-rabbit-transit-gtfs-499.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-rabbit-transit-gtfs-499.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 499,
+    "data_type": "gtfs",
+    "provider": "Rabbit Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "York",
+        "bounding_box": {
+            "minimum_latitude": 39.39941459,
+            "maximum_latitude": 40.29388372,
+            "minimum_longitude": -77.27423287,
+            "maximum_longitude": -76.50190692,
+            "extracted_on": "2022-03-16T17:24:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.rabbittransit.org/infopoint/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-rabbit-transit-gtfs-499.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-southeastern-pennsylvania-transportation-authority-gtfs-502.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-southeastern-pennsylvania-transportation-authority-gtfs-502.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 502,
+    "data_type": "gtfs",
+    "provider": "Southeastern Pennsylvania Transportation Authority",
+    "name": "SEPTA",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Philadelphia",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T17:25:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/septadev/GTFS/releases/download/v202106061/gtfs_public.zip#google_bus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-southeastern-pennsylvania-transportation-authority-gtfs-502.zip?alt=media",
+        "license": "http://www3.septa.org/developer/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-southeastern-pennsylvania-transportation-authority-gtfs-503.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-southeastern-pennsylvania-transportation-authority-gtfs-503.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 503,
+    "data_type": "gtfs",
+    "provider": "Southeastern Pennsylvania Transportation Authority",
+    "name": "SEPTA",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Philadelphia",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T17:25:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/septadev/GTFS/releases/download/v202106061/gtfs_public.zip#google_rail.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-southeastern-pennsylvania-transportation-authority-gtfs-503.zip?alt=media",
+        "license": "http://www3.septa.org/developer/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-rhode-island-block-island-ferry-gtfs-554.json
+++ b/catalogs/sources/gtfs/schedule/us-rhode-island-block-island-ferry-gtfs-554.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 554,
+    "data_type": "gtfs",
+    "provider": "Block Island Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Rhode Island",
+        "municipality": "Newport",
+        "bounding_box": {
+            "minimum_latitude": 41.1737044812591,
+            "maximum_latitude": 41.704592042552,
+            "minimum_longitude": -71.5566758629379,
+            "maximum_longitude": -71.164247226387,
+            "extracted_on": "2022-03-16T17:28:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/blockislandferry-ri-us/blockislandferry-ri-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-rhode-island-block-island-ferry-gtfs-554.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-addison-county-transit-actr-gtfs-543.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-addison-county-transit-actr-gtfs-543.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 543,
+    "data_type": "gtfs",
+    "provider": "Addison County Transit (ACTR)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Burlington",
+        "bounding_box": {
+            "minimum_latitude": 43.607222,
+            "maximum_latitude": 44.480452,
+            "minimum_longitude": -73.262769,
+            "maximum_longitude": -72.9503,
+            "extracted_on": "2022-03-16T17:28:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/addisoncounty-vt-us/addisoncounty-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-addison-county-transit-actr-gtfs-543.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-green-mountain-community-network-gmcn-gtfs-539.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-green-mountain-community-network-gmcn-gtfs-539.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 539,
+    "data_type": "gtfs",
+    "provider": "Green Mountain Community Network (GMCN)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Bennington",
+        "bounding_box": {
+            "minimum_latitude": 42.69515,
+            "maximum_latitude": 43.188563940883,
+            "minimum_longitude": -73.247172,
+            "maximum_longitude": -72.8519291383657,
+            "extracted_on": "2022-03-16T17:27:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/greenmtncn-vt-us/greenmtncn-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-green-mountain-community-network-gmcn-gtfs-539.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-lake-champlain-ferries-gtfs-547.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-lake-champlain-ferries-gtfs-547.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 547,
+    "data_type": "gtfs",
+    "provider": "Lake Champlain Ferries",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Burlington",
+        "bounding_box": {
+            "minimum_latitude": 44.301404212561,
+            "maximum_latitude": 44.699028441487,
+            "minimum_longitude": -73.403367449566,
+            "maximum_longitude": -73.2212047725063,
+            "extracted_on": "2022-03-16T17:28:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lctferries-vt-us/lctferries-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-lake-champlain-ferries-gtfs-547.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-alexandria-transit-company-dash-gtfs-482.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-alexandria-transit-company-dash-gtfs-482.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 482,
+    "data_type": "gtfs",
+    "provider": "Alexandria Transit Company (DASH)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Alexandria",
+        "bounding_box": {
+            "minimum_latitude": 38.797661,
+            "maximum_latitude": 38.869018,
+            "minimum_longitude": -77.142937,
+            "maximum_longitude": -77.040077,
+            "extracted_on": "2022-03-16T17:24:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://dashbus.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-alexandria-transit-company-dash-gtfs-482.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-arlington-transit-gtfs-485.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-arlington-transit-gtfs-485.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 485,
+    "data_type": "gtfs",
+    "provider": "Arlington Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Arlington",
+        "bounding_box": {
+            "minimum_latitude": 38.8394,
+            "maximum_latitude": 38.925182,
+            "minimum_longitude": -77.162273,
+            "maximum_longitude": -77.049105,
+            "extracted_on": "2022-03-16T17:24:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://realtime.commuterpage.com/rtt/public/utility/gtfs.aspx",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-arlington-transit-gtfs-485.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-fairfax-connector-gtfs-483.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-fairfax-connector-gtfs-483.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 483,
+    "data_type": "gtfs",
+    "provider": "Fairfax Connector",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Fairfax",
+        "bounding_box": {
+            "minimum_latitude": 38.68777,
+            "maximum_latitude": 39.013594,
+            "minimum_longitude": -77.465336,
+            "maximum_longitude": -77.023716,
+            "extracted_on": "2022-03-16T17:24:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.fairfaxcounty.gov/connector/sites/connector/files/Assets/connector_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-fairfax-connector-gtfs-483.zip?alt=media",
+        "license": "https://www.fairfaxcounty.gov/connector/bustracker/data"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-fairfax-cue-bus-cue-gtfs-484.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-fairfax-cue-bus-cue-gtfs-484.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 484,
+    "data_type": "gtfs",
+    "provider": "Fairfax CUE Bus (CUE)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Fairfax",
+        "bounding_box": {
+            "minimum_latitude": 38.834623,
+            "maximum_latitude": 38.878837,
+            "minimum_longitude": -77.3328054577,
+            "maximum_longitude": -77.2623,
+            "extracted_on": "2022-03-16T17:24:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.fairfaxva.gov/Home/ShowDocument?id=6713",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-fairfax-cue-bus-cue-gtfs-484.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-hampton-roads-transit-hrt-gtfs-473.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-hampton-roads-transit-hrt-gtfs-473.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 473,
+    "data_type": "gtfs",
+    "provider": "Hampton Roads Transit (HRT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Hampton",
+        "bounding_box": {
+            "minimum_latitude": 36.709858,
+            "maximum_latitude": 37.286199,
+            "minimum_longitude": -76.708169,
+            "maximum_longitude": -75.972374,
+            "extracted_on": "2022-03-16T17:23:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://googletf.gohrt.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-hampton-roads-transit-hrt-gtfs-473.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-potomac-and-rappahannock-transportation-commission-prtc-gtfs-481.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-potomac-and-rappahannock-transportation-commission-prtc-gtfs-481.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 481,
+    "data_type": "gtfs",
+    "provider": "Potomac and Rappahannock Transportation Commission (PRTC)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Woodbridge",
+        "bounding_box": {
+            "minimum_latitude": 38.475418,
+            "maximum_latitude": 38.931923,
+            "minimum_longitude": -77.637254,
+            "maximum_longitude": -76.992477,
+            "extracted_on": "2022-03-16T17:24:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.prtctransit.org/feeds/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-potomac-and-rappahannock-transportation-commission-prtc-gtfs-481.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-virginia-railway-express-vre-gtfs-478.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-virginia-railway-express-vre-gtfs-478.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 478,
+    "data_type": "gtfs",
+    "provider": "Virginia Railway Express (VRE)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "bounding_box": {
+            "minimum_latitude": 38.22099,
+            "maximum_latitude": 38.89955,
+            "minimum_longitude": -77.52548,
+            "maximum_longitude": -77.00472,
+            "extracted_on": "2022-03-16T17:24:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.vre.org/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-virginia-railway-express-vre-gtfs-478.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.json
@@ -18,4 +18,4 @@
         "direct_download": "http://www.gowata.org/DocumentCenter/View/500",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.zip?alt=media"
     }
-} 
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 474,
+    "data_type": "gtfs",
+    "provider": "Williamsburg Area Transit Authority (WATA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Williamsburg",
+        "bounding_box": {
+            "minimum_latitude": 37.19292,
+            "maximum_latitude": 37.41068,
+            "minimum_longitude": -76.82154,
+            "maximum_longitude": -76.51867,
+            "extracted_on": "2022-03-16T17:23:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.gowata.org/DocumentCenter/View/500",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.json
@@ -18,4 +18,4 @@
         "direct_download": "http://www.gowata.org/DocumentCenter/View/500",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-williamsburg-area-transit-authority-wata-gtfs-474.zip?alt=media"
     }
-}
+} 


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the seventh part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 92 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~