### PR TITLE
feat: Fourth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ar-buenos-aires-trenes-argentinos-gtfs-647.json
+++ b/catalogs/sources/gtfs/schedule/ar-buenos-aires-trenes-argentinos-gtfs-647.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 647,
+    "data_type": "gtfs",
+    "provider": "Trenes Argentinos",
+    "location": {
+        "country_code": "AR",
+        "subdivision_name": "Buenos Aires",
+        "bounding_box": {
+            "minimum_latitude": -35.8738929,
+            "maximum_latitude": -34.0979051,
+            "minimum_longitude": -59.4336661,
+            "maximum_longitude": -57.8954007,
+            "extracted_on": "2022-03-16T21:17:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://cdn.buenosaires.gob.ar/datosabiertos/datasets/trenes-gtfs/trenes-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ar-buenos-aires-trenes-argentinos-gtfs-647.zip?alt=media",
+        "license": "https://data.buenosaires.gob.ar/dataset/trenes-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/at-wien-wiener-lokalbahnen-wlb-gtfs-648.json
+++ b/catalogs/sources/gtfs/schedule/at-wien-wiener-lokalbahnen-wlb-gtfs-648.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 648,
+    "data_type": "gtfs",
+    "provider": "Wiener Lokalbahnen (WLB), Wiener Linien",
+    "location": {
+        "country_code": "AT",
+        "subdivision_name": "Wien",
+        "bounding_box": {
+            "minimum_latitude": 47.9995020902886,
+            "maximum_latitude": 48.3011051975429,
+            "minimum_longitude": 16.1977025532707,
+            "maximum_longitude": 16.5494019702052,
+            "extracted_on": "2022-03-16T21:18:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.wienerlinien.at/ogd_realtime/doku/ogd/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/at-wien-wiener-lokalbahnen-wlb-gtfs-648.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-new-south-wales-byron-easybus-gtfs-666.json
+++ b/catalogs/sources/gtfs/schedule/au-new-south-wales-byron-easybus-gtfs-666.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 666,
+    "data_type": "gtfs",
+    "provider": "Byron Easybus",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "New South Wales",
+        "municipality": "Byron Bay",
+        "bounding_box": {
+            "minimum_latitude": -28.869311578117728,
+            "maximum_latitude": -27.38539101196501,
+            "minimum_longitude": 153.018619,
+            "maximum_longitude": 153.61247062683103,
+            "extracted_on": "2022-03-16T22:00:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://addtransit.com/gtfsfile/54743/ByronEasybus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-new-south-wales-byron-easybus-gtfs-666.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-northern-territory-department-of-transport-gtfs-680.json
+++ b/catalogs/sources/gtfs/schedule/au-northern-territory-department-of-transport-gtfs-680.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 680,
+    "data_type": "gtfs",
+    "provider": "Department of Transport, Public Transport",
+    "name": "Darwin public bus network",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Northern Territory",
+        "municipality": "Darwin",
+        "bounding_box": {
+            "minimum_latitude": -12.673611,
+            "maximum_latitude": -12.35262,
+            "minimum_longitude": 130.82082,
+            "maximum_longitude": 131.131822,
+            "extracted_on": "2022-03-16T22:01:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://dipl.nt.gov.au/data-feeds/bus-gtfs/google-transit-darwin.zip?v=0.16.0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-northern-territory-department-of-transport-gtfs-680.zip?alt=media",
+        "license": "https://dipl.nt.gov.au/data/bus-timetable-data-and-geographic-information"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-northern-territory-department-of-transport-public-transport-gtfs-683.json
+++ b/catalogs/sources/gtfs/schedule/au-northern-territory-department-of-transport-public-transport-gtfs-683.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 683,
+    "data_type": "gtfs",
+    "provider": "Department of Transport - Public Transport",
+    "name": "Alice Springs public bus network",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Northern Territory",
+        "municipality": "Alice Springs",
+        "bounding_box": {
+            "minimum_latitude": -23.777408,
+            "maximum_latitude": -23.668637,
+            "minimum_longitude": 133.826057,
+            "maximum_longitude": 133.903218,
+            "extracted_on": "2022-03-16T22:01:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://dipl.nt.gov.au/data-feeds/bus-gtfs/google-transit-alice-springs.zip?v=0.7.0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-northern-territory-department-of-transport-public-transport-gtfs-683.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-bowen-transit-gtfs-675.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-bowen-transit-gtfs-675.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 675,
+    "data_type": "gtfs",
+    "provider": "Bowen Transit",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "bounding_box": {
+            "minimum_latitude": -20.018563,
+            "maximum_latitude": -19.970855,
+            "minimum_longitude": 148.225334,
+            "maximum_longitude": 148.265372,
+            "extracted_on": "2022-03-16T22:00:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/BOW_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-bowen-transit-gtfs-675.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-bus-queensland-toowoomba-bus-qld-toowoomba-gtfs-653.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-bus-queensland-toowoomba-bus-qld-toowoomba-gtfs-653.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 653,
+    "data_type": "gtfs",
+    "provider": "Bus Queensland Toowoomba (Bus Qld Toowoomba)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Toowoomba",
+        "bounding_box": {
+            "minimum_latitude": -27.611151,
+            "maximum_latitude": -27.258647,
+            "minimum_longitude": 151.869525,
+            "maximum_longitude": 152.06874,
+            "extracted_on": "2022-03-16T21:18:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/TWB_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-bus-queensland-toowoomba-bus-qld-toowoomba-gtfs-653.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/48501fd9-148b-4b96-a9fa-b412d768048c"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-buslink-gladstone-gtfs-667.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-buslink-gladstone-gtfs-667.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 667,
+    "data_type": "gtfs",
+    "provider": "Buslink Gladstone",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Gladstone",
+        "bounding_box": {
+            "minimum_latitude": -23.960521,
+            "maximum_latitude": -23.838753,
+            "minimum_longitude": 151.21067,
+            "maximum_longitude": 151.370321,
+            "extracted_on": "2022-03-16T22:00:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/GLT_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-buslink-gladstone-gtfs-667.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-christensens-bus-and-coach-gtfs-669.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-christensens-bus-and-coach-gtfs-669.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 669,
+    "data_type": "gtfs",
+    "provider": "Christensens Bus and Coach",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Caboolture",
+        "bounding_box": {
+            "minimum_latitude": -27.103209,
+            "maximum_latitude": -26.923223,
+            "minimum_longitude": 152.564827,
+            "maximum_longitude": 152.963944,
+            "extracted_on": "2022-03-16T22:00:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/KIL_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-christensens-bus-and-coach-gtfs-669.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-duffys-buses-and-stewarts-sons-coaches-gtfs-672.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-duffys-buses-and-stewarts-sons-coaches-gtfs-672.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 672,
+    "data_type": "gtfs",
+    "provider": "Duffy's Buses and Stewarts & Sons Coaches",
+    "name": "Bundaberg",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Bundaberg",
+        "bounding_box": {
+            "minimum_latitude": -24.921379,
+            "maximum_latitude": -24.695965,
+            "minimum_longitude": 152.239464,
+            "maximum_longitude": 152.492233,
+            "extracted_on": "2022-03-16T22:00:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/BUN_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-duffys-buses-and-stewarts-sons-coaches-gtfs-672.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/699184c3-8c0e-44db-8a83-7e23709aefbe"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-glass-house-country-coaches-gtfs-670.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-glass-house-country-coaches-gtfs-670.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 670,
+    "data_type": "gtfs",
+    "provider": "Glass House Country Coaches",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "bounding_box": {
+            "minimum_latitude": -26.808098,
+            "maximum_latitude": -26.61763,
+            "minimum_longitude": 152.850518,
+            "maximum_longitude": 152.966173,
+            "extracted_on": "2022-03-16T22:00:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/MAL_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-glass-house-country-coaches-gtfs-670.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-haidleys-panoramic-coaches-gtfs-654.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-haidleys-panoramic-coaches-gtfs-654.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 654,
+    "data_type": "gtfs",
+    "provider": "Haidleys Panoramic Coaches",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Warwick",
+        "bounding_box": {
+            "minimum_latitude": -28.238421,
+            "maximum_latitude": -28.194167,
+            "minimum_longitude": 151.985483,
+            "maximum_longitude": 152.044586,
+            "extracted_on": "2022-03-16T21:18:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/WAR_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-haidleys-panoramic-coaches-gtfs-654.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/4b6cc276-0d70-4c9c-adac-0b8cb384268a"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-mackay-transit-coaches-gtfs-678.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-mackay-transit-coaches-gtfs-678.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 678,
+    "data_type": "gtfs",
+    "provider": "Mackay Transit Coaches",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Mackay",
+        "bounding_box": {
+            "minimum_latitude": -21.422896,
+            "maximum_latitude": -21.002182,
+            "minimum_longitude": 148.863599,
+            "maximum_longitude": 149.226987,
+            "extracted_on": "2022-03-16T22:01:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/MKY_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-mackay-transit-coaches-gtfs-678.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/03426b3e-1ea6-4878-bd9b-cfaef7ca2b1d?truncate=30&inner_span=True"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-north-stradbroke-island-buses-gtfs-652.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-north-stradbroke-island-buses-gtfs-652.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 652,
+    "data_type": "gtfs",
+    "provider": "North Stradbroke Island Buses",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Brisbane",
+        "bounding_box": {
+            "minimum_latitude": -27.50324,
+            "maximum_latitude": -27.394988,
+            "minimum_longitude": 153.40117,
+            "maximum_longitude": 153.543723,
+            "extracted_on": "2022-03-16T21:18:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/NSI_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-north-stradbroke-island-buses-gtfs-652.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-polleys-coaches-gtfs-671.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-polleys-coaches-gtfs-671.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 671,
+    "data_type": "gtfs",
+    "provider": "Polleys Coaches",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Gympie",
+        "bounding_box": {
+            "minimum_latitude": -26.223348,
+            "maximum_latitude": -25.901583,
+            "minimum_longitude": 152.639085,
+            "maximum_longitude": 153.091887,
+            "extracted_on": "2022-03-16T22:00:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/GYM_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-polleys-coaches-gtfs-671.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-sunbus-townsville-gtfs-677.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-sunbus-townsville-gtfs-677.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 677,
+    "data_type": "gtfs",
+    "provider": "Sunbus Townsville",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Townsville",
+        "bounding_box": {
+            "minimum_latitude": -19.393504,
+            "maximum_latitude": -19.189667,
+            "minimum_longitude": 146.646356,
+            "maximum_longitude": 146.850212,
+            "extracted_on": "2022-03-16T22:01:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/TSV_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-sunbus-townsville-gtfs-677.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-trans-north-innisfail-gtfs-673.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-trans-north-innisfail-gtfs-673.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 673,
+    "data_type": "gtfs",
+    "provider": "Trans North Innisfail",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "bounding_box": {
+            "minimum_latitude": -17.543952,
+            "maximum_latitude": -16.819678,
+            "minimum_longitude": 145.424125,
+            "maximum_longitude": 146.076331,
+            "extracted_on": "2022-03-16T22:00:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/INN_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-trans-north-innisfail-gtfs-673.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-magnetic-island-ferry-gtfs-679.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-magnetic-island-ferry-gtfs-679.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 679,
+    "data_type": "gtfs",
+    "provider": "Translink Magnetic Island Ferry",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Magnetic Island",
+        "bounding_box": {
+            "minimum_latitude": -19.25514,
+            "maximum_latitude": -19.158991,
+            "minimum_longitude": 146.825978,
+            "maximum_longitude": 146.855407,
+            "extracted_on": "2022-03-16T22:01:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/MIF_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-magnetic-island-ferry-gtfs-679.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/a7a3282c-ce87-4b4e-8b7b-70a4cc081ed6?truncate=30&inner_span=True"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-magnetic-island-gtfs-650.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-magnetic-island-gtfs-650.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 650,
+    "data_type": "gtfs",
+    "provider": "Translink Magnetic Island",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Magnetic Island",
+        "bounding_box": {
+            "minimum_latitude": -19.180021,
+            "maximum_latitude": -19.117094,
+            "minimum_longitude": 146.837611,
+            "maximum_longitude": 146.868939,
+            "extracted_on": "2022-03-16T21:18:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/MAG_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-magnetic-island-gtfs-650.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/81030a70-b1e1-4cb1-b7ae-67051d1368e5"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-south-east-queensland-translink-seq-gtfs-668.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-south-east-queensland-translink-seq-gtfs-668.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 668,
+    "data_type": "gtfs",
+    "provider": "Translink South East Queensland (Translink SEQ)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "bounding_box": {
+            "minimum_latitude": -28.172196,
+            "maximum_latitude": -26.15939,
+            "minimum_longitude": 152.124238,
+            "maximum_longitude": 153.543374,
+            "extracted_on": "2022-03-16T22:00:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/SEQ_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-south-east-queensland-translink-seq-gtfs-668.zip?alt=media",
+        "license": "https://data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-seq/resource/be7f19e5-3ee8-4396-b9eb-46f6b4ce8039"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-sunbus-cairns-gtfs-674.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-sunbus-cairns-gtfs-674.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 674,
+    "data_type": "gtfs",
+    "provider": "TransLink Sunbus Cairns",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Cairns",
+        "bounding_box": {
+            "minimum_latitude": -17.104064,
+            "maximum_latitude": -16.743567,
+            "minimum_longitude": 145.663264,
+            "maximum_longitude": 145.786494,
+            "extracted_on": "2022-03-16T22:00:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/CNS_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-sunbus-cairns-gtfs-674.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/9850f8e5-f572-4de7-97c5-84d45526f9bd"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-whitsunday-transit-gtfs-676.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-whitsunday-transit-gtfs-676.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 676,
+    "data_type": "gtfs",
+    "provider": "Whitsunday Transit",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Proserpine",
+        "bounding_box": {
+            "minimum_latitude": -20.406011,
+            "maximum_latitude": -20.264272,
+            "minimum_longitude": 148.57356,
+            "maximum_longitude": 148.785562,
+            "extracted_on": "2022-03-16T22:00:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/WHT_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-whitsunday-transit-gtfs-676.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-wide-bay-transit-gtfs-651.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-wide-bay-transit-gtfs-651.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 651,
+    "data_type": "gtfs",
+    "provider": "Wide Bay Transit",
+    "name": "Maryborough-Hervey Bay",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Maryborough",
+        "bounding_box": {
+            "minimum_latitude": -25.560525,
+            "maximum_latitude": -25.183988,
+            "minimum_longitude": 152.558177,
+            "maximum_longitude": 152.908899,
+            "extracted_on": "2022-03-16T21:18:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/MHB_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-wide-bay-transit-gtfs-651.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/ee40c2d4-f170-426d-9719-3cc3e32c567c"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-youngs-bus-service-gtfs-655.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-youngs-bus-service-gtfs-655.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 655,
+    "data_type": "gtfs",
+    "provider": "Youngs Bus Service",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Rockhampton",
+        "bounding_box": {
+            "minimum_latitude": -23.638604,
+            "maximum_latitude": -23.099773,
+            "minimum_longitude": 150.387628,
+            "maximum_longitude": 150.826186,
+            "extracted_on": "2022-03-16T21:18:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/YEP_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-youngs-bus-service-gtfs-655.zip?alt=media",
+        "license": "https://www.data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/63dec6b1-bb77-470f-bb34-54fa0db3d6a7"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-south-australia-adelaide-metro-gtfs-660.json
+++ b/catalogs/sources/gtfs/schedule/au-south-australia-adelaide-metro-gtfs-660.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 660,
+    "data_type": "gtfs",
+    "provider": "Adelaide Metro",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "South Australia",
+        "municipality": "Adelaide",
+        "bounding_box": {
+            "minimum_latitude": -35.339223,
+            "maximum_latitude": -34.571043,
+            "minimum_longitude": 138.445316,
+            "maximum_longitude": 139.036087,
+            "extracted_on": "2022-03-16T21:38:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.adelaidemetro.com.au/v1/static/latest/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-south-australia-adelaide-metro-gtfs-660.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-tasmania-metrotas-burnie-gtfs-681.json
+++ b/catalogs/sources/gtfs/schedule/au-tasmania-metrotas-burnie-gtfs-681.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 681,
+    "data_type": "gtfs",
+    "provider": "MetroTas Burnie",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Tasmania",
+        "municipality": "Burnie",
+        "bounding_box": {
+            "minimum_latitude": -41.55744214603599,
+            "maximum_latitude": -40.7606108112925,
+            "minimum_longitude": 145.12451253471826,
+            "maximum_longitude": 147.1571264979121,
+            "extracted_on": "2022-03-16T22:01:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.metrotas.com.au/wp-content/uploads/transit/Burnie/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-tasmania-metrotas-burnie-gtfs-681.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-tasmania-metrotas-hobart-gtfs-665.json
+++ b/catalogs/sources/gtfs/schedule/au-tasmania-metrotas-hobart-gtfs-665.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 665,
+    "data_type": "gtfs",
+    "provider": "MetroTas Hobart",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Tasmania",
+        "municipality": "Hobart",
+        "bounding_box": {
+            "minimum_latitude": -43.31239511583733,
+            "maximum_latitude": -41.04707909408461,
+            "minimum_longitude": 145.318106,
+            "maximum_longitude": 148.303394,
+            "extracted_on": "2022-03-16T22:00:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.metrotas.com.au/wp-content/uploads/transit/Hobart/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-tasmania-metrotas-hobart-gtfs-665.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-tasmania-metrotas-launceston-gtfs-682.json
+++ b/catalogs/sources/gtfs/schedule/au-tasmania-metrotas-launceston-gtfs-682.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 682,
+    "data_type": "gtfs",
+    "provider": "MetroTas Launceston",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Tasmania",
+        "municipality": "Launceston",
+        "bounding_box": {
+            "minimum_latitude": -42.88489072090745,
+            "maximum_latitude": -41.00315447,
+            "minimum_longitude": 146.8052311,
+            "maximum_longitude": 148.3035978,
+            "extracted_on": "2022-03-16T22:01:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.metrotas.com.au/wp-content/uploads/transit/Launceston/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-tasmania-metrotas-launceston-gtfs-682.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-port-phillip-ferries-gtfs-649.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-port-phillip-ferries-gtfs-649.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 649,
+    "data_type": "gtfs",
+    "provider": "Port Phillip Ferries",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "bounding_box": {
+            "minimum_latitude": -38.14312171418421,
+            "maximum_latitude": -37.81696682290608,
+            "minimum_longitude": 144.36218577889218,
+            "maximum_longitude": 144.9450472321603,
+            "extracted_on": "2022-03-16T21:18:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/PPF-GTFS/GTFS/raw/main/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-port-phillip-ferries-gtfs-649.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-656.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-656.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 656,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T21:23:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#1/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-656.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-657.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-657.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 657,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T21:28:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#10/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-657.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-658.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-658.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 658,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T21:34:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#6/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-658.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-659.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-659.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 659,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T21:38:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#5/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-659.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-661.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-661.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 661,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T21:45:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#2/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-661.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-662.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-662.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 662,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T21:49:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#4/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-662.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-663.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-663.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 663,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T21:55:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#3/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-663.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-664.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-664.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 664,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-16T22:00:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip#11/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-664.zip?alt=media",
+        "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/be-antwerpen-de-waterbus-gtfs-685.json
+++ b/catalogs/sources/gtfs/schedule/be-antwerpen-de-waterbus-gtfs-685.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 685,
+    "data_type": "gtfs",
+    "provider": "De Waterbus",
+    "location": {
+        "country_code": "BE",
+        "subdivision_name": "Antwerpen",
+        "bounding_box": {
+            "minimum_latitude": 51.1431779315168,
+            "maximum_latitude": 51.302229653616,
+            "minimum_longitude": 4.286191463470459,
+            "maximum_longitude": 4.5152118,
+            "extracted_on": "2022-03-16T22:03:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://addtransit.com/gtfsfile/85165/DeWaterbus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/be-antwerpen-de-waterbus-gtfs-685.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/be-unknown-societe-nationale-des-chemins-de-fer-belges-nmbs-sncb-gtfs-686.json
+++ b/catalogs/sources/gtfs/schedule/be-unknown-societe-nationale-des-chemins-de-fer-belges-nmbs-sncb-gtfs-686.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 686,
+    "data_type": "gtfs",
+    "provider": "Société nationale des chemins de fer belges (NMBS-SNCB)",
+    "location": {
+        "country_code": "BE",
+        "bounding_box": {
+            "minimum_latitude": 48.86667,
+            "maximum_latitude": 52.35,
+            "minimum_longitude": 2.333333,
+            "maximum_longitude": 6.133333,
+            "extracted_on": "2022-03-16T22:03:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.irail.be/nmbs/gtfs/latest.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/be-unknown-societe-nationale-des-chemins-de-fer-belges-nmbs-sncb-gtfs-686.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/be-vlaams-gewest-de-lijn-gtfs-684.json
+++ b/catalogs/sources/gtfs/schedule/be-vlaams-gewest-de-lijn-gtfs-684.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 684,
+    "data_type": "gtfs",
+    "provider": "De Lijn",
+    "location": {
+        "country_code": "BE",
+        "subdivision_name": "Vlaams Gewest",
+        "bounding_box": {
+            "minimum_latitude": 50.6451,
+            "maximum_latitude": 51.5605,
+            "minimum_longitude": 2.58059,
+            "maximum_longitude": 5.88695,
+            "extracted_on": "2022-03-16T22:03:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.irail.be/de-lijn/de_lijn-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/be-vlaams-gewest-de-lijn-gtfs-684.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-687.json
+++ b/catalogs/sources/gtfs/schedule/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-687.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 687,
+    "data_type": "gtfs",
+    "provider": "Empresa de Transportes e Transito de Belo Horizonte (BHTRANS) ",
+    "name": "Supplemental",
+    "location": {
+        "country_code": "BR",
+        "subdivision_name": "Minas Gerais",
+        "municipality": "Belo Horizonte",
+        "bounding_box": {
+            "minimum_latitude": -20.02215077788596,
+            "maximum_latitude": -19.7837028260423,
+            "minimum_longitude": -44.05937769694836,
+            "maximum_longitude": -43.881705475531,
+            "extracted_on": "2022-03-16T22:03:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ckan.pbh.gov.br/dataset/af0c47bb-5a82-4ae1-874f-e45dea1397ff/resource/b2a9341e-4471-45cc-a8c0-11be805590bc/download/gtfsfiles.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/br-minas-gerais-empresa-de-transportes-e-transito-de-belo-horizonte-bhtrans-gtfs-687.zip?alt=media",
+        "license": "https://dados.pbh.gov.br/dataset/feed-gtfs-estatico-do-sistema-suplementar"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-alberta-calgary-transit-gtfs-712.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-calgary-transit-gtfs-712.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 712,
+    "data_type": "gtfs",
+    "provider": "Calgary Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Alberta",
+        "municipality": "Calgary",
+        "bounding_box": {
+            "minimum_latitude": 50.854661,
+            "maximum_latitude": 51.184083,
+            "minimum_longitude": -114.269483,
+            "maximum_longitude": -113.821508,
+            "extracted_on": "2022-03-16T22:05:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.calgary.ca/download/npk7-z3bj/application%2Fzip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-alberta-calgary-transit-gtfs-712.zip?alt=media",
+        "license": "https://data.calgary.ca/stories/s/u45n-7awa/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-alberta-edmonton-transit-system-gtfs-714.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-edmonton-transit-system-gtfs-714.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 714,
+    "data_type": "gtfs",
+    "provider": "Edmonton Transit System",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Alberta",
+        "municipality": "Edmonton",
+        "bounding_box": {
+            "minimum_latitude": 53.302688,
+            "maximum_latitude": 53.704407,
+            "minimum_longitude": -113.934884,
+            "maximum_longitude": -113.218139,
+            "extracted_on": "2022-03-16T22:06:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.edmonton.ca/TMGTFSRealTimeWebService/GTFS/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-alberta-edmonton-transit-system-gtfs-714.zip?alt=media",
+        "license": "https://data.strathcona.ca/Transportation/Transit-Bus-Schedule-GTFS-Data-Feed-Zip-File/2ek5-rxs5/data?no_mobile=true"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-alberta-red-deer-transit-gtfs-713.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-red-deer-transit-gtfs-713.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 713,
+    "data_type": "gtfs",
+    "provider": "Red Deer Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Alberta",
+        "municipality": "Red Deer",
+        "bounding_box": {
+            "minimum_latitude": 52.204934,
+            "maximum_latitude": 52.315697,
+            "minimum_longitude": -113.859632,
+            "maximum_longitude": -113.746221,
+            "extracted_on": "2022-03-16T22:05:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://webmap.reddeer.ca/transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-alberta-red-deer-transit-gtfs-713.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-alberta-roam-transit-gtfs-711.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-roam-transit-gtfs-711.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 711,
+    "data_type": "gtfs",
+    "provider": "Roam Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Alberta",
+        "municipality": "Banff",
+        "bounding_box": {
+            "minimum_latitude": 50.8997692685086,
+            "maximum_latitude": 51.4252040530679,
+            "minimum_longitude": -116.212714404789,
+            "maximum_longitude": -114.0599361464,
+            "extracted_on": "2022-03-16T22:05:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/roamtransit-banff-ab-ca/roamtransit-banff-ab-ca.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-alberta-roam-transit-gtfs-711.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-ferries-gtfs-690.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-ferries-gtfs-690.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 690,
+    "data_type": "gtfs",
+    "provider": "BC Ferries",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Vancouver",
+        "bounding_box": {
+            "minimum_latitude": 48.5772095826738,
+            "maximum_latitude": 54.2977845717889,
+            "minimum_longitude": -132.010339,
+            "maximum_longitude": -123.12942224916,
+            "extracted_on": "2022-03-16T22:04:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bcferries-bc-ca/bcferries-bc-ca.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-ferries-gtfs-690.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-campbell-river-transit-gtfs-691.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-campbell-river-transit-gtfs-691.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 691,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Campbell River Transit)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Campbell River",
+        "bounding_box": {
+            "minimum_latitude": 49.869973,
+            "maximum_latitude": 50.063857,
+            "minimum_longitude": -125.286389,
+            "maximum_longitude": -125.129018,
+            "extracted_on": "2022-03-16T22:04:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/campbell-river.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-campbell-river-transit-gtfs-691.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-central-fraser-valley-transit-system-gtfs-697.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-central-fraser-valley-transit-system-gtfs-697.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 697,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Central Fraser Valley Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Abbotsford",
+        "bounding_box": {
+            "minimum_latitude": 49.004222,
+            "maximum_latitude": 49.158304,
+            "minimum_longitude": -122.470676,
+            "maximum_longitude": -122.214539,
+            "extracted_on": "2022-03-16T22:04:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/central-fraser-valley.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-central-fraser-valley-transit-system-gtfs-697.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-chilliwack-gtfs-699.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-chilliwack-gtfs-699.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 699,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Chilliwack)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Chilliwhack",
+        "bounding_box": {
+            "minimum_latitude": 49.082095,
+            "maximum_latitude": 49.382539,
+            "minimum_longitude": -122.080467,
+            "maximum_longitude": -121.419945,
+            "extracted_on": "2022-03-16T22:05:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/chilliwack.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-chilliwack-gtfs-699.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-comox-valley-transit-system-gtfs-693.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-comox-valley-transit-system-gtfs-693.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 693,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Comox Valley Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Comox Valley",
+        "bounding_box": {
+            "minimum_latitude": 49.472244,
+            "maximum_latitude": 49.873376,
+            "minimum_longitude": -125.147712,
+            "maximum_longitude": -124.795209,
+            "extracted_on": "2022-03-16T22:04:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://comox.mapstrat.com/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-comox-valley-transit-system-gtfs-693.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-cowichan-valley-regional-transit-system-gtfs-694.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-cowichan-valley-regional-transit-system-gtfs-694.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 694,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Cowichan Valley Regional Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "bounding_box": {
+            "minimum_latitude": 48.418266,
+            "maximum_latitude": 48.998334,
+            "minimum_longitude": -124.218623,
+            "maximum_longitude": -123.364449,
+            "extracted_on": "2022-03-16T22:04:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/cowichan-valley.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-cowichan-valley-regional-transit-system-gtfs-694.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-cranbrook-gtfs-706.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-cranbrook-gtfs-706.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 706,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Cranbrook)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Cranbrook",
+        "bounding_box": {
+            "minimum_latitude": 49.489582,
+            "maximum_latitude": 49.53763,
+            "minimum_longitude": -115.783128,
+            "maximum_longitude": -115.739014,
+            "extracted_on": "2022-03-16T22:05:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/cranbrook.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-cranbrook-gtfs-706.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-dawson-creek-transit-system-gtfs-710.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-dawson-creek-transit-system-gtfs-710.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 710,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Dawson Creek Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Dawson Creek",
+        "bounding_box": {
+            "minimum_latitude": 55.738673,
+            "maximum_latitude": 55.776274,
+            "minimum_longitude": -120.253959,
+            "maximum_longitude": -120.211266,
+            "extracted_on": "2022-03-16T22:05:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/dawson-creek.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-dawson-creek-transit-system-gtfs-710.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-fort-st-john-transit-system-gtfs-709.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-fort-st-john-transit-system-gtfs-709.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 709,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Fort St John Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Fort St. John",
+        "bounding_box": {
+            "minimum_latitude": 56.231758,
+            "maximum_latitude": 56.26674,
+            "minimum_longitude": -120.873862,
+            "maximum_longitude": -120.803019,
+            "extracted_on": "2022-03-16T22:05:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/fort-st-john.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-fort-st-john-transit-system-gtfs-709.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-kamloops-transit-system-gtfs-707.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-kamloops-transit-system-gtfs-707.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 707,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Kamloops Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Kamloops",
+        "bounding_box": {
+            "minimum_latitude": 50.634135,
+            "maximum_latitude": 50.860312,
+            "minimum_longitude": -120.42291,
+            "maximum_longitude": -120.078766,
+            "extracted_on": "2022-03-16T22:05:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://kamloops.mapstrat.com/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-kamloops-transit-system-gtfs-707.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-kelowna-regional-transit-system-gtfs-704.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-kelowna-regional-transit-system-gtfs-704.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 704,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Kelowna Regional Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Kelowna",
+        "bounding_box": {
+            "minimum_latitude": 49.751924,
+            "maximum_latitude": 50.073517,
+            "minimum_longitude": -119.790038,
+            "maximum_longitude": -119.347167,
+            "extracted_on": "2022-03-16T22:05:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://kelowna.mapstrat.com/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-kelowna-regional-transit-system-gtfs-704.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-powell-river-regional-transit-system-gtfs-688.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-powell-river-regional-transit-system-gtfs-688.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 688,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Powell River Regional Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Powell River",
+        "bounding_box": {
+            "minimum_latitude": 49.653951,
+            "maximum_latitude": 49.981554,
+            "minimum_longitude": -124.760471,
+            "maximum_longitude": -124.178869,
+            "extracted_on": "2022-03-16T22:04:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/powell-river.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-powell-river-regional-transit-system-gtfs-688.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-regional-district-of-nanaimo-rdn-transit-system-gtfs-692.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-regional-district-of-nanaimo-rdn-transit-system-gtfs-692.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 692,
+    "data_type": "gtfs",
+    "provider": "BC Transit - Regional District of Nanaimo (RDN) Transit System",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Nanaimo",
+        "bounding_box": {
+            "minimum_latitude": 48.774918,
+            "maximum_latitude": 49.464455,
+            "minimum_longitude": -124.72594,
+            "maximum_longitude": -123.701411,
+            "extracted_on": "2022-03-16T22:04:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://nanaimo.mapstrat.com/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-regional-district-of-nanaimo-rdn-transit-system-gtfs-692.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-squamish-gtfs-701.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-squamish-gtfs-701.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 701,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Squamish)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Squamish",
+        "bounding_box": {
+            "minimum_latitude": 49.696302,
+            "maximum_latitude": 49.774333,
+            "minimum_longitude": -123.157502,
+            "maximum_longitude": -123.099042,
+            "extracted_on": "2022-03-16T22:05:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://squamish.mapstrat.com/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-squamish-gtfs-701.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-sunshine-coast-transit-system-gtfs-700.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-sunshine-coast-transit-system-gtfs-700.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 700,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Sunshine Coast Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "bounding_box": {
+            "minimum_latitude": 49.391845,
+            "maximum_latitude": 49.51393,
+            "minimum_longitude": -123.91146,
+            "maximum_longitude": -123.47472,
+            "extracted_on": "2022-03-16T22:05:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/sunshine-coast.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-sunshine-coast-transit-system-gtfs-700.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-vernon-regional-transit-system-gtfs-703.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-vernon-regional-transit-system-gtfs-703.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 703,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Vernon Regional Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Kelowna",
+        "bounding_box": {
+            "minimum_latitude": 49.939561,
+            "maximum_latitude": 50.551067,
+            "minimum_longitude": -119.406769,
+            "maximum_longitude": -118.962945,
+            "extracted_on": "2022-03-16T22:05:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/vernon.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-vernon-regional-transit-system-gtfs-703.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-victoria-regional-transit-system-gtfs-695.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-victoria-regional-transit-system-gtfs-695.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 695,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Victoria Regional Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Victoria",
+        "bounding_box": {
+            "minimum_latitude": 48.33716,
+            "maximum_latitude": 48.697757,
+            "minimum_longitude": -123.795435,
+            "maximum_longitude": -123.275822,
+            "extracted_on": "2022-03-16T22:04:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://victoria.mapstrat.com/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-victoria-regional-transit-system-gtfs-695.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-west-kootenay-transit-system-gtfs-705.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-west-kootenay-transit-system-gtfs-705.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 705,
+    "data_type": "gtfs",
+    "provider": "BC Transit (West Kootenay Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Nelson",
+        "bounding_box": {
+            "minimum_latitude": 49.071572,
+            "maximum_latitude": 50.296696,
+            "minimum_longitude": -118.140813,
+            "maximum_longitude": -116.896812,
+            "extracted_on": "2022-03-16T22:05:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/west-kootenay.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-west-kootenay-transit-system-gtfs-705.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-whistler-transit-system-gtfs-702.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-bc-transit-whistler-transit-system-gtfs-702.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 702,
+    "data_type": "gtfs",
+    "provider": "BC Transit (Whistler Transit System)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Whistler",
+        "bounding_box": {
+            "minimum_latitude": 50.077122,
+            "maximum_latitude": 50.159071,
+            "minimum_longitude": -123.043635,
+            "maximum_longitude": -122.926836,
+            "extracted_on": "2022-03-16T22:05:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://whistler.mapstrat.com/current/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-bc-transit-whistler-transit-system-gtfs-702.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-fraser-valley-express-gtfs-698.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-fraser-valley-express-gtfs-698.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 698,
+    "data_type": "gtfs",
+    "provider": "Fraser Valley Express",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Fraser Valley",
+        "bounding_box": {
+            "minimum_latitude": 49.03258,
+            "maximum_latitude": 49.247973,
+            "minimum_longitude": -122.895491,
+            "maximum_longitude": -121.955443,
+            "extracted_on": "2022-03-16T22:05:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/fraser-valley-express.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-fraser-valley-express-gtfs-698.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-prince-george-transit-gtfs-708.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-prince-george-transit-gtfs-708.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 708,
+    "data_type": "gtfs",
+    "provider": "Prince George Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Prince George",
+        "bounding_box": {
+            "minimum_latitude": 53.830781,
+            "maximum_latitude": 54.010517,
+            "minimum_longitude": -122.830644,
+            "maximum_longitude": -122.737908,
+            "extracted_on": "2022-03-16T22:05:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/prince-george.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-prince-george-transit-gtfs-708.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-translink-west-coast-express-gtfs-696.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-translink-west-coast-express-gtfs-696.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 696,
+    "data_type": "gtfs",
+    "provider": "TransLink West Coast Express",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Vancouver",
+        "bounding_box": {
+            "minimum_latitude": 49.004383,
+            "maximum_latitude": 49.474111,
+            "minimum_longitude": -123.423063,
+            "maximum_longitude": -122.30486,
+            "extracted_on": "2022-03-16T22:04:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.translink.ca/static/latest",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-translink-west-coast-express-gtfs-696.zip?alt=media",
+        "license": "https://developer.translink.ca/ServicesGtfs/GtfsData"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-indiana-muncie-indiana-transit-system-mits-gtfs-719.json
+++ b/catalogs/sources/gtfs/schedule/ca-indiana-muncie-indiana-transit-system-mits-gtfs-719.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 719,
+    "data_type": "gtfs",
+    "provider": "Muncie Indiana Transit System (MITS)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Indiana",
+        "municipality": "Muncie",
+        "bounding_box": {
+            "minimum_latitude": 40.154119,
+            "maximum_latitude": 40.231927,
+            "minimum_longitude": -85.442719,
+            "maximum_longitude": -85.329372,
+            "extracted_on": "2022-03-16T22:06:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.mitsbus.org/wp-content/uploads/2016/11/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-indiana-muncie-indiana-transit-system-mits-gtfs-719.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-manitoba-winnipeg-transit-gtfs-717.json
+++ b/catalogs/sources/gtfs/schedule/ca-manitoba-winnipeg-transit-gtfs-717.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 717,
+    "data_type": "gtfs",
+    "provider": "Winnipeg Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Manitoba",
+        "municipality": "Winnipeg",
+        "bounding_box": {
+            "minimum_latitude": 49.763940715545736,
+            "maximum_latitude": 49.96947367856984,
+            "minimum_longitude": -97.32299682965768,
+            "maximum_longitude": -96.96269333563112,
+            "extracted_on": "2022-03-16T22:06:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.winnipegtransit.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-manitoba-winnipeg-transit-gtfs-717.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-brampton-transit-gtfs-729.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-brampton-transit-gtfs-729.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 729,
+    "data_type": "gtfs",
+    "provider": "Brampton Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Brampton",
+        "bounding_box": {
+            "minimum_latitude": 43.547852,
+            "maximum_latitude": 43.819111,
+            "minimum_longitude": -79.861496,
+            "maximum_longitude": -79.527649,
+            "extracted_on": "2022-03-16T22:07:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.brampton.ca/EN/City-Hall/OpenGov/Open-Data-Catalogue/Documents/Google_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-brampton-transit-gtfs-729.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-burlington-transit-gtfs-724.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-burlington-transit-gtfs-724.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 724,
+    "data_type": "gtfs",
+    "provider": "Burlington Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Burlington",
+        "bounding_box": {
+            "minimum_latitude": 43.256679,
+            "maximum_latitude": 43.411717,
+            "minimum_longitude": -79.892603,
+            "maximum_longitude": -79.725184,
+            "extracted_on": "2022-03-16T22:06:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://opendata.burlington.ca/gtfs-rt/GTFS_Data.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-burlington-transit-gtfs-724.zip?alt=media",
+        "license": "https://cob.burlington.opendata.arcgis.com/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-cornwall-transit-gtfs-718.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-cornwall-transit-gtfs-718.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 718,
+    "data_type": "gtfs",
+    "provider": "Cornwall Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Cornwall",
+        "bounding_box": {
+            "minimum_latitude": 45.0104676437,
+            "maximum_latitude": 45.0626772444,
+            "minimum_longitude": -74.77124,
+            "maximum_longitude": -74.67393,
+            "extracted_on": "2022-03-16T22:06:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://metrolinx.tmix.se/gtfs/gtfs-cornwall.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-cornwall-transit-gtfs-718.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-durham-region-transit-gtfs-726.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-durham-region-transit-gtfs-726.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 726,
+    "data_type": "gtfs",
+    "provider": "Durham Region Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Durham",
+        "bounding_box": {
+            "minimum_latitude": 43.774936,
+            "maximum_latitude": 44.112316,
+            "minimum_longitude": -79.252857,
+            "maximum_longitude": -78.674384,
+            "extracted_on": "2022-03-16T22:07:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://maps.durham.ca/OpenDataGTFS/GTFS_Durham_TXT.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-durham-region-transit-gtfs-726.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-go-transit-gtfs-727.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-go-transit-gtfs-727.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 727,
+    "data_type": "gtfs",
+    "provider": "Go Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Toronto",
+        "bounding_box": {
+            "minimum_latitude": 42.981586,
+            "maximum_latitude": 44.4297562,
+            "minimum_longitude": -81.244272,
+            "maximum_longitude": -78.2870331,
+            "extracted_on": "2022-03-16T22:07:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.gotransit.com/static_files/gotransit/assets/Files/GO_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-go-transit-gtfs-727.zip?alt=media",
+        "license": "https://www.gotransit.com/en/information-resources/software-developers"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-grand-river-transit-gtfs-721.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-grand-river-transit-gtfs-721.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 721,
+    "data_type": "gtfs",
+    "provider": "Grand River Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Waterloo",
+        "bounding_box": {
+            "minimum_latitude": 43.335858,
+            "maximum_latitude": 43.600215,
+            "minimum_longitude": -80.71477,
+            "maximum_longitude": -80.274613,
+            "extracted_on": "2022-03-16T22:06:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.regionofwaterloo.ca/opendatadownloads/GRT_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-grand-river-transit-gtfs-721.zip?alt=media",
+        "license": "http://www.regionofwaterloo.ca/en/regionalGovernment/GRT_GTFSdata.asp"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-hamilton-street-railway-gtfs-723.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-hamilton-street-railway-gtfs-723.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 723,
+    "data_type": "gtfs",
+    "provider": "Hamilton Street Railway",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Hamilton",
+        "bounding_box": {
+            "minimum_latitude": 43.156343,
+            "maximum_latitude": 43.326073,
+            "minimum_longitude": -80.031354,
+            "maximum_longitude": -79.692514,
+            "extracted_on": "2022-03-16T22:06:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://googlehsrdocs.hamilton.ca/",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-hamilton-street-railway-gtfs-723.zip?alt=media",
+        "license": "https://www.hamilton.ca/city-initiatives/strategies-actions/open-accessible-data"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-kingston-transit-gtfs-733.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-kingston-transit-gtfs-733.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 733,
+    "data_type": "gtfs",
+    "provider": "Kingston Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Kingston",
+        "bounding_box": {
+            "minimum_latitude": 44.2175,
+            "maximum_latitude": 44.27897,
+            "minimum_longitude": -76.66738,
+            "maximum_longitude": -76.43906,
+            "extracted_on": "2022-03-16T22:08:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://api.cityofkingston.ca/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-kingston-transit-gtfs-733.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-miway-gtfs-730.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-miway-gtfs-730.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 730,
+    "data_type": "gtfs",
+    "provider": "MiWay",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Mississauga",
+        "bounding_box": {
+            "minimum_latitude": 43.469292,
+            "maximum_latitude": 43.838069,
+            "minimum_longitude": -79.797795,
+            "maximum_longitude": -79.512874,
+            "extracted_on": "2022-03-16T22:07:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.miapp.ca/GTFS/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-miway-gtfs-730.zip?alt=media",
+        "license": "https://www.mississauga.ca/miway-transit/developer-download/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-niagara-region-transit-gtfs-722.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-niagara-region-transit-gtfs-722.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 722,
+    "data_type": "gtfs",
+    "provider": "Niagara Region Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Niagara",
+        "bounding_box": {
+            "minimum_latitude": 42.878677,
+            "maximum_latitude": 43.222885,
+            "minimum_longitude": -79.286779,
+            "maximum_longitude": -78.97349,
+            "extracted_on": "2022-03-16T22:06:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://maps.niagararegion.ca/googletransit/NiagaraRegionTransit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-niagara-region-transit-gtfs-722.zip?alt=media",
+        "license": "https://niagaraopendata.ca/pages/open-government-license-2-0-niagara-region"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-oakville-transit-gtfs-725.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-oakville-transit-gtfs-725.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 725,
+    "data_type": "gtfs",
+    "provider": "Oakville Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Oakville",
+        "bounding_box": {
+            "minimum_latitude": 43.372358,
+            "maximum_latitude": 43.543996,
+            "minimum_longitude": -79.829729,
+            "maximum_longitude": -79.632124,
+            "extracted_on": "2022-03-16T22:07:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.arcgis.com/sharing/rest/content/items/d78a1c1ad6a940009de8b68839a8f606/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-oakville-transit-gtfs-725.zip?alt=media",
+        "license": "http://www.oakville.ca/data/oakville-transit-route-information.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-toronto-transit-commission-gtfs-732.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-toronto-transit-commission-gtfs-732.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 732,
+    "data_type": "gtfs",
+    "provider": "Toronto Transit Commission",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Toronto",
+        "bounding_box": {
+            "minimum_latitude": 43.591811,
+            "maximum_latitude": 43.909707,
+            "minimum_longitude": -79.649908,
+            "maximum_longitude": -79.123111,
+            "extracted_on": "2022-03-16T22:08:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://opendata.toronto.ca/toronto.transit.commission/ttc-routes-and-schedules/OpenData_TTC_Schedules.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-toronto-transit-commission-gtfs-732.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-transit-windsor-gtfs-720.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-transit-windsor-gtfs-720.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 720,
+    "data_type": "gtfs",
+    "provider": "Transit Windsor",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Windsor",
+        "bounding_box": {
+            "minimum_latitude": 42.042087,
+            "maximum_latitude": 42.34243354,
+            "minimum_longitude": -83.103199,
+            "maximum_longitude": -82.606767,
+            "extracted_on": "2022-03-16T22:06:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://opendata.citywindsor.ca/Uploads/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-transit-windsor-gtfs-720.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-union-pearson-express-up-express-gtfs-731.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-union-pearson-express-up-express-gtfs-731.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 731,
+    "data_type": "gtfs",
+    "provider": "Union Pearson Express (UP Express)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Toronto",
+        "bounding_box": {
+            "minimum_latitude": 43.644238,
+            "maximum_latitude": 43.70058,
+            "minimum_longitude": -79.612968,
+            "maximum_longitude": -79.383555,
+            "extracted_on": "2022-03-16T22:07:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.gotransit.com/static_files/gotransit/assets/Files/UP-GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-union-pearson-express-up-express-gtfs-731.zip?alt=media",
+        "license": "https://www.gotransit.com/en/information-resources/software-developers"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-york-region-transit-gtfs-728.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-york-region-transit-gtfs-728.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 728,
+    "data_type": "gtfs",
+    "provider": "York Region Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "York",
+        "bounding_box": {
+            "minimum_latitude": 43.720413,
+            "maximum_latitude": 44.32131,
+            "minimum_longitude": -79.659289,
+            "maximum_longitude": -79.212178,
+            "extracted_on": "2022-03-16T22:07:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.yrt.ca/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-york-region-transit-gtfs-728.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-saskatchewan-city-of-regina-gtfs-715.json
+++ b/catalogs/sources/gtfs/schedule/ca-saskatchewan-city-of-regina-gtfs-715.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 715,
+    "data_type": "gtfs",
+    "provider": "City of Regina",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Saskatchewan",
+        "municipality": "Regina",
+        "bounding_box": {
+            "minimum_latitude": 50.40078,
+            "maximum_latitude": 50.50887,
+            "minimum_longitude": -104.7079,
+            "maximum_longitude": -104.503773,
+            "extracted_on": "2022-03-16T22:06:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://opengis.regina.ca/reginagtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-saskatchewan-city-of-regina-gtfs-715.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-saskatchewan-saskatoon-transit-gtfs-716.json
+++ b/catalogs/sources/gtfs/schedule/ca-saskatchewan-saskatoon-transit-gtfs-716.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 716,
+    "data_type": "gtfs",
+    "provider": "Saskatoon Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Saskatchewan",
+        "municipality": "Saskatoon",
+        "bounding_box": {
+            "minimum_latitude": 52.078661,
+            "maximum_latitude": 52.202189,
+            "minimum_longitude": -106.760746,
+            "maximum_longitude": -106.550137,
+            "extracted_on": "2022-03-16T22:06:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://apps2.saskatoon.ca/app/data/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-saskatchewan-saskatoon-transit-gtfs-716.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-yukon-whitehorse-transit-gtfs-689.json
+++ b/catalogs/sources/gtfs/schedule/ca-yukon-whitehorse-transit-gtfs-689.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 689,
+    "data_type": "gtfs",
+    "provider": "Whitehorse Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Yukon",
+        "municipality": "Whitehorse",
+        "bounding_box": {
+            "minimum_latitude": 60.683944,
+            "maximum_latitude": 60.7876185,
+            "minimum_longitude": -135.1688514,
+            "maximum_longitude": -135.0168974,
+            "extracted_on": "2022-03-16T22:04:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.whitehorse.ca/Google_transit_Feed_Docs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-yukon-whitehorse-transit-gtfs-689.zip?alt=media",
+        "license": "https://data.whitehorse.ca/"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the fourth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 87 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~