### PR TITLE
feat: Truncate strings on the first comma to create filename/latest URL

### DIFF
--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -171,6 +171,7 @@ def create_filename(
 
 
 def normalize(string):
+    string = string.split(",")[0]
     string = "-".join(
         ("".join(s for s in string.lower() if s.isalnum() or s in [" ", "-"])).split()
     )

--- a/tools/tests/test_helpers.py
+++ b/tools/tests/test_helpers.py
@@ -274,6 +274,10 @@ class TestCreationFunctions(TestCase):
         under_test = normalize(test_string)
         self.assertEqual(under_test, "source-co-coa-co-caa")
 
+        test_string = "Source provider,, another, , pro"
+        under_test = normalize(test_string)
+        self.assertEqual(under_test, "source-provider")
+
     @freeze_time("2022-01-01")
     def test_get_iso_time(self):
         test_time = "2022-01-01T00:00:00+00:00"


### PR DESCRIPTION
**Summary:**

Fixes #74: Truncating JSON file name (setting limits on provider input)

This PR updates the string normalizer function to truncate the string after the first comma.

Changes:

- `helpers.py` to update `normalize()`

**Expected behavior:** 

The `filename` and latest_url of a source will be created with only the first part of a given string (eg. provider).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~