### PR TITLE
feat: Fifth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ca-alberta-lethbridge-transit-gtfs-765.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-lethbridge-transit-gtfs-765.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 765,
+    "data_type": "gtfs",
+    "provider": "Lethbridge Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Alberta",
+        "municipality": "Lethbridge",
+        "bounding_box": {
+            "minimum_latitude": 49.6515019030274,
+            "maximum_latitude": 49.7383759759889,
+            "minimum_longitude": -112.913215781046,
+            "maximum_longitude": -112.781255112961,
+            "extracted_on": "2022-03-17T13:16:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.lethbridge.ca/OpenDataSets/GTFS_Transit_Data.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-alberta-lethbridge-transit-gtfs-765.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-port-alberni-gtfs-761.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-port-alberni-gtfs-761.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 761,
+    "data_type": "gtfs",
+    "provider": "Port Alberni",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Port Alberni",
+        "bounding_box": {
+            "minimum_latitude": 49.21847,
+            "maximum_latitude": 49.27743,
+            "minimum_longitude": -124.85047,
+            "maximum_longitude": -124.78265,
+            "extracted_on": "2022-03-17T13:16:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://bct.tmix.se/Tmix.Cap.TdExport.WebApi/gtfs/?operatorIds=11",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-port-alberni-gtfs-761.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-south-okanagan-similkameen-gtfs-762.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-south-okanagan-similkameen-gtfs-762.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 762,
+    "data_type": "gtfs",
+    "provider": "South Okanagan-Similkameen",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "bounding_box": {
+            "minimum_latitude": 49.453034,
+            "maximum_latitude": 49.887128,
+            "minimum_longitude": -119.735228,
+            "maximum_longitude": -119.494941,
+            "extracted_on": "2022-03-17T13:16:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bctransit.com/data/gtfs/south-okanagan-similkameen.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-south-okanagan-similkameen-gtfs-762.zip?alt=media",
+        "license": "https://www.bctransit.com/open-data/terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-new-brunswick-fredericton-transit-gtfs-764.json
+++ b/catalogs/sources/gtfs/schedule/ca-new-brunswick-fredericton-transit-gtfs-764.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 764,
+    "data_type": "gtfs",
+    "provider": "Fredericton Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "New Brunswick",
+        "municipality": "Fredericton",
+        "bounding_box": {
+            "minimum_latitude": 45.90273428,
+            "maximum_latitude": 46.01368444,
+            "minimum_longitude": -66.76942465,
+            "maximum_longitude": -66.57699011,
+            "extracted_on": "2022-03-17T13:16:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.arcgis.com/sharing/rest/content/items/36704575683245329a1b208bcbc72e72/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-new-brunswick-fredericton-transit-gtfs-764.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-newfoundland-metrobus-transit-gtfs-758.json
+++ b/catalogs/sources/gtfs/schedule/ca-newfoundland-metrobus-transit-gtfs-758.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 758,
+    "data_type": "gtfs",
+    "provider": "Metrobus Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Newfoundland",
+        "municipality": "St. John's",
+        "bounding_box": {
+            "minimum_latitude": 47.436518,
+            "maximum_latitude": 47.619686,
+            "minimum_longitude": -52.872601,
+            "maximum_longitude": -52.67875,
+            "extracted_on": "2022-03-17T13:16:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.metrobustransit.ca/google/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-newfoundland-metrobus-transit-gtfs-758.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-nova-scotia-halifax-transit-gtfs-734.json
+++ b/catalogs/sources/gtfs/schedule/ca-nova-scotia-halifax-transit-gtfs-734.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 734,
+    "data_type": "gtfs",
+    "provider": "Halifax Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Nova Scotia",
+        "municipality": "Halifax",
+        "bounding_box": {
+            "minimum_latitude": 44.565098,
+            "maximum_latitude": 44.886253,
+            "minimum_longitude": -63.858243,
+            "maximum_longitude": -63.28321,
+            "extracted_on": "2022-03-17T13:15:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.halifax.ca/static/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-nova-scotia-halifax-transit-gtfs-734.zip?alt=media",
+        "license": "http://www.halifax.ca/opendata/OD_TermsOfUse.php"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-greater-sudbury-transit-gtfs-737.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-greater-sudbury-transit-gtfs-737.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 737,
+    "data_type": "gtfs",
+    "provider": "Greater Sudbury Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Sudbury",
+        "bounding_box": {
+            "minimum_latitude": 46.3981059752405,
+            "maximum_latitude": 46.7159690335393,
+            "minimum_longitude": -81.2044530082495,
+            "maximum_longitude": -80.8472879603506,
+            "extracted_on": "2022-03-17T13:15:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.greatersudbury.ca/image/opendata/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-greater-sudbury-transit-gtfs-737.zip?alt=media",
+        "license": "http://www.greatersudbury.ca/inside-city-hall/open-government/open-data/open-data-apps/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-milton-transit-gtfs-759.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-milton-transit-gtfs-759.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 759,
+    "data_type": "gtfs",
+    "provider": "Milton Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Milton",
+        "bounding_box": {
+            "minimum_latitude": 43.48015,
+            "maximum_latitude": 43.54222,
+            "minimum_longitude": -79.89257,
+            "maximum_longitude": -79.82503,
+            "extracted_on": "2022-03-17T13:16:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://metrolinx.tmix.se/gtfs/gtfs-milton.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-milton-transit-gtfs-759.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-ottawa-carleton-regional-transit-commission-oc-transpo-gtfs-738.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-ottawa-carleton-regional-transit-commission-oc-transpo-gtfs-738.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 738,
+    "data_type": "gtfs",
+    "provider": "Ottawa-Carleton Regional Transit Commission (OC Transpo)",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Ottawa",
+        "bounding_box": {
+            "minimum_latitude": 45.130139,
+            "maximum_latitude": 45.519695,
+            "minimum_longitude": -76.042785,
+            "maximum_longitude": -75.342688,
+            "extracted_on": "2022-03-17T13:15:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.octranspo1.com/files/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-ottawa-carleton-regional-transit-commission-oc-transpo-gtfs-738.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-thunder-bay-transit-gtfs-736.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-thunder-bay-transit-gtfs-736.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 736,
+    "data_type": "gtfs",
+    "provider": "Thunder Bay Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Thunder Bay",
+        "bounding_box": {
+            "minimum_latitude": 48.34626,
+            "maximum_latitude": 48.47868,
+            "minimum_longitude": -89.38849,
+            "maximum_longitude": -89.1819,
+            "extracted_on": "2022-03-17T13:15:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://api.nextlift.ca/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-thunder-bay-transit-gtfs-736.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-chambly-richelieu-carignan-gtfs-750.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-chambly-richelieu-carignan-gtfs-750.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 750,
+    "data_type": "gtfs",
+    "provider": "Exo Chambly-Richelieu-Carignan",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.297053,
+            "maximum_latitude": 45.540842,
+            "minimum_longitude": -73.566033,
+            "maximum_longitude": -73.143402,
+            "extracted_on": "2022-03-17T13:15:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citcrc/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-chambly-richelieu-carignan-gtfs-750.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-gtfs-748.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-gtfs-748.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 748,
+    "data_type": "gtfs",
+    "provider": "Exo",
+    "name": "Trains",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.360651,
+            "maximum_latitude": 45.773179,
+            "minimum_longitude": -74.140935,
+            "maximum_longitude": -73.1785,
+            "extracted_on": "2022-03-17T13:15:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/trains/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-gtfs-748.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-haut-saint-laurent-gtfs-745.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-haut-saint-laurent-gtfs-745.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 745,
+    "data_type": "gtfs",
+    "provider": "Exo Haut-Saint-Laurent",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.235,
+            "maximum_latitude": 45.498306,
+            "minimum_longitude": -73.811902,
+            "maximum_longitude": -73.564724,
+            "extracted_on": "2022-03-17T13:15:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/cithsl/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-haut-saint-laurent-gtfs-745.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-la-presquile-gtfs-743.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-la-presquile-gtfs-743.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 743,
+    "data_type": "gtfs",
+    "provider": "Exo La Presqu'île",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.350844,
+            "maximum_latitude": 45.513436,
+            "minimum_longitude": -74.315165,
+            "maximum_longitude": -73.682942,
+            "extracted_on": "2022-03-17T13:15:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citpi/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-la-presquile-gtfs-743.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-lassomption-gtfs-755.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-lassomption-gtfs-755.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 755,
+    "data_type": "gtfs",
+    "provider": "Exo L'Assomption",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "L'Assomption",
+        "bounding_box": {
+            "minimum_latitude": 45.589483,
+            "maximum_latitude": 45.901438,
+            "minimum_longitude": -73.539828,
+            "maximum_longitude": -73.277404,
+            "extracted_on": "2022-03-17T13:16:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/mrclasso/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-lassomption-gtfs-755.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-laurentides-gtfs-744.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-laurentides-gtfs-744.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 744,
+    "data_type": "gtfs",
+    "provider": "Exo Laurentides",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.460471,
+            "maximum_latitude": 45.813779,
+            "minimum_longitude": -74.206726,
+            "maximum_longitude": -73.56419,
+            "extracted_on": "2022-03-17T13:15:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citla/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-laurentides-gtfs-744.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-le-richelain-gtfs-746.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-le-richelain-gtfs-746.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 746,
+    "data_type": "gtfs",
+    "provider": "Exo Le Richelain",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.351194,
+            "maximum_latitude": 45.548627,
+            "minimum_longitude": -73.565996,
+            "maximum_longitude": -73.387583,
+            "extracted_on": "2022-03-17T13:15:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citlr/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-le-richelain-gtfs-746.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-roussillon-gtfs-747.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-roussillon-gtfs-747.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 747,
+    "data_type": "gtfs",
+    "provider": "Exo Roussillon",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.362224,
+            "maximum_latitude": 45.548687,
+            "minimum_longitude": -73.645546,
+            "maximum_longitude": -73.465159,
+            "extracted_on": "2022-03-17T13:15:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citrous/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-roussillon-gtfs-747.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-sorel-varennes-gtfs-741.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-sorel-varennes-gtfs-741.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 741,
+    "data_type": "gtfs",
+    "provider": "Exo Sorel-Varennes",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Varennes",
+        "bounding_box": {
+            "minimum_latitude": 45.524297,
+            "maximum_latitude": 46.046225,
+            "minimum_longitude": -73.540802,
+            "maximum_longitude": -73.084444,
+            "extracted_on": "2022-03-17T13:15:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citsv/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-sorel-varennes-gtfs-741.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-sud-ouest-gtfs-742.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-sud-ouest-gtfs-742.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 742,
+    "data_type": "gtfs",
+    "provider": "Exo Sud-ouest",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.251963,
+            "maximum_latitude": 45.4981,
+            "minimum_longitude": -74.132096,
+            "maximum_longitude": -73.564442,
+            "extracted_on": "2022-03-17T13:15:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citso/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-sud-ouest-gtfs-742.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-vallee-du-richelieu-gtfs-752.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-vallee-du-richelieu-gtfs-752.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 752,
+    "data_type": "gtfs",
+    "provider": "Exo Vallée du Richelieu",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "La Vallée-du-Richelieu",
+        "bounding_box": {
+            "minimum_latitude": 45.496375,
+            "maximum_latitude": 45.652233,
+            "minimum_longitude": -73.564192,
+            "maximum_longitude": -72.88893,
+            "extracted_on": "2022-03-17T13:16:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/citvr/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-vallee-du-richelieu-gtfs-752.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-exo-ville-de-sainte-julie-gtfs-753.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-exo-ville-de-sainte-julie-gtfs-753.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 753,
+    "data_type": "gtfs",
+    "provider": "Exo Ville de Sainte-Julie",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Sainte-Julie",
+        "bounding_box": {
+            "minimum_latitude": 45.497418,
+            "maximum_latitude": 45.63169,
+            "minimum_longitude": -73.56448,
+            "maximum_longitude": -73.288934,
+            "extracted_on": "2022-03-17T13:16:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/omitsju/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-exo-ville-de-sainte-julie-gtfs-753.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-regie-intermunicipale-de-transport-des-collines-gtfs-739.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-regie-intermunicipale-de-transport-des-collines-gtfs-739.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 739,
+    "data_type": "gtfs",
+    "provider": "Régie intermunicipale de transport des Collines",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "La Pêche",
+        "bounding_box": {
+            "minimum_latitude": 45.407263,
+            "maximum_latitude": 45.919647,
+            "minimum_longitude": -77.076473,
+            "maximum_longitude": -75.617139,
+            "extracted_on": "2022-03-17T13:15:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transcollines/gtfs/raw/master/transcollines-qc-ca.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-regie-intermunicipale-de-transport-des-collines-gtfs-739.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-reseau-de-transport-de-la-capitale-gtfs-757.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-reseau-de-transport-de-la-capitale-gtfs-757.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 757,
+    "data_type": "gtfs",
+    "provider": "Réseau de transport de la Capitale",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 46.734726,
+            "maximum_latitude": 46.943394,
+            "minimum_longitude": -71.472099,
+            "maximum_longitude": -71.149269,
+            "extracted_on": "2022-03-17T13:16:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://cdn.rtcquebec.ca/Site_Internet/DonneesOuvertes/googletransit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-reseau-de-transport-de-la-capitale-gtfs-757.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-reseau-de-transport-de-longueuil-gtfs-751.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-reseau-de-transport-de-longueuil-gtfs-751.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 751,
+    "data_type": "gtfs",
+    "provider": "Réseau de transport de Longueuil",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Longueuil",
+        "bounding_box": {
+            "minimum_latitude": 45.4249621194855,
+            "maximum_latitude": 45.6373480184109,
+            "minimum_longitude": -73.5668819023177,
+            "maximum_longitude": -73.3023082633461,
+            "extracted_on": "2022-03-17T13:16:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.rtl-longueuil.qc.ca/transit/latestfeed/RTL.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-reseau-de-transport-de-longueuil-gtfs-751.zip?alt=media",
+        "license": "http://www.rtl-longueuil.qc.ca/fr-CA/donnees-ouvertes/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-laval-gtfs-749.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-laval-gtfs-749.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 749,
+    "data_type": "gtfs",
+    "provider": "Société de transport de Laval",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Laval",
+        "bounding_box": {
+            "minimum_latitude": 45.504517,
+            "maximum_latitude": 45.699292,
+            "minimum_longitude": -73.88344,
+            "maximum_longitude": -73.53437,
+            "extracted_on": "2022-03-17T13:15:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.stl.laval.qc.ca/opendata/GTF_STL.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-societe-de-transport-de-laval-gtfs-749.zip?alt=media",
+        "license": "http://www.stl.laval.qc.ca/en/stl-synchro/developers/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-levis-gtfs-763.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-levis-gtfs-763.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 763,
+    "data_type": "gtfs",
+    "provider": "Société de transport de Lévis",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Lévis",
+        "bounding_box": {
+            "minimum_latitude": 46.552296,
+            "maximum_latitude": 46.828171,
+            "minimum_longitude": -71.409636,
+            "maximum_longitude": -71.064983,
+            "extracted_on": "2022-03-17T13:16:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.stlevis.ca/sites/default/files/public/assets/gtfs/transit/gtfs_stlevis.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-societe-de-transport-de-levis-gtfs-763.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-loutaouais-gtfs-740.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-loutaouais-gtfs-740.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 740,
+    "data_type": "gtfs",
+    "provider": "Société de transport de l'Outaouais",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Gatineau",
+        "bounding_box": {
+            "minimum_latitude": 45.381261,
+            "maximum_latitude": 45.592886,
+            "minimum_longitude": -75.890201,
+            "maximum_longitude": -75.390856,
+            "extracted_on": "2022-03-17T13:15:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.contenu.sto.ca/GTFS/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-societe-de-transport-de-loutaouais-gtfs-740.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-sherbrooke-gtfs-756.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-sherbrooke-gtfs-756.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 756,
+    "data_type": "gtfs",
+    "provider": "Société de Transport de Sherbrooke",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Sherbrooke",
+        "bounding_box": {
+            "minimum_latitude": 45.314276,
+            "maximum_latitude": 45.481662,
+            "minimum_longitude": -72.082565,
+            "maximum_longitude": -71.815462,
+            "extracted_on": "2022-03-17T13:16:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.donneesquebec.ca/recherche/dataset/e82b9141-09d8-4f85-af37-d84937bc2503/resource/b7f43b2a-2557-4e3b-ba12-5a5c6d4de5b1/download/gtfssherbrooke.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-societe-de-transport-de-sherbrooke-gtfs-756.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-societe-des-transports-de-rimouski-gtfs-760.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-societe-des-transports-de-rimouski-gtfs-760.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 760,
+    "data_type": "gtfs",
+    "provider": "Société des transports de Rimouski",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Rimouski",
+        "bounding_box": {
+            "minimum_latitude": 48.4261848,
+            "maximum_latitude": 48.46963779,
+            "minimum_longitude": -68.59305527,
+            "maximum_longitude": -68.49610563,
+            "extracted_on": "2022-03-17T13:16:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/str-qc-ca/str-qc-ca.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-societe-des-transports-de-rimouski-gtfs-760.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-terrebonne-mascouche-gtfs-754.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-terrebonne-mascouche-gtfs-754.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 754,
+    "data_type": "gtfs",
+    "provider": "Terrebonne-Mascouche",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.5542,
+            "maximum_latitude": 45.80231,
+            "minimum_longitude": -73.842682,
+            "maximum_longitude": -73.498242,
+            "extracted_on": "2022-03-17T13:16:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://exo.quebec/xdata/mrclm/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-terrebonne-mascouche-gtfs-754.zip?alt=media",
+        "license": "https://www.donneesquebec.ca/fr/licence/#cc-by"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-unknown-via-rail-canada-gtfs-735.json
+++ b/catalogs/sources/gtfs/schedule/ca-unknown-via-rail-canada-gtfs-735.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 735,
+    "data_type": "gtfs",
+    "provider": "VIA Rail Canada",
+    "location": {
+        "country_code": "CA",
+        "bounding_box": {
+            "minimum_latitude": 40.7502300443,
+            "maximum_latitude": 58.767685933,
+            "minimum_longitude": -130.352241212,
+            "maximum_longitude": -63.2759008362,
+            "extracted_on": "2022-03-17T13:15:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.viarail.ca/sites/all/files/gtfs/viarail.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-unknown-via-rail-canada-gtfs-735.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/cm-littoral-socatur-gtfs-766.json
+++ b/catalogs/sources/gtfs/schedule/cm-littoral-socatur-gtfs-766.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 766,
+    "data_type": "gtfs",
+    "provider": "Socatur",
+    "location": {
+        "country_code": "CM",
+        "subdivision_name": "Littoral",
+        "municipality": "Communauté urbaine de Douala",
+        "bounding_box": {
+            "minimum_latitude": 3.9931,
+            "maximum_latitude": 4.1016334,
+            "minimum_longitude": 9.6304111,
+            "maximum_longitude": 9.80538,
+            "extracted_on": "2022-03-17T13:16:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://git.digitaltransport4africa.org/places/douala/raw/master/GTFS-SYSTRA/GTFS-SYSTRA.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/cm-littoral-socatur-gtfs-766.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/cz-praha-prazska-integrovana-doprava-pid-gtfs-767.json
+++ b/catalogs/sources/gtfs/schedule/cz-praha-prazska-integrovana-doprava-pid-gtfs-767.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 767,
+    "data_type": "gtfs",
+    "provider": "Prazska integrovana doprava (PID)",
+    "location": {
+        "country_code": "CZ",
+        "subdivision_name": "Praha, hlavní mešto",
+        "bounding_box": {
+            "minimum_latitude": 49.007847,
+            "maximum_latitude": 50.951221,
+            "minimum_longitude": 13.312689,
+            "maximum_longitude": 15.576265,
+            "extracted_on": "2022-03-17T13:17:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.pid.cz/PID_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/cz-praha-prazska-integrovana-doprava-pid-gtfs-767.zip?alt=media",
+        "license": "https://pid.cz/o-systemu/opendata/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-bodo-verkehrsverbund-gtfs-769.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-bodo-verkehrsverbund-gtfs-769.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 769,
+    "data_type": "gtfs",
+    "provider": "bodo Verkehrsverbund",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Ravensburg",
+        "bounding_box": {
+            "minimum_latitude": -89.5741127664391,
+            "maximum_latitude": 69.5764400666113,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 87.2540642445966,
+            "extracted_on": "2022-03-17T13:17:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bodo.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-bodo-verkehrsverbund-gtfs-769.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-db-zugbus-regionalverkehr-alb-bodensee-gtfs-773.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-db-zugbus-regionalverkehr-alb-bodensee-gtfs-773.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 773,
+    "data_type": "gtfs",
+    "provider": "DB ZugBus Regionalverkehr Alb-Bodensee",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Ulm",
+        "bounding_box": {
+            "minimum_latitude": 47.5451266420834,
+            "maximum_latitude": 48.6809579393641,
+            "minimum_longitude": 8.56868813660092,
+            "maximum_longitude": 10.2950524835564,
+            "extracted_on": "2022-03-17T13:23:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/rab.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-db-zugbus-regionalverkehr-alb-bodensee-gtfs-773.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-deutsche-bahn-s-bahn-stuttgart-gtfs-775.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-deutsche-bahn-s-bahn-stuttgart-gtfs-775.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 775,
+    "data_type": "gtfs",
+    "provider": "Deutsche Bahn (S-Bahn Stuttgart)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "bounding_box": {
+            "minimum_latitude": 48.593991,
+            "maximum_latitude": 48.948229,
+            "minimum_longitude": 8.862662,
+            "maximum_longitude": 9.52631,
+            "extracted_on": "2022-03-17T13:23:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://download-data.deutschebahn.com/static/datasets/sbahn_stuttgart_gtfs/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-deutsche-bahn-s-bahn-stuttgart-gtfs-775.zip?alt=media",
+        "license": "http://data.deutschebahn.com/dataset/data-s-bahn-stuttgart-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-naldo-verkehrsverbund-gtfs-771.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-naldo-verkehrsverbund-gtfs-771.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 771,
+    "data_type": "gtfs",
+    "provider": "naldo Verkehrsverbund",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Hechingen",
+        "bounding_box": {
+            "minimum_latitude": 47.7691186771883,
+            "maximum_latitude": 48.6917099455617,
+            "minimum_longitude": 8.68140873846793,
+            "maximum_longitude": 9.72322090621772,
+            "extracted_on": "2022-03-17T13:19:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_ohne_liniennetz/naldo.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-naldo-verkehrsverbund-gtfs-771.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-ova-aalen-gtfs-772.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-ova-aalen-gtfs-772.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 772,
+    "data_type": "gtfs",
+    "provider": "OVA-Aalen, OVA-Bopfingen, Beck+Schubert",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 48.9455003669179,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 10.4367347701875,
+            "extracted_on": "2022-03-17T13:19:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/oam.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-ova-aalen-gtfs-772.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-rhein-neckar-verkehr-gtfs-777.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-rhein-neckar-verkehr-gtfs-777.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 777,
+    "data_type": "gtfs",
+    "provider": "Rhein-Neckar-Verkehr",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Mannheim",
+        "bounding_box": {
+            "minimum_latitude": 49.3434511,
+            "maximum_latitude": 49.5811911,
+            "minimum_longitude": 8.1704289,
+            "maximum_longitude": 8.811395,
+            "extracted_on": "2022-03-17T13:24:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs-sandbox-dds.rnv-online.de/latest/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-rhein-neckar-verkehr-gtfs-777.zip?alt=media",
+        "license": "https://opendata.rnv-online.de/dataset/gtfs-general-transit-feed-specification"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-stadtwerke-heilbronn-swhn-gtfs-783.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-stadtwerke-heilbronn-swhn-gtfs-783.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 783,
+    "data_type": "gtfs",
+    "provider": "Stadtwerke Heilbronn (SWHN)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Heilbronn",
+        "bounding_box": {
+            "minimum_latitude": 48.4965248104922,
+            "maximum_latitude": 49.4934318893617,
+            "minimum_longitude": 7.33659482534244,
+            "maximum_longitude": 10.0675631209744,
+            "extracted_on": "2022-03-17T13:26:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/hnv.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-stadtwerke-heilbronn-swhn-gtfs-783.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-swu-verkehr-gmbh-swu-gtfs-776.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-swu-verkehr-gmbh-swu-gtfs-776.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 776,
+    "data_type": "gtfs",
+    "provider": "SWU Verkehr GmbH (SWU)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Ulm",
+        "bounding_box": {
+            "minimum_latitude": 48.299865723,
+            "maximum_latitude": 48.455051422,
+            "minimum_longitude": 9.8788261414,
+            "maximum_longitude": 10.030753136,
+            "extracted_on": "2022-03-17T13:23:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.swu.de/daten/SWU.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-swu-verkehr-gmbh-swu-gtfs-776.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-bbs-schapfl-gtfs-770.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-bbs-schapfl-gtfs-770.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 770,
+    "data_type": "gtfs",
+    "provider": "BBS Schapfl",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 48.7636530586771,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 10.4537937774353,
+            "extracted_on": "2022-03-17T13:18:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/ding.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-bbs-schapfl-gtfs-770.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-erfurter-verkehrsbetriebe-ag-gtfs-780.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-erfurter-verkehrsbetriebe-ag-gtfs-780.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 780,
+    "data_type": "gtfs",
+    "provider": "Erfurter Verkehrsbetriebe AG",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "bounding_box": {
+            "minimum_latitude": 50.035311,
+            "maximum_latitude": 52.594718,
+            "minimum_longitude": 9.446892,
+            "maximum_longitude": 12.48745,
+            "extracted_on": "2022-03-17T13:24:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.vmt-thueringen.de/fileadmin/user_upload/Open_Data/VMT_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-erfurter-verkehrsbetriebe-ag-gtfs-780.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-gesamtnetz-der-deutschen-bahn-gtfs-768.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-gesamtnetz-der-deutschen-bahn-gtfs-768.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 768,
+    "data_type": "gtfs",
+    "provider": "Gesamtnetz der deutschen Bahn",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "bounding_box": {
+            "minimum_latitude": 44.50614,
+            "maximum_latitude": 56.150074,
+            "minimum_longitude": 2.35912,
+            "maximum_longitude": 22.776363,
+            "extracted_on": "2022-03-17T13:17:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://download.gtfs.de/germany/fv_free/latest.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-gesamtnetz-der-deutschen-bahn-gtfs-768.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-munchner-verkehrs-und-tarifverbund-mvv-gtfs-779.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-munchner-verkehrs-und-tarifverbund-mvv-gtfs-779.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 779,
+    "data_type": "gtfs",
+    "provider": "Münchner Verkehrs und Tarifverbund (MVV)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "municipality": "Munich",
+        "bounding_box": {
+            "minimum_latitude": 47.7410778270886,
+            "maximum_latitude": 48.649323180728,
+            "minimum_longitude": 10.9765863234071,
+            "maximum_longitude": 12.2729361269476,
+            "extracted_on": "2022-03-17T13:24:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.mvv-muenchen.de/fileadmin/mediapool/02-Fahrplanauskunft/03-Downloads/openData/mvv_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-munchner-verkehrs-und-tarifverbund-mvv-gtfs-779.zip?alt=media",
+        "license": "https://www.mvv-muenchen.de/fahrplanauskunft/fuer-entwickler/opendata/index.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-verkehrsverbund-rhein-sieg-gtfs-778.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-verkehrsverbund-rhein-sieg-gtfs-778.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 778,
+    "data_type": "gtfs",
+    "provider": "Verkehrsverbund Rhein-Sieg",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "bounding_box": {
+            "minimum_latitude": 49.961427,
+            "maximum_latitude": 51.274642,
+            "minimum_longitude": 6.230127,
+            "maximum_longitude": 8.394097,
+            "extracted_on": "2022-03-17T13:24:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://download.vrsinfo.de/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-verkehrsverbund-rhein-sieg-gtfs-778.zip?alt=media",
+        "license": "https://www.vrs.de/fahren/fahrplanauskunft/opendata-/-openservice"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-berlin-verkehrsverbund-berlin-brandenburg-gtfs-782.json
+++ b/catalogs/sources/gtfs/schedule/de-berlin-verkehrsverbund-berlin-brandenburg-gtfs-782.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 782,
+    "data_type": "gtfs",
+    "provider": "Verkehrsverbund Berlin-Brandenburg",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Berlin",
+        "bounding_box": {
+            "minimum_latitude": 50.839245,
+            "maximum_latitude": 54.322927,
+            "minimum_longitude": 10.669821,
+            "maximum_longitude": 17.037088,
+            "extracted_on": "2022-03-17T13:25:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://vbb.de/vbbgtfs",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-berlin-verkehrsverbund-berlin-brandenburg-gtfs-782.zip?alt=media",
+        "license": "http://vbb.de/vbbgtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-germany-verkehrsverbund-rhein-ruhr-gtfs-785.json
+++ b/catalogs/sources/gtfs/schedule/de-germany-verkehrsverbund-rhein-ruhr-gtfs-785.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 785,
+    "data_type": "gtfs",
+    "provider": "Verkehrsverbund Rhein-Ruhr",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Germany",
+        "municipality": "Ruhr",
+        "bounding_box": {
+            "minimum_latitude": 50.3493192,
+            "maximum_latitude": 52.2906704,
+            "minimum_longitude": 5.8534852,
+            "maximum_longitude": 9.4481208,
+            "extracted_on": "2022-03-17T13:29:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.opendata-oepnv.de/dataset/496eea5d-d6ef-4dc2-aeb0-d15c4fbf3178/resource/9874f617-0b5d-46c4-93da-cc0bb8598fd1/download/20220129_gtfs_vrr.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-germany-verkehrsverbund-rhein-ruhr-gtfs-785.zip?alt=media",
+        "license": "https://opendata.ruhr/dataset/soll-fahrplandaten-vrr"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-sachsen-leipziger-verkehrsbetriebe-lvb-gtfs-781.json
+++ b/catalogs/sources/gtfs/schedule/de-sachsen-leipziger-verkehrsbetriebe-lvb-gtfs-781.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 781,
+    "data_type": "gtfs",
+    "provider": "Leipziger Verkehrsbetriebe (LVB)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Sachsen",
+        "municipality": "Leipzig",
+        "bounding_box": {
+            "minimum_latitude": 50.822654,
+            "maximum_latitude": 51.669633,
+            "minimum_longitude": 11.411137,
+            "maximum_longitude": 13.226496,
+            "extracted_on": "2022-03-17T13:24:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://opendata.leipzig.de/dataset/8803f612-2ce1-4643-82d1-213434889200/resource/b38955c4-431c-4e8b-a4ef-9964a3a2c95d/download/gtfsmdvlvb.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-sachsen-leipziger-verkehrsbetriebe-lvb-gtfs-781.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-rursee-schifffahrt-kg-gtfs-784.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-rursee-schifffahrt-kg-gtfs-784.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 784,
+    "data_type": "gtfs",
+    "provider": "Rursee-Schifffahrt KG",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": -89.999999,
+            "maximum_latitude": 69.57644,
+            "minimum_longitude": -170.198799,
+            "maximum_longitude": 179.999997,
+            "extracted_on": "2022-03-17T13:28:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://de.data.public-transport.earth/gtfs-germany.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-rursee-schifffahrt-kg-gtfs-784.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-schweizer-reisen-gtfs-774.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-schweizer-reisen-gtfs-774.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 774,
+    "data_type": "gtfs",
+    "provider": "Schweizer Reisen",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 48.5981862388082,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 8.78219971336017,
+            "extracted_on": "2022-03-17T13:23:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vgf.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-schweizer-reisen-gtfs-774.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/eg-al-qahirah-cairo-metro-gtfs-786.json
+++ b/catalogs/sources/gtfs/schedule/eg-al-qahirah-cairo-metro-gtfs-786.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 786,
+    "data_type": "gtfs",
+    "provider": "Cairo Metro",
+    "location": {
+        "country_code": "EG",
+        "subdivision_name": "Al Qahirah",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-17T13:29:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transportforcairo/Metro-GTFS/archive/master.zip#Metro-GTFS-master",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/eg-al-qahirah-cairo-metro-gtfs-786.zip?alt=media",
+        "license": "https://github.com/transportforcairo/Metro-GTFS/blob/master/LICENSE.md"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-alava-tuvisa-euskotran-gtfs-797.json
+++ b/catalogs/sources/gtfs/schedule/es-alava-tuvisa-euskotran-gtfs-797.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 797,
+    "data_type": "gtfs",
+    "provider": "Tuvisa-EuskoTran",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Álava",
+        "municipality": "Vitoria-Gasteiz",
+        "bounding_box": {
+            "minimum_latitude": 42.826908111572266,
+            "maximum_latitude": 42.89276123046875,
+            "minimum_longitude": -2.748260021209717,
+            "maximum_longitude": -2.6160459518432617,
+            "extracted_on": "2022-03-17T13:40:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.vitoria-gasteiz.org/we001/http/vgTransit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-alava-tuvisa-euskotran-gtfs-797.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-andalucia-empresa-malaguena-de-transportes-gtfs-789.json
+++ b/catalogs/sources/gtfs/schedule/es-andalucia-empresa-malaguena-de-transportes-gtfs-789.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 789,
+    "data_type": "gtfs",
+    "provider": "Empresa Malagueña de Transportes",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Andalucía",
+        "municipality": "Málaga",
+        "bounding_box": {
+            "minimum_latitude": 36.65337,
+            "maximum_latitude": 36.780029,
+            "minimum_longitude": -4.576147,
+            "maximum_longitude": -4.335785,
+            "extracted_on": "2022-03-17T13:29:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://joseflorido.com/emt_fixed.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-andalucia-empresa-malaguena-de-transportes-gtfs-789.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-canarias-transportes-interurbanos-de-tenerife-titsa-gtfs-787.json
+++ b/catalogs/sources/gtfs/schedule/es-canarias-transportes-interurbanos-de-tenerife-titsa-gtfs-787.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 787,
+    "data_type": "gtfs",
+    "provider": "Transportes interurbanos de Tenerife (TITSA)",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Canarias",
+        "municipality": "Tenerife",
+        "bounding_box": {
+            "minimum_latitude": 28.0067,
+            "maximum_latitude": 28.5722,
+            "minimum_longitude": -16.9205,
+            "maximum_longitude": -16.1544,
+            "extracted_on": "2022-03-17T13:29:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.titsa.com/Google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-canarias-transportes-interurbanos-de-tenerife-titsa-gtfs-787.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-madrid-autobuses-interurbanos-madrid-crtm-gtfs-791.json
+++ b/catalogs/sources/gtfs/schedule/es-madrid-autobuses-interurbanos-madrid-crtm-gtfs-791.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 791,
+    "data_type": "gtfs",
+    "provider": "Autobuses Interurbanos Madrid (CRTM)",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Madrid",
+        "bounding_box": {
+            "minimum_latitude": 39.6040077209473,
+            "maximum_latitude": 41.1010131835938,
+            "minimum_longitude": -4.58037137985229,
+            "maximum_longitude": -2.82549953460693,
+            "extracted_on": "2022-03-17T13:30:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://crtm.maps.arcgis.com/sharing/rest/content/items/885399f83408473c8d815e40c5e702b7/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-madrid-autobuses-interurbanos-madrid-crtm-gtfs-791.zip?alt=media",
+        "license": "http://www.crtm.es/licencia-de-uso"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-madrid-consorcio-regional-de-transportes-de-madrid-gtfs-792.json
+++ b/catalogs/sources/gtfs/schedule/es-madrid-consorcio-regional-de-transportes-de-madrid-gtfs-792.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 792,
+    "data_type": "gtfs",
+    "provider": "Consorcio Regional de Transportes de Madrid",
+    "name": "Metro Ligero de Madrid",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Madrid",
+        "municipality": "Madrid",
+        "bounding_box": {
+            "minimum_latitude": 40.22195,
+            "maximum_latitude": 40.50824,
+            "minimum_longitude": -3.90378,
+            "maximum_longitude": -3.65126,
+            "extracted_on": "2022-03-17T13:30:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://crtm.maps.arcgis.com/sharing/rest/content/items/aaed26cc0ff64b0c947ac0bc3e033196/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-madrid-consorcio-regional-de-transportes-de-madrid-gtfs-792.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-madrid-empresa-municipal-de-transportes-de-madrid-emt-madrid-gtfs-793.json
+++ b/catalogs/sources/gtfs/schedule/es-madrid-empresa-municipal-de-transportes-de-madrid-emt-madrid-gtfs-793.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 793,
+    "data_type": "gtfs",
+    "provider": "Empresa Municipal de Transportes de Madrid (EMT Madrid)",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Madrid",
+        "bounding_box": {
+            "minimum_latitude": 40.3322,
+            "maximum_latitude": 40.51721,
+            "minimum_longitude": -3.83657,
+            "maximum_longitude": -3.54249,
+            "extracted_on": "2022-03-17T13:30:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://servicios.emtmadrid.es:8443/gtfs/transitemt.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-madrid-empresa-municipal-de-transportes-de-madrid-emt-madrid-gtfs-793.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-madrid-metro-de-madrid-gtfs-794.json
+++ b/catalogs/sources/gtfs/schedule/es-madrid-metro-de-madrid-gtfs-794.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 794,
+    "data_type": "gtfs",
+    "provider": "Metro de Madrid",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Madrid",
+        "bounding_box": {
+            "minimum_latitude": 40.2826,
+            "maximum_latitude": 40.5602,
+            "minimum_longitude": -3.87471,
+            "maximum_longitude": -3.4475,
+            "extracted_on": "2022-03-17T13:30:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://crtm.maps.arcgis.com/sharing/rest/content/items/5c7f2951962540d69ffe8f640d94c246/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-madrid-metro-de-madrid-gtfs-794.zip?alt=media",
+        "license": "http://www.crtm.es/licencia-de-uso"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-pais-vasco-ceferino-apezetxea-eta-semeak-gtfs-796.json
+++ b/catalogs/sources/gtfs/schedule/es-pais-vasco-ceferino-apezetxea-eta-semeak-gtfs-796.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 796,
+    "data_type": "gtfs",
+    "provider": "Ceferino Apezetxea Eta Semeak",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "País Vasco",
+        "municipality": "San Sebastián",
+        "bounding_box": {
+            "minimum_latitude": 41.6424981847183,
+            "maximum_latitude": 43.3425474660011,
+            "minimum_longitude": -2.68474298385968,
+            "maximum_longitude": -0.88834736718245,
+            "extracted_on": "2022-03-17T13:40:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.navarra.es/appsext/DescargarFichero/default.aspx?codigoAcceso=OpenData&fichero=TransporteInterurbano/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-pais-vasco-ceferino-apezetxea-eta-semeak-gtfs-796.zip?alt=media",
+        "license": "http://creativecommons.org/licenses/by/3.0/es/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-santa-cruz-de-tenerife-metropolitano-de-tenerife-gtfs-788.json
+++ b/catalogs/sources/gtfs/schedule/es-santa-cruz-de-tenerife-metropolitano-de-tenerife-gtfs-788.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 788,
+    "data_type": "gtfs",
+    "provider": "Metropolitano de Tenerife",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Santa Cruz de Tenerife",
+        "bounding_box": {
+            "minimum_latitude": 28.44376,
+            "maximum_latitude": 28.48579349,
+            "minimum_longitude": -16.316764,
+            "maximum_longitude": -16.2482308,
+            "extracted_on": "2022-03-17T13:29:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://metrotenerife.com/transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-santa-cruz-de-tenerife-metropolitano-de-tenerife-gtfs-788.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-unknown-alta-velocidad-larga-distancia-media-distancia-gtfs-790.json
+++ b/catalogs/sources/gtfs/schedule/es-unknown-alta-velocidad-larga-distancia-media-distancia-gtfs-790.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 790,
+    "data_type": "gtfs",
+    "provider": "Alta-Velocidad-Larga Distancia-Media Distancia",
+    "location": {
+        "country_code": "ES",
+        "bounding_box": {
+            "minimum_latitude": 36.126831,
+            "maximum_latitude": 43.535175,
+            "minimum_longitude": -8.762523,
+            "maximum_longitude": 3.163259,
+            "extracted_on": "2022-03-17T13:30:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.renfe.com/dataset/34be0058-3a3d-4ee1-89cd-512e1226f53f/resource/25d6b043-9e47-4f99-bd91-edd51d782450/download/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-unknown-alta-velocidad-larga-distancia-media-distancia-gtfs-790.zip?alt=media",
+        "license": "http://data.renfe.com/legal"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-valencia-emt-valencia-gtfs-795.json
+++ b/catalogs/sources/gtfs/schedule/es-valencia-emt-valencia-gtfs-795.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 795,
+    "data_type": "gtfs",
+    "provider": "EMT Valencia",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "València",
+        "bounding_box": {
+            "minimum_latitude": 39.2752950790789,
+            "maximum_latitude": 39.5427829801224,
+            "minimum_longitude": -0.429217044835186,
+            "maximum_longitude": -0.277794650854308,
+            "extracted_on": "2022-03-17T13:30:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://opendata.vlci.valencia.es/dataset/ab058cf8-ad3e-4d9c-ac89-0c6367ecf351/resource/c81b69e6-c082-44dc-acc6-66fc417b4e66/download/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-valencia-emt-valencia-gtfs-795.zip?alt=media",
+        "license": "https://www.valencia.es/val/ajuntament/govern-obert"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-south-carolina-clemson-area-transit-cat-gtfs-798.json
+++ b/catalogs/sources/gtfs/schedule/us-south-carolina-clemson-area-transit-cat-gtfs-798.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 798,
+    "data_type": "gtfs",
+    "provider": "Clemson Area Transit (CAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "South Carolina",
+        "municipality": "Clemson",
+        "bounding_box": {
+            "minimum_latitude": 34.555187,
+            "maximum_latitude": 34.7265552436914,
+            "minimum_longitude": -82.99781,
+            "maximum_longitude": -82.678375,
+            "extracted_on": "2022-03-17T13:40:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/clemson-sc-us/clemson-sc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-south-carolina-clemson-area-transit-cat-gtfs-798.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the fifth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 65 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~