### PR TITLE
feat: Eighth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-arizona-roadrunner-gtfs-644.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-roadrunner-gtfs-644.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 644,
+    "data_type": "gtfs",
+    "provider": "RoadRunner",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Sedona",
+        "bounding_box": {
+            "minimum_latitude": 35.15968333,
+            "maximum_latitude": 35.33031,
+            "minimum_longitude": -111.719754,
+            "maximum_longitude": -111.5733528,
+            "extracted_on": "2022-03-16T20:12:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/naipta-az-us/naipta-az-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-roadrunner-gtfs-644.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-alcatraz-cruises-hornblower-gtfs-595.json
+++ b/catalogs/sources/gtfs/schedule/us-california-alcatraz-cruises-hornblower-gtfs-595.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 595,
+    "data_type": "gtfs",
+    "provider": "Alcatraz Cruises - Hornblower, Angel Island Tiburon Ferry, Blue & Gold Fleet",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.795497,
+            "maximum_latitude": 37.872939,
+            "minimum_longitude": -122.478275,
+            "maximum_longitude": -122.393365,
+            "extracted_on": "2022-03-16T20:10:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bayareaferries-ca-us/bayareaferries-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-alcatraz-cruises-hornblower-gtfs-595.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-blue-lake-rancheria-transit-system-gtfs-598.json
+++ b/catalogs/sources/gtfs/schedule/us-california-blue-lake-rancheria-transit-system-gtfs-598.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 598,
+    "data_type": "gtfs",
+    "provider": "Blue Lake Rancheria Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Blue Lake",
+        "bounding_box": {
+            "minimum_latitude": 40.0680453004959,
+            "maximum_latitude": 41.061448107054,
+            "minimum_longitude": -124.223416986081,
+            "maximum_longitude": -123.631606,
+            "extracted_on": "2022-03-16T20:10:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/blue-lake-rancheria-transit-system/1142/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-blue-lake-rancheria-transit-system-gtfs-598.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-city-coach-gtfs-599.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-coach-gtfs-599.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 599,
+    "data_type": "gtfs",
+    "provider": "City Coach",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Vacaville",
+        "bounding_box": {
+            "minimum_latitude": 38.32518498,
+            "maximum_latitude": 38.3978029,
+            "minimum_longitude": -122.00789,
+            "maximum_longitude": -121.93363,
+            "extracted_on": "2022-03-16T20:10:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/vacavillecitycoach-ca-us/vacavillecitycoach-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-coach-gtfs-599.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-get-around-town-express-gtfs-606.json
+++ b/catalogs/sources/gtfs/schedule/us-california-get-around-town-express-gtfs-606.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 606,
+    "data_type": "gtfs",
+    "provider": "Get Around Town Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.9159852759617,
+            "maximum_latitude": 33.9592318964122,
+            "minimum_longitude": -118.225215727351,
+            "maximum_longitude": -118.163997470108,
+            "extracted_on": "2022-03-16T20:10:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/getaroundtownexpress-ca-us/getaroundtownexpress-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-get-around-town-express-gtfs-606.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-glendora-transportation-division-gtfs-609.json
+++ b/catalogs/sources/gtfs/schedule/us-california-glendora-transportation-division-gtfs-609.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 609,
+    "data_type": "gtfs",
+    "provider": "Glendora Transportation Division",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 34.0833929992766,
+            "maximum_latitude": 34.1468809776457,
+            "minimum_longitude": -117.89009,
+            "maximum_longitude": -117.838194,
+            "extracted_on": "2022-03-16T20:10:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/glendora-ca-us/glendora-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-glendora-transportation-division-gtfs-609.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-go-west-shuttle-gtfs-623.json
+++ b/catalogs/sources/gtfs/schedule/us-california-go-west-shuttle-gtfs-623.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 623,
+    "data_type": "gtfs",
+    "provider": "Go West Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 34.0022032814329,
+            "maximum_latitude": 34.0868832783108,
+            "minimum_longitude": -117.954219468385,
+            "maximum_longitude": -117.872601420076,
+            "extracted_on": "2022-03-16T20:11:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/westcovina-ca-us/westcovina-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-go-west-shuttle-gtfs-623.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-gtrans-gtfs-616.json
+++ b/catalogs/sources/gtfs/schedule/us-california-gtrans-gtfs-616.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 616,
+    "data_type": "gtfs",
+    "provider": "GTrans",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Gardena",
+        "bounding_box": {
+            "minimum_latitude": 33.789348268787,
+            "maximum_latitude": 34.051940409636,
+            "minimum_longitude": -118.37830550252,
+            "maximum_longitude": -118.223107,
+            "extracted_on": "2022-03-16T20:11:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/gtrans-ca-us/gtrans-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-gtrans-gtfs-616.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-guadalupe-flyer-gtfs-617.json
+++ b/catalogs/sources/gtfs/schedule/us-california-guadalupe-flyer-gtfs-617.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 617,
+    "data_type": "gtfs",
+    "provider": "Guadalupe Flyer",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 34.946112429823,
+            "maximum_latitude": 34.9711071914409,
+            "minimum_longitude": -120.589191040142,
+            "maximum_longitude": -120.43050668825,
+            "extracted_on": "2022-03-16T20:11:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/guadalupeflyer-ca-us/guadalupeflyer-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-guadalupe-flyer-gtfs-617.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-huntington-park-express-gtfs-558.json
+++ b/catalogs/sources/gtfs/schedule/us-california-huntington-park-express-gtfs-558.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 558,
+    "data_type": "gtfs",
+    "provider": "Huntington Park Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Huntington Park",
+        "bounding_box": {
+            "minimum_latitude": 33.9633554216803,
+            "maximum_latitude": 33.9891364484214,
+            "minimum_longitude": -118.238692091684,
+            "maximum_longitude": -118.192457392484,
+            "extracted_on": "2022-03-16T20:09:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/huntingtonpark-ca-us/huntingtonpark-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-huntington-park-express-gtfs-558.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-la-campana-gtfs-562.json
+++ b/catalogs/sources/gtfs/schedule/us-california-la-campana-gtfs-562.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 562,
+    "data_type": "gtfs",
+    "provider": "La Campana",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.9653511222492,
+            "maximum_latitude": 33.9824536922432,
+            "minimum_longitude": -118.202539281078,
+            "maximum_longitude": -118.164965,
+            "extracted_on": "2022-03-16T20:09:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lacampana-ca-us/lacampana-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-la-campana-gtfs-562.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-la-puente-link-gtfs-563.json
+++ b/catalogs/sources/gtfs/schedule/us-california-la-puente-link-gtfs-563.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 563,
+    "data_type": "gtfs",
+    "provider": "La Puente LINK",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "La Puente",
+        "bounding_box": {
+            "minimum_latitude": 34.0093465695576,
+            "maximum_latitude": 34.0554403598575,
+            "minimum_longitude": -117.980788784323,
+            "maximum_longitude": -117.924657370715,
+            "extracted_on": "2022-03-16T20:09:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lapuente-ca-us/lapuente-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-la-puente-link-gtfs-563.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-los-angeles-county-shuttles-gtfs-561.json
+++ b/catalogs/sources/gtfs/schedule/us-california-los-angeles-county-shuttles-gtfs-561.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 561,
+    "data_type": "gtfs",
+    "provider": "Los Angeles County Shuttles",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T20:09:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gitlab.com/LACMTA/gtfs_lax/-/archive/master/gtfs_lax-master.zip?path=la_county",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-los-angeles-county-shuttles-gtfs-561.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-lynwood-trolley-breeze-gtfs-570.json
+++ b/catalogs/sources/gtfs/schedule/us-california-lynwood-trolley-breeze-gtfs-570.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 570,
+    "data_type": "gtfs",
+    "provider": "Lynwood Trolley / Breeze",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.9076946648605,
+            "maximum_latitude": 33.9452214237674,
+            "minimum_longitude": -118.239279931577,
+            "maximum_longitude": -118.180320930699,
+            "extracted_on": "2022-03-16T20:09:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lynwood-ca-us/lynwood-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-lynwood-trolley-breeze-gtfs-570.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-madera-county-transit-gtfs-572.json
+++ b/catalogs/sources/gtfs/schedule/us-california-madera-county-transit-gtfs-572.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 572,
+    "data_type": "gtfs",
+    "provider": "Madera County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Madera",
+        "bounding_box": {
+            "minimum_latitude": 36.8516460649093,
+            "maximum_latitude": 37.337971,
+            "minimum_longitude": -120.275078,
+            "maximum_longitude": -119.497243593285,
+            "extracted_on": "2022-03-16T20:09:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/maderactc-ca-us/maderactc-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-madera-county-transit-gtfs-572.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-montebello-bus-lines-gtfs-577.json
+++ b/catalogs/sources/gtfs/schedule/us-california-montebello-bus-lines-gtfs-577.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 577,
+    "data_type": "gtfs",
+    "provider": "Montebello Bus Lines",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Montebello",
+        "bounding_box": {
+            "minimum_latitude": 33.891737,
+            "maximum_latitude": 34.1110781039375,
+            "minimum_longitude": -118.266356,
+            "maximum_longitude": -117.994749,
+            "extracted_on": "2022-03-16T20:09:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/montebello-ca-us/montebello-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-montebello-bus-lines-gtfs-577.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-moorpark-city-transit-gtfs-578.json
+++ b/catalogs/sources/gtfs/schedule/us-california-moorpark-city-transit-gtfs-578.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 578,
+    "data_type": "gtfs",
+    "provider": "Moorpark City Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Moorpark",
+        "bounding_box": {
+            "minimum_latitude": 34.26332,
+            "maximum_latitude": 34.3020749386964,
+            "minimum_longitude": -118.90097,
+            "maximum_longitude": -118.835209,
+            "extracted_on": "2022-03-16T20:09:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/moorparkcitytransit-ca-us/moorparkcitytransit-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-moorpark-city-transit-gtfs-578.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-morongo-basin-transit-authority-gtfs-579.json
+++ b/catalogs/sources/gtfs/schedule/us-california-morongo-basin-transit-authority-gtfs-579.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 579,
+    "data_type": "gtfs",
+    "provider": "Morongo Basin Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Palm Springs",
+        "bounding_box": {
+            "minimum_latitude": 33.823284,
+            "maximum_latitude": 34.266281881282,
+            "minimum_longitude": -116.583611,
+            "maximum_longitude": -116.036545,
+            "extracted_on": "2022-03-16T20:09:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/morongobasin-ca-us/morongobasin-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-morongo-basin-transit-authority-gtfs-579.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-needles-area-transit-gtfs-583.json
+++ b/catalogs/sources/gtfs/schedule/us-california-needles-area-transit-gtfs-583.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 583,
+    "data_type": "gtfs",
+    "provider": "Needles Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Needles",
+        "bounding_box": {
+            "minimum_latitude": 34.821873,
+            "maximum_latitude": 34.851116701061,
+            "minimum_longitude": -114.62423844998,
+            "maximum_longitude": -114.595169,
+            "extracted_on": "2022-03-16T20:10:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/needles-ca-us/needles-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-needles-area-transit-gtfs-583.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-juan-capistrano-free-weekend-trolley-gtfs-596.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-juan-capistrano-free-weekend-trolley-gtfs-596.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 596,
+    "data_type": "gtfs",
+    "provider": "San Juan Capistrano Free Weekend Trolley",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 33.473604,
+            "maximum_latitude": 33.507589,
+            "minimum_longitude": -117.685329157228,
+            "maximum_longitude": -117.662424646365,
+            "extracted_on": "2022-03-16T20:10:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sanjuancapistrano-ca-us/sanjuancapistrano-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-juan-capistrano-free-weekend-trolley-gtfs-596.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-tulare-county-area-transit-gtfs-646.json
+++ b/catalogs/sources/gtfs/schedule/us-california-tulare-county-area-transit-gtfs-646.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 646,
+    "data_type": "gtfs",
+    "provider": "Tulare County Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Tulare",
+        "bounding_box": {
+            "minimum_latitude": 35.761867,
+            "maximum_latitude": 36.545631,
+            "minimum_longitude": -119.486362,
+            "maximum_longitude": -118.815159,
+            "extracted_on": "2022-03-16T20:12:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/tcat-flex-ca-us/tcat-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-tulare-county-area-transit-gtfs-646.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-turlock-transit-gtfs-619.json
+++ b/catalogs/sources/gtfs/schedule/us-california-turlock-transit-gtfs-619.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 619,
+    "data_type": "gtfs",
+    "provider": "Turlock Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Turlock",
+        "bounding_box": {
+            "minimum_latitude": 37.47806,
+            "maximum_latitude": 37.52925,
+            "minimum_longitude": -120.88435,
+            "maximum_longitude": -120.83076,
+            "extracted_on": "2022-03-16T20:11:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/turlock-ca-us/turlock-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-turlock-transit-gtfs-619.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-union-city-transit-gtfs-628.json
+++ b/catalogs/sources/gtfs/schedule/us-california-union-city-transit-gtfs-628.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 628,
+    "data_type": "gtfs",
+    "provider": "Union City Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 37.567764,
+            "maximum_latitude": 37.612185,
+            "minimum_longitude": -122.082768,
+            "maximum_longitude": -122.002866,
+            "extracted_on": "2022-03-16T20:11:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/unioncity-ca-us/unioncity-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-union-city-transit-gtfs-628.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-west-berkeley-shuttle-gtfs-622.json
+++ b/catalogs/sources/gtfs/schedule/us-california-west-berkeley-shuttle-gtfs-622.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 622,
+    "data_type": "gtfs",
+    "provider": "West Berkeley Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Berkeley",
+        "bounding_box": {
+            "minimum_latitude": 37.8513586852571,
+            "maximum_latitude": 37.859964149085,
+            "minimum_longitude": -122.295178114587,
+            "maximum_longitude": -122.270110040259,
+            "extracted_on": "2022-03-16T20:11:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/westberkeleyshuttle-ca-us/westberkeleyshuttle-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-west-berkeley-shuttle-gtfs-622.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-greeley-evans-transit-get-gtfs-612.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-greeley-evans-transit-get-gtfs-612.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 612,
+    "data_type": "gtfs",
+    "provider": "Greeley-Evans Transit (GET)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Greeley",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T20:10:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://nextcloud.greeleygov.com/index.php/s/yf5gysdomcLyCib/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-greeley-evans-transit-get-gtfs-612.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-home-james-gtfs-607.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-home-james-gtfs-607.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 607,
+    "data_type": "gtfs",
+    "provider": "Home James",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Boulder",
+        "bounding_box": {
+            "minimum_latitude": 39.8475614987303,
+            "maximum_latitude": 40.2570157561979,
+            "minimum_longitude": -105.939539015688,
+            "maximum_longitude": -104.672864277409,
+            "extracted_on": "2022-03-16T20:10:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/homejames-co-us/homejames-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-home-james-gtfs-607.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-mountain-express-mtnexp-gtfs-581.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-mountain-express-mtnexp-gtfs-581.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 581,
+    "data_type": "gtfs",
+    "provider": "Mountain Express (MtnExp)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Crested Butte",
+        "bounding_box": {
+            "minimum_latitude": 38.866968,
+            "maximum_latitude": 38.957698,
+            "minimum_longitude": -106.988743,
+            "maximum_longitude": -106.959567,
+            "extracted_on": "2022-03-16T20:10:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/cb_mtnexpress_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-mountain-express-mtnexp-gtfs-581.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-national-park-service-gtfs-627.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-national-park-service-gtfs-627.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 627,
+    "data_type": "gtfs",
+    "provider": "National Park Service",
+    "name": "Rocky Mountain National Park Shuttles",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Boulder",
+        "bounding_box": {
+            "minimum_latitude": 40.310403,
+            "maximum_latitude": 40.378788,
+            "minimum_longitude": -105.6458,
+            "maximum_longitude": -105.513549,
+            "extracted_on": "2022-03-16T20:11:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://nationalparkservice.github.io/nps-gtfs/romo/shuttles/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-national-park-service-gtfs-627.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-town-of-mountain-village-gtfs-594.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-town-of-mountain-village-gtfs-594.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 594,
+    "data_type": "gtfs",
+    "provider": "Town of Mountain Village",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Town of Mountain Village",
+        "bounding_box": {
+            "minimum_latitude": 37.93133,
+            "maximum_latitude": 37.947176,
+            "minimum_longitude": -107.881954,
+            "maximum_longitude": -107.807134,
+            "extracted_on": "2022-03-16T20:10:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/mountainvillage-co-us/mountainvillage-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-town-of-mountain-village-gtfs-594.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-town-of-telluride-gtfs-603.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-town-of-telluride-gtfs-603.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 603,
+    "data_type": "gtfs",
+    "provider": "Town of Telluride",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Montrose",
+        "bounding_box": {
+            "minimum_latitude": 37.93503,
+            "maximum_latitude": 37.94021,
+            "minimum_longitude": -107.82207,
+            "maximum_longitude": -107.80002,
+            "extracted_on": "2022-03-16T20:10:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/telluride-co-us/telluride-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-town-of-telluride-gtfs-603.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-connecticut-transit-gtfs-597.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-connecticut-transit-gtfs-597.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 597,
+    "data_type": "gtfs",
+    "provider": "Connecticut Transit",
+    "name": "Hartford Line - Rail",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "bounding_box": {
+            "minimum_latitude": 41.29732995,
+            "maximum_latitude": 42.1063349,
+            "minimum_longitude": -72.92619467,
+            "maximum_longitude": -72.5933969,
+            "extracted_on": "2022-03-16T20:10:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.hartfordline.com/files/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-connecticut-transit-gtfs-597.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-middletown-area-transit-gtfs-576.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-middletown-area-transit-gtfs-576.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 576,
+    "data_type": "gtfs",
+    "provider": "Middletown Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "bounding_box": {
+            "minimum_latitude": 41.5034374574747,
+            "maximum_latitude": 41.6087292654757,
+            "minimum_longitude": -72.809799,
+            "maximum_longitude": -72.4877517383079,
+            "extracted_on": "2022-03-16T20:09:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/middletown-ct-us/middletown-ct-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-middletown-area-transit-gtfs-576.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-citrus-county-transit-gtfs-630.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-citrus-county-transit-gtfs-630.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 630,
+    "data_type": "gtfs",
+    "provider": "Citrus County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Lecanto",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T20:11:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ftis.org/PostFileDownload.aspx?id=152A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-citrus-county-transit-gtfs-630.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-gowal-gtfs-610.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-gowal-gtfs-610.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 610,
+    "data_type": "gtfs",
+    "provider": "GoWal",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "bounding_box": {
+            "minimum_latitude": 30.3395255098718,
+            "maximum_latitude": 30.722111,
+            "minimum_longitude": -86.1807470036327,
+            "maximum_longitude": -86.1105577,
+            "extracted_on": "2022-03-16T20:10:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/gowal-fl-us/gowal-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-gowal-gtfs-610.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-manatee-county-area-transit-mcat-gtfs-643.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-manatee-county-area-transit-mcat-gtfs-643.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 643,
+    "data_type": "gtfs",
+    "provider": "Manatee County Area Transit (MCAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Bradenton",
+        "bounding_box": {
+            "minimum_latitude": 27.33753195,
+            "maximum_latitude": 27.81173,
+            "minimum_longitude": -82.780321,
+            "maximum_longitude": -82.45171619,
+            "extracted_on": "2022-03-16T20:12:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/manatee-fl-us/manatee-fl-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-manatee-county-area-transit-mcat-gtfs-643.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-sunrail-gtfs-626.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-sunrail-gtfs-626.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 626,
+    "data_type": "gtfs",
+    "provider": "SunRail",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "bounding_box": {
+            "minimum_latitude": 28.258907,
+            "maximum_latitude": 28.855694,
+            "minimum_longitude": -81.484367,
+            "maximum_longitude": -81.298115,
+            "extracted_on": "2022-03-16T20:11:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/florida-department-of-transportation/684/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-sunrail-gtfs-626.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-hawaii-hawaii-mass-transit-agency-hele-on-bus-gtfs-557.json
+++ b/catalogs/sources/gtfs/schedule/us-hawaii-hawaii-mass-transit-agency-hele-on-bus-gtfs-557.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 557,
+    "data_type": "gtfs",
+    "provider": "Hawai'i Mass Transit Agency (Hele-On Bus)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Hawaii",
+        "municipality": "Hawai'i Island",
+        "bounding_box": {
+            "minimum_latitude": 19.060278,
+            "maximum_latitude": 20.238104,
+            "minimum_longitude": -156.0404873,
+            "maximum_longitude": -154.8897767,
+            "extracted_on": "2022-03-16T20:09:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.heleonbus.org/transit-info-and-statistics/MTA_FEED4.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-hawaii-hawaii-mass-transit-agency-hele-on-bus-gtfs-557.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-interurban-trolley-gtfs-571.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-interurban-trolley-gtfs-571.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 571,
+    "data_type": "gtfs",
+    "provider": "Interurban Trolley",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "Indianapolis",
+        "bounding_box": {
+            "minimum_latitude": 41.554451,
+            "maximum_latitude": 41.739892,
+            "minimum_longitude": -86.180541,
+            "maximum_longitude": -85.789122,
+            "extracted_on": "2022-03-16T20:09:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://macog.com/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-interurban-trolley-gtfs-571.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-south-shore-line-gtfs-585.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-south-shore-line-gtfs-585.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 585,
+    "data_type": "gtfs",
+    "provider": "South Shore Line",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "South Bend",
+        "bounding_box": {
+            "minimum_latitude": 41.597858,
+            "maximum_latitude": 41.8841667,
+            "minimum_longitude": -87.6230556,
+            "maximum_longitude": -86.310951,
+            "extracted_on": "2022-03-16T20:10:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.mysouthshoreline.com/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-south-shore-line-gtfs-585.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-valparaiso-transit-gtfs-620.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-valparaiso-transit-gtfs-620.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 620,
+    "data_type": "gtfs",
+    "provider": "Valparaiso Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "Gary",
+        "bounding_box": {
+            "minimum_latitude": 41.4552612,
+            "maximum_latitude": 41.886761,
+            "minimum_longitude": -87.635139,
+            "maximum_longitude": -87.0139127,
+            "extracted_on": "2022-03-16T20:11:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/valpotransit-chi-us/valpotransit-chi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-valparaiso-transit-gtfs-620.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-iowa-city-transit-system-gtfs-559.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-iowa-city-transit-system-gtfs-559.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 559,
+    "data_type": "gtfs",
+    "provider": "Iowa City Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Iowa City",
+        "bounding_box": {
+            "minimum_latitude": 41.628025,
+            "maximum_latitude": 41.690047,
+            "minimum_longitude": -91.598839,
+            "maximum_longitude": -91.4688,
+            "extracted_on": "2022-03-16T20:09:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/iowacitytransit-ia-us/iowacitytransit-ia-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-iowa-city-transit-system-gtfs-559.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-metropolitan-transit-authority-of-black-hawk-county-gtfs-575.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-metropolitan-transit-authority-of-black-hawk-county-gtfs-575.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 575,
+    "data_type": "gtfs",
+    "provider": "Metropolitan Transit Authority of Black Hawk County",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Waterloo",
+        "bounding_box": {
+            "minimum_latitude": 42.429376,
+            "maximum_latitude": 42.539077,
+            "minimum_longitude": -92.473383,
+            "maximum_longitude": -92.298033,
+            "extracted_on": "2022-03-16T20:09:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mettransit.org/sites/default/files/MET_Transit_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-metropolitan-transit-authority-of-black-hawk-county-gtfs-575.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-harbor-connector-gtfs-618.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-harbor-connector-gtfs-618.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 618,
+    "data_type": "gtfs",
+    "provider": "Harbor Connector",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "municipality": "Baltimore",
+        "bounding_box": {
+            "minimum_latitude": 39.2759223488919,
+            "maximum_latitude": 39.2839428588262,
+            "minimum_longitude": -76.6070138686386,
+            "maximum_longitude": -76.5740556363514,
+            "extracted_on": "2022-03-16T20:11:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/harborconnector-md-us/harborconnector-md-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-harbor-connector-gtfs-618.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-bloom-tours-gtfs-592.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-bloom-tours-gtfs-592.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 592,
+    "data_type": "gtfs",
+    "provider": "Bloom Tours",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 41.900542,
+            "maximum_latitude": 42.350794,
+            "minimum_longitude": -71.100949,
+            "maximum_longitude": -71.048179,
+            "extracted_on": "2022-03-16T20:10:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.mass.gov/doc/bloom-tours-zip-file-6242015/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-bloom-tours-gtfs-592.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-cape-code-regional-transportation-authority-cape-cod-rta-gtfs-645.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-cape-code-regional-transportation-authority-cape-cod-rta-gtfs-645.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 645,
+    "data_type": "gtfs",
+    "provider": "Cape Code Regional Transportation Authority (Cape Cod RTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Cape Cod",
+        "bounding_box": {
+            "minimum_latitude": 41.52303,
+            "maximum_latitude": 42.0793734132862,
+            "minimum_longitude": -70.669797,
+            "maximum_longitude": -69.961949,
+            "extracted_on": "2022-03-16T20:12:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/capecod-ma-us/capecod-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-cape-code-regional-transportation-authority-cape-cod-rta-gtfs-645.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-logan-express-gtfs-601.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-logan-express-gtfs-601.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 601,
+    "data_type": "gtfs",
+    "provider": "Logan Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "municipality": "Boston",
+        "bounding_box": {
+            "minimum_latitude": 42.21736,
+            "maximum_latitude": 42.51759,
+            "minimum_longitude": -71.39341,
+            "maximum_longitude": -71.017076,
+            "extracted_on": "2022-03-16T20:10:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/loganexpress-ma-us/loganexpress-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-logan-express-gtfs-601.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-plymouth-brockton-street-railway-co-gtfs-556.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-plymouth-brockton-street-railway-co-gtfs-556.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 556,
+    "data_type": "gtfs",
+    "provider": "Plymouth & Brockton Street Railway Co",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 41.522486633975,
+            "maximum_latitude": 42.365821,
+            "minimum_longitude": -71.436908,
+            "maximum_longitude": -69.973627957113,
+            "extracted_on": "2022-03-16T20:09:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/plymouthbrockton-ma-us/plymouthbrockton-ma-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-plymouth-brockton-street-railway-co-gtfs-556.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-nebraska-omaha-metro-gtfs-587.json
+++ b/catalogs/sources/gtfs/schedule/us-nebraska-omaha-metro-gtfs-587.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 587,
+    "data_type": "gtfs",
+    "provider": "Omaha Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Nebraska",
+        "municipality": "Omaha",
+        "bounding_box": {
+            "minimum_latitude": 41.1405456595003,
+            "maximum_latitude": 41.345776,
+            "minimum_longitude": -96.196039,
+            "maximum_longitude": -95.89996,
+            "extracted_on": "2022-03-16T20:10:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/omaha-metro/TrapezeExport/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-nebraska-omaha-metro-gtfs-587.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-nevada-city-of-las-vegas-gtfs-565.json
+++ b/catalogs/sources/gtfs/schedule/us-nevada-city-of-las-vegas-gtfs-565.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 565,
+    "data_type": "gtfs",
+    "provider": "City of Las Vegas",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Nevada",
+        "municipality": "Las Vegas",
+        "bounding_box": {
+            "minimum_latitude": 36.1478325021643,
+            "maximum_latitude": 36.172628431689,
+            "minimum_longitude": -115.157172813709,
+            "maximum_longitude": -115.13942,
+            "extracted_on": "2022-03-16T20:09:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lasvegasloop-nv-us/lasvegasloop-nv-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-nevada-city-of-las-vegas-gtfs-565.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-new-jersey-transit-gtfs-641.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-new-jersey-transit-gtfs-641.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 641,
+    "data_type": "gtfs",
+    "provider": "New Jersey Transit ",
+    "name": "Rail",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Jersey",
+        "bounding_box": {
+            "minimum_latitude": 39.363299,
+            "maximum_latitude": 41.471784,
+            "minimum_longitude": -75.182327,
+            "maximum_longitude": -73.988331,
+            "extracted_on": "2022-03-16T20:11:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/nj-transit/408/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-jersey-new-jersey-transit-gtfs-641.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-north-central-regional-transit-district-ncrtd-gtfs-582.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-north-central-regional-transit-district-ncrtd-gtfs-582.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 582,
+    "data_type": "gtfs",
+    "provider": "North Central Regional Transit District (NCRTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "bounding_box": {
+            "minimum_latitude": 35.000311,
+            "maximum_latitude": 36.978963,
+            "minimum_longitude": -108.18002,
+            "maximum_longitude": -105.209957,
+            "extracted_on": "2022-03-16T20:10:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.ncrtd.org/wp-content/uploads/2021/05/gtfs-5.12.21.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-north-central-regional-transit-district-ncrtd-gtfs-582.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-roadrunner-transit-gtfs-564.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-roadrunner-transit-gtfs-564.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 564,
+    "data_type": "gtfs",
+    "provider": "RoadRUNNER Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "municipality": "Las Cruces",
+        "bounding_box": {
+            "minimum_latitude": 32.271352,
+            "maximum_latitude": 32.390319,
+            "minimum_longitude": -106.815623,
+            "maximum_longitude": -106.701135,
+            "extracted_on": "2022-03-16T20:09:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/lascrucesroadrunner_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-roadrunner-transit-gtfs-564.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-greene-county-transit-gtfs-613.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-greene-county-transit-gtfs-613.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 613,
+    "data_type": "gtfs",
+    "provider": "Greene County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 42.11024,
+            "maximum_latitude": 42.453165,
+            "minimum_longitude": -74.435418,
+            "maximum_longitude": -73.778373,
+            "extracted_on": "2022-03-16T20:10:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Greene_County_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-greene-county-transit-gtfs-613.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-herkimer-oneida-counties-transportation-study-hocts-gtfs-588.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-herkimer-oneida-counties-transportation-study-hocts-gtfs-588.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 588,
+    "data_type": "gtfs",
+    "provider": "Herkimer-Oneida Counties Transportation Study (HOCTS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Utica",
+        "bounding_box": {
+            "minimum_latitude": 42.307476,
+            "maximum_latitude": 44.163689,
+            "minimum_longitude": -77.884659,
+            "maximum_longitude": -74.752197,
+            "extracted_on": "2022-03-16T20:10:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Oneida_County_Rural_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-herkimer-oneida-counties-transportation-study-hocts-gtfs-588.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-lewis-county-public-transportation-gtfs-566.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-lewis-county-public-transportation-gtfs-566.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 566,
+    "data_type": "gtfs",
+    "provider": "Lewis County Public Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Lowville",
+        "bounding_box": {
+            "minimum_latitude": 43.076425,
+            "maximum_latitude": 44.043536,
+            "minimum_longitude": -75.951539,
+            "maximum_longitude": -74.968202,
+            "extracted_on": "2022-03-16T20:09:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Lewis_County.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-lewis-county-public-transportation-gtfs-566.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-madison-county-transit-gtfs-573.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-madison-county-transit-gtfs-573.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 573,
+    "data_type": "gtfs",
+    "provider": "Madison County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 42.682384,
+            "maximum_latitude": 43.156107,
+            "minimum_longitude": -75.969992,
+            "maximum_longitude": -75.457106,
+            "extracted_on": "2022-03-16T20:09:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Madison_Transit_Services.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-madison-county-transit-gtfs-573.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-newburgh-beacon-shuttle-leperchaun-lines-gtfs-584.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-newburgh-beacon-shuttle-leperchaun-lines-gtfs-584.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 584,
+    "data_type": "gtfs",
+    "provider": "Newburgh Beacon Shuttle (Leperchaun Lines)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Poughkeepsie",
+        "bounding_box": {
+            "minimum_latitude": 41.498394,
+            "maximum_latitude": 41.517948,
+            "minimum_longitude": -74.100904,
+            "maximum_longitude": -73.984502,
+            "extracted_on": "2022-03-16T20:10:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Newburgh_Beacon_Shuttle.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-newburgh-beacon-shuttle-leperchaun-lines-gtfs-584.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-olean-area-transit-system-gtfs-586.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-olean-area-transit-system-gtfs-586.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 586,
+    "data_type": "gtfs",
+    "provider": "Olean Area Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Olean",
+        "bounding_box": {
+            "minimum_latitude": 42.066323,
+            "maximum_latitude": 42.220286,
+            "minimum_longitude": -78.767734,
+            "maximum_longitude": -78.276716,
+            "extracted_on": "2022-03-16T20:10:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Olean_Area_Transit_System.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-olean-area-transit-system-gtfs-586.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-otsego-express-public-transportation-gtfs-589.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-otsego-express-public-transportation-gtfs-589.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 589,
+    "data_type": "gtfs",
+    "provider": "Otsego Express Public Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Cooperstown",
+        "bounding_box": {
+            "minimum_latitude": 42.296663,
+            "maximum_latitude": 42.883622,
+            "minimum_longitude": -75.414187,
+            "maximum_longitude": -74.671786,
+            "extracted_on": "2022-03-16T20:10:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Otsego_Express_Public_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-otsego-express-public-transportation-gtfs-589.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-charlotte-area-transit-system-cats-gtfs-640.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-charlotte-area-transit-system-cats-gtfs-640.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 640,
+    "data_type": "gtfs",
+    "provider": "Charlotte Area Transit System (CATS)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Charlotte",
+        "bounding_box": {
+            "minimum_latitude": 34.927049,
+            "maximum_latitude": 35.509161,
+            "minimum_longitude": -81.179888,
+            "maximum_longitude": -80.558109,
+            "extracted_on": "2022-03-16T20:11:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/charlotte-area-transit-system/1252/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-charlotte-area-transit-system-cats-gtfs-640.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-greensboro-transit-authority-gta-gtfs-615.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-greensboro-transit-authority-gta-gtfs-615.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 615,
+    "data_type": "gtfs",
+    "provider": "Greensboro Transit Authority (GTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Greensboro",
+        "bounding_box": {
+            "minimum_latitude": 35.997281,
+            "maximum_latitude": 36.147221,
+            "minimum_longitude": -79.918696,
+            "maximum_longitude": -79.725097,
+            "extracted_on": "2022-03-16T20:10:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://app.mecatran.com/urb/ws/feed/c2l0ZT1ncmVlbnNib3JvO2NsaWVudD1zZWxmO2V4cGlyZT07dHlwZT1ndGZzO2tleT00ZDQ3MDYyMjNiNjI3ZjFmMTU1YzFiNGIxNTY0Mzg0ZDFjNzYyOTQy",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-greensboro-transit-authority-gta-gtfs-615.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-canby-ferry-gtfs-605.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-canby-ferry-gtfs-605.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 605,
+    "data_type": "gtfs",
+    "provider": "Canby Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 45.2989871385735,
+            "maximum_latitude": 45.3010657654158,
+            "minimum_longitude": -122.692828552403,
+            "maximum_longitude": -122.692637681176,
+            "extracted_on": "2022-03-16T20:10:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/canbyferry-or-us/canbyferry-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-canby-ferry-gtfs-605.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-cascade-point-gtfs-639.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-cascade-point-gtfs-639.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 639,
+    "data_type": "gtfs",
+    "provider": "Cascade POINT",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Eugene",
+        "bounding_box": {
+            "minimum_latitude": 44.0428,
+            "maximum_latitude": 45.52899472,
+            "minimum_longitude": -123.102580956479,
+            "maximum_longitude": -122.5958316,
+            "extracted_on": "2022-03-16T20:11:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/cascadespoint-or-us/cascadespoint-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-cascade-point-gtfs-639.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-eastern-point-gtfs-632.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-eastern-point-gtfs-632.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 632,
+    "data_type": "gtfs",
+    "provider": "Eastern Point",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Ontario",
+        "bounding_box": {
+            "minimum_latitude": 43.54207602,
+            "maximum_latitude": 44.058021435071,
+            "minimum_longitude": -121.301143956693,
+            "maximum_longitude": -116.951137,
+            "extracted_on": "2022-03-16T20:11:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/easternpoint-or-us/easternpoint-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-eastern-point-gtfs-632.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-coos-bay-gtfs-634.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-coos-bay-gtfs-634.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 634,
+    "data_type": "gtfs",
+    "provider": "Eugene to Coos Bay",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Eugene",
+        "bounding_box": {
+            "minimum_latitude": 43.3690937400976,
+            "maximum_latitude": 44.291248,
+            "minimum_longitude": -124.213689565659,
+            "maximum_longitude": -116.958099,
+            "extracted_on": "2022-03-16T20:11:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/eugenetocoosbay-or-us/eugenetocoosbay-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-eugene-to-coos-bay-gtfs-634.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-high-desert-point-gtfs-636.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-high-desert-point-gtfs-636.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 636,
+    "data_type": "gtfs",
+    "provider": "High Desert Point",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Redmond",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T20:11:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/highdesertpoint-or-us/highdesertpoint-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-high-desert-point-gtfs-636.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-hut-airport-shuttle-gtfs-635.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-hut-airport-shuttle-gtfs-635.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 635,
+    "data_type": "gtfs",
+    "provider": "HUT Airport Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T20:11:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/hut-or-us/hut-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-hut-airport-shuttle-gtfs-635.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-klamath-shuttle-gtfs-560.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-klamath-shuttle-gtfs-560.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 560,
+    "data_type": "gtfs",
+    "provider": "Klamath Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Klamath Falls",
+        "bounding_box": {
+            "minimum_latitude": 42.225506,
+            "maximum_latitude": 42.91113,
+            "minimum_longitude": -122.144812,
+            "maximum_longitude": -121.771952,
+            "extracted_on": "2022-03-16T20:09:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://oregon-gtfs.com/gtfs_data/klamathshuttle-or-us/klamathshuttle-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-klamath-shuttle-gtfs-560.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-leter-bus-gtfs-590.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-leter-bus-gtfs-590.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 590,
+    "data_type": "gtfs",
+    "provider": "Let'er Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Pendleton",
+        "bounding_box": {
+            "minimum_latitude": 45.6451995398724,
+            "maximum_latitude": 45.6884126437407,
+            "minimum_longitude": -118.840975383736,
+            "maximum_longitude": -118.749787194685,
+            "extracted_on": "2022-03-16T20:10:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/pendleton-or-us/pendleton-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-leter-bus-gtfs-590.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-mt-hood-express-gtfs-600.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-mt-hood-express-gtfs-600.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 600,
+    "data_type": "gtfs",
+    "provider": "Mt Hood Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Sandy",
+        "bounding_box": {
+            "minimum_latitude": 45.285866,
+            "maximum_latitude": 45.502997144364,
+            "minimum_longitude": -122.427862,
+            "maximum_longitude": -121.7089955,
+            "extracted_on": "2022-03-16T20:10:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mt-hood-express/473/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-mt-hood-express-gtfs-600.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-northwest-point-gtfs-638.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-northwest-point-gtfs-638.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 638,
+    "data_type": "gtfs",
+    "provider": "NorthWest POINT",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Astoria",
+        "bounding_box": {
+            "minimum_latitude": 45.510194773438,
+            "maximum_latitude": 46.19021,
+            "minimum_longitude": -123.9618428,
+            "maximum_longitude": -122.676247358322,
+            "extracted_on": "2022-03-16T20:11:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/northwestpoint-or-us/northwestpoint-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-northwest-point-gtfs-638.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-southwest-point-gtfs-637.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-southwest-point-gtfs-637.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 637,
+    "data_type": "gtfs",
+    "provider": "SouthWest POINT",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Brookings",
+        "bounding_box": {
+            "minimum_latitude": 41.75243,
+            "maximum_latitude": 42.44289,
+            "minimum_longitude": -124.288308,
+            "maximum_longitude": -121.74456016694,
+            "extracted_on": "2022-03-16T20:11:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/southwestpoint-or-us/southwestpoint-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-southwest-point-gtfs-637.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-valley-retriever-busline-gtfs-633.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-valley-retriever-busline-gtfs-633.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 633,
+    "data_type": "gtfs",
+    "provider": "Valley Retriever Busline",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Newport",
+        "bounding_box": {
+            "minimum_latitude": 44.0579701022706,
+            "maximum_latitude": 45.5280202718972,
+            "minimum_longitude": -124.0604784,
+            "maximum_longitude": -121.300789117813,
+            "extracted_on": "2022-03-16T20:11:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/valleyretriever-or-us/valleyretriever-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-valley-retriever-busline-gtfs-633.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-rhode-island-rhode-island-public-transit-authority-gtfs-624.json
+++ b/catalogs/sources/gtfs/schedule/us-rhode-island-rhode-island-public-transit-authority-gtfs-624.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 624,
+    "data_type": "gtfs",
+    "provider": "Rhode Island Public Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Rhode Island",
+        "bounding_box": {
+            "minimum_latitude": 41.372687,
+            "maximum_latitude": 42.016993,
+            "minimum_longitude": -71.829808,
+            "maximum_longitude": -71.154292,
+            "extracted_on": "2022-03-16T20:11:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.ripta.com/wp-content/uploads/2022/01/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-rhode-island-rhode-island-public-transit-authority-gtfs-624.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-rhode-island-rhode-island-public-transit-authority-ripta-gtfs-642.json
+++ b/catalogs/sources/gtfs/schedule/us-rhode-island-rhode-island-public-transit-authority-ripta-gtfs-642.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 642,
+    "data_type": "gtfs",
+    "provider": "Rhode Island Public Transit Authority (RIPTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Rhode Island",
+        "municipality": "Providence",
+        "bounding_box": {
+            "minimum_latitude": 41.372687,
+            "maximum_latitude": 42.016993,
+            "minimum_longitude": -71.829808,
+            "maximum_longitude": -71.154292,
+            "extracted_on": "2022-03-16T20:12:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.ripta.com/wp-content/uploads/2020/10/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-rhode-island-rhode-island-public-transit-authority-ripta-gtfs-642.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-tennessee-memphis-area-transit-authoritiy-gtfs-602.json
+++ b/catalogs/sources/gtfs/schedule/us-tennessee-memphis-area-transit-authoritiy-gtfs-602.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 602,
+    "data_type": "gtfs",
+    "provider": "Memphis Area Transit Authoritiy",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Tennessee",
+        "municipality": "Memphis",
+        "bounding_box": {
+            "minimum_latitude": 35.001607,
+            "maximum_latitude": 35.269264,
+            "minimum_longitude": -90.127347,
+            "maximum_longitude": -89.754447,
+            "extracted_on": "2022-03-16T20:10:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.matatransit.com/assets/2/6/Memphis_TN_transitfeed2.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-tennessee-memphis-area-transit-authoritiy-gtfs-602.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-citibus-gtfs-569.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-citibus-gtfs-569.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 569,
+    "data_type": "gtfs",
+    "provider": "Citibus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Lubbock",
+        "bounding_box": {
+            "minimum_latitude": 33.5195921229278,
+            "maximum_latitude": 33.6561989783133,
+            "minimum_longitude": -101.948367108508,
+            "maximum_longitude": -101.799039221073,
+            "extracted_on": "2022-03-16T20:09:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lubbock-tx-us/lubbock-tx-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-citibus-gtfs-569.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-gulf-coast-center-gtfs-625.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-gulf-coast-center-gtfs-625.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 625,
+    "data_type": "gtfs",
+    "provider": "Gulf Coast Center",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "bounding_box": {
+            "minimum_latitude": 28.9438134,
+            "maximum_latitude": 29.5135344528876,
+            "minimum_longitude": -95.4648053214995,
+            "maximum_longitude": -94.89328642,
+            "extracted_on": "2022-03-16T20:11:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/gulfcoastcenter-tx-us/gulfcoastcenter-tx-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-gulf-coast-center-gtfs-625.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-unknown-flixbus-gtfs-593.json
+++ b/catalogs/sources/gtfs/schedule/us-unknown-flixbus-gtfs-593.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 593,
+    "data_type": "gtfs",
+    "provider": "Flixbus",
+    "location": {
+        "country_code": "US",
+        "bounding_box": {
+            "minimum_latitude": 25.7782,
+            "maximum_latitude": 42.343998,
+            "minimum_longitude": -118.449001,
+            "maximum_longitude": -71.061576,
+            "extracted_on": "2022-03-16T20:10:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ndovloket.nl/flixbus/flixbus-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-unknown-flixbus-gtfs-593.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-unknown-groome-transportation-gtfs-614.json
+++ b/catalogs/sources/gtfs/schedule/us-unknown-groome-transportation-gtfs-614.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 614,
+    "data_type": "gtfs",
+    "provider": "Groome Transportation",
+    "location": {
+        "country_code": "US",
+        "bounding_box": {
+            "minimum_latitude": 39.849751,
+            "maximum_latitude": 41.319546,
+            "minimum_longitude": -105.671434,
+            "maximum_longitude": -104.672284,
+            "extracted_on": "2022-03-16T20:10:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/greenride-co-us/greenride-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-unknown-groome-transportation-gtfs-614.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-advance-transit-gtfs-631.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-advance-transit-gtfs-631.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 631,
+    "data_type": "gtfs",
+    "provider": "Advance Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Hartford",
+        "bounding_box": {
+            "minimum_latitude": 43.625202179,
+            "maximum_latitude": 43.729133606,
+            "minimum_longitude": -72.3435561363965,
+            "maximum_longitude": -72.0132064819,
+            "extracted_on": "2022-03-16T20:11:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/advancetransit-vt-us/advancetransit-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-advance-transit-gtfs-631.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-chittenden-county-transportation-authority-ccta-gtfs-629.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-chittenden-county-transportation-authority-ccta-gtfs-629.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 629,
+    "data_type": "gtfs",
+    "provider": "Chittenden County Transportation Authority  (CCTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Burlington",
+        "bounding_box": {
+            "minimum_latitude": 44.010319,
+            "maximum_latitude": 44.99747,
+            "minimum_longitude": -73.29892,
+            "maximum_longitude": -72.02065,
+            "extracted_on": "2022-03-16T20:11:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ccta-vt-us/ccta-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-chittenden-county-transportation-authority-ccta-gtfs-629.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-graham-transit-gtfs-611.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-graham-transit-gtfs-611.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 611,
+    "data_type": "gtfs",
+    "provider": "Graham Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Bluefield",
+        "bounding_box": {
+            "minimum_latitude": 37.2322934348219,
+            "maximum_latitude": 37.3073947649655,
+            "minimum_longitude": -81.3460041737645,
+            "maximum_longitude": -81.2347962623343,
+            "extracted_on": "2022-03-16T20:10:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/grahamtransit-va-us/grahamtransit-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-graham-transit-gtfs-611.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-petersburg-area-transit-gtfs-591.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-petersburg-area-transit-gtfs-591.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 591,
+    "data_type": "gtfs",
+    "provider": "Petersburg Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Petersburg",
+        "bounding_box": {
+            "minimum_latitude": 37.1803868625173,
+            "maximum_latitude": 37.5404865378737,
+            "minimum_longitude": -77.467684930818,
+            "maximum_longitude": -77.2861622676174,
+            "extracted_on": "2022-03-16T20:10:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/petersburg-va-us/petersburg-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-petersburg-area-transit-gtfs-591.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-virginia-regional-transit-gtfs-621.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-virginia-regional-transit-gtfs-621.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 621,
+    "data_type": "gtfs",
+    "provider": "Virginia Regional Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "bounding_box": {
+            "minimum_latitude": 38.0289070749037,
+            "maximum_latitude": 39.143534,
+            "minimum_longitude": -78.4998357379939,
+            "maximum_longitude": -77.561757,
+            "extracted_on": "2022-03-16T20:11:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/vatransit-va-us/vatransit-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-virginia-regional-transit-gtfs-621.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-wintran-gtfs-608.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-wintran-gtfs-608.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 608,
+    "data_type": "gtfs",
+    "provider": "WinTran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Winchester",
+        "bounding_box": {
+            "minimum_latitude": 39.13712,
+            "maximum_latitude": 39.2084813977251,
+            "minimum_longitude": -78.19513,
+            "maximum_longitude": -78.143465090073,
+            "extracted_on": "2022-03-16T20:10:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/wintran-va-us/wintran-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-wintran-gtfs-608.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-lewis-mountain-highway-transit-gtfs-567.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-lewis-mountain-highway-transit-gtfs-567.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 567,
+    "data_type": "gtfs",
+    "provider": "L.E.W.I.S. Mountain Highway Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 46.522289458157,
+            "maximum_latitude": 46.7171997017871,
+            "minimum_longitude": -122.979824299701,
+            "maximum_longitude": -121.675902753039,
+            "extracted_on": "2022-03-16T20:09:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lmht-morton-us/lmht-morton-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-lewis-mountain-highway-transit-gtfs-567.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-lower-columbia-cap-community-action-program-gtfs-568.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-lower-columbia-cap-community-action-program-gtfs-568.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 568,
+    "data_type": "gtfs",
+    "provider": "Lower Columbia CAP (Community Action Program)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Longview",
+        "bounding_box": {
+            "minimum_latitude": 45.6906915250296,
+            "maximum_latitude": 46.283358015664,
+            "minimum_longitude": -122.934549104713,
+            "maximum_longitude": -122.66373300428,
+            "extracted_on": "2022-03-16T20:09:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/lowercolumbiacap-wa-us/lowercolumbiacap-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-lower-columbia-cap-community-action-program-gtfs-568.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-makah-public-transit-gtfs-574.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-makah-public-transit-gtfs-574.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 574,
+    "data_type": "gtfs",
+    "provider": "Makah Public Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 48.345925,
+            "maximum_latitude": 48.370977,
+            "minimum_longitude": -124.672653,
+            "maximum_longitude": -124.587256,
+            "extracted_on": "2022-03-16T20:09:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/makah_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-makah-public-transit-gtfs-574.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-mount-adams-transportation-service-gtfs-580.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-mount-adams-transportation-service-gtfs-580.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 580,
+    "data_type": "gtfs",
+    "provider": "Mount Adams Transportation Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 45.533467,
+            "maximum_latitude": 46.593247,
+            "minimum_longitude": -122.650095,
+            "maximum_longitude": -119.102094,
+            "extracted_on": "2022-03-16T20:09:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/mountadams-wa-us/mountadams-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-mount-adams-transportation-service-gtfs-580.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-wahkiakum-ferry-gtfs-604.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-wahkiakum-ferry-gtfs-604.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 604,
+    "data_type": "gtfs",
+    "provider": "Wahkiakum Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Longview",
+        "bounding_box": {
+            "minimum_latitude": 46.1371023921546,
+            "maximum_latitude": 46.1532992569825,
+            "minimum_longitude": -123.378724476539,
+            "maximum_longitude": -123.377110622681,
+            "extracted_on": "2022-03-16T20:10:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/wahkiakumferry-or-us/wahkiakumferry-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-wahkiakum-ferry-gtfs-604.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the eighth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 91 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~