### PR TITLE
feat: Ninth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/at-unknown-bean-shuttle-gtfs-859.json
+++ b/catalogs/sources/gtfs/schedule/at-unknown-bean-shuttle-gtfs-859.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 859,
+    "data_type": "gtfs",
+    "provider": "Bean Shuttle",
+    "location": {
+        "country_code": "AT",
+        "bounding_box": {
+            "minimum_latitude": 47.55705985377181,
+            "maximum_latitude": 48.810539,
+            "minimum_longitude": 13.044686168432236,
+            "maximum_longitude": 16.562506556510925,
+            "extracted_on": "2022-03-17T15:25:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.beanshuttle.com/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/at-unknown-bean-shuttle-gtfs-859.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/cz-praha-praha-gtfs-860.json
+++ b/catalogs/sources/gtfs/schedule/cz-praha-praha-gtfs-860.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 860,
+    "data_type": "gtfs",
+    "provider": "Praha",
+    "location": {
+        "country_code": "CZ",
+        "subdivision_name": "Praha, Hlavní město",
+        "bounding_box": {
+            "minimum_latitude": 49.007848,
+            "maximum_latitude": 50.951224,
+            "minimum_longitude": 13.312689,
+            "maximum_longitude": 15.569623,
+            "extracted_on": "2022-03-17T15:27:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://opendata.iprpraha.cz/DPP/JR/jrdata.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/cz-praha-praha-gtfs-860.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-augsburger-verkehrs--und-tarifverbund-avv-gtfs-857.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-augsburger-verkehrs--und-tarifverbund-avv-gtfs-857.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 857,
+    "data_type": "gtfs",
+    "provider": "Augsburger Verkehrs- und Tarifverbund (AVV)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "municipality": "Augsburg",
+        "bounding_box": {
+            "minimum_latitude": 48.1056968806613,
+            "maximum_latitude": 48.6600285985759,
+            "minimum_longitude": 10.520112269356,
+            "maximum_longitude": 11.2876647586401,
+            "extracted_on": "2022-03-17T15:25:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.avv-augsburg.de/avvdata/GTFS_AVV.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-augsburger-verkehrs--und-tarifverbund-avv-gtfs-857.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-verkehrsverbund-grossraum-nurnberg-vgn-gtfs-858.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-verkehrsverbund-grossraum-nurnberg-vgn-gtfs-858.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 858,
+    "data_type": "gtfs",
+    "provider": "Ver­kehrs­ver­bund Groß­raum Nürn­berg (VGN)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "bounding_box": {
+            "minimum_latitude": 48.7448254171593,
+            "maximum_latitude": 50.2210317244878,
+            "minimum_longitude": 10.0643112196454,
+            "maximum_longitude": 12.1713187019939,
+            "extracted_on": "2022-03-17T15:25:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.vgn.de/opendata/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-verkehrsverbund-grossraum-nurnberg-vgn-gtfs-858.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-flixbus-gtfs-853.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-flixbus-gtfs-853.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 853,
+    "data_type": "gtfs",
+    "provider": "FlixBus",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": 33.88979,
+            "maximum_latitude": 59.911605,
+            "minimum_longitude": -122.299233,
+            "maximum_longitude": 43.900588,
+            "extracted_on": "2022-03-17T15:24:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.ndovloket.nl/flixbus/flixbus-eu.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-flixbus-gtfs-853.zip?alt=media",
+        "license": "http://data.ndovloket.nl/LICENTIE-CC0.TXT"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-keski-suomi-jyvaskyla-gtfs-867.json
+++ b/catalogs/sources/gtfs/schedule/fi-keski-suomi-jyvaskyla-gtfs-867.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 867,
+    "data_type": "gtfs",
+    "provider": "Jyväskylä",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Keski-Suomi",
+        "municipality": "Jyväskylä",
+        "bounding_box": {
+            "minimum_latitude": 61.9556933685758,
+            "maximum_latitude": 62.62864111217454,
+            "minimum_longitude": 25.3666653747545,
+            "maximum_longitude": 26.288704903267423,
+            "extracted_on": "2022-03-17T15:28:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.jyvaskyla.fi/tiedostot/linkkidata.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-keski-suomi-jyvaskyla-gtfs-867.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-pohjois-pohjanmaa-oulun-joukkoliikenne-gtfs-869.json
+++ b/catalogs/sources/gtfs/schedule/fi-pohjois-pohjanmaa-oulun-joukkoliikenne-gtfs-869.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 869,
+    "data_type": "gtfs",
+    "provider": "Oulun joukkoliikenne",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Pohjois-Pohjanmaa",
+        "municipality": "Oulu",
+        "bounding_box": {
+            "minimum_latitude": 64.7601,
+            "maximum_latitude": 65.37246111597628,
+            "minimum_longitude": 24.5629,
+            "maximum_longitude": 26.42116229383981,
+            "extracted_on": "2022-03-17T15:28:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.transitdata.fi/oulu/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-pohjois-pohjanmaa-oulun-joukkoliikenne-gtfs-869.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-pohjois-savo-kuopio-gtfs-868.json
+++ b/catalogs/sources/gtfs/schedule/fi-pohjois-savo-kuopio-gtfs-868.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 868,
+    "data_type": "gtfs",
+    "provider": "Kuopio",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Pohjois-Savo",
+        "municipality": "Kuopio",
+        "bounding_box": {
+            "minimum_latitude": 62.623896,
+            "maximum_latitude": 63.38547752,
+            "minimum_longitude": 26.406358,
+            "maximum_longitude": 28.4804,
+            "extracted_on": "2022-03-17T15:28:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://karttapalvelu.kuopio.fi/google_transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-pohjois-savo-kuopio-gtfs-868.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-unknown-tampereen-joukkoliikenne-joli-gtfs-866.json
+++ b/catalogs/sources/gtfs/schedule/fi-unknown-tampereen-joukkoliikenne-joli-gtfs-866.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 866,
+    "data_type": "gtfs",
+    "provider": "Tampereen joukkoliikenne (JOLI)",
+    "location": {
+        "country_code": "FI",
+        "bounding_box": {
+            "minimum_latitude": 61.12899,
+            "maximum_latitude": 61.8796,
+            "minimum_longitude": 23.21423,
+            "maximum_longitude": 25.18222,
+            "extracted_on": "2022-03-17T15:28:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.itsfactory.fi/journeys/files/gtfs/latest/gtfs_tampere.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-unknown-tampereen-joukkoliikenne-joli-gtfs-866.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-uusimaa-helsingin-seudun-liikenne-hsl-gtfs-865.json
+++ b/catalogs/sources/gtfs/schedule/fi-uusimaa-helsingin-seudun-liikenne-hsl-gtfs-865.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 865,
+    "data_type": "gtfs",
+    "provider": "Helsingin seudun liikenne (HSL)",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Uusimaa",
+        "municipality": "Helsinki",
+        "bounding_box": {
+            "minimum_latitude": 59.987483,
+            "maximum_latitude": 60.976337,
+            "minimum_longitude": 24.018075,
+            "maximum_longitude": 26.705,
+            "extracted_on": "2022-03-17T15:27:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://dev.hsl.fi/gtfs/hsl.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-uusimaa-helsingin-seudun-liikenne-hsl-gtfs-865.zip?alt=media",
+        "license": "http://developer.reittiopas.fi/pages/en/home.php"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-varsinais-suomi-turku-gtfs-864.json
+++ b/catalogs/sources/gtfs/schedule/fi-varsinais-suomi-turku-gtfs-864.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 864,
+    "data_type": "gtfs",
+    "provider": "Turku",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Varsinais-Suomi",
+        "municipality": "Turku",
+        "bounding_box": {
+            "minimum_latitude": 60.019907,
+            "maximum_latitude": 60.743421,
+            "minimum_longitude": 21.329408,
+            "maximum_longitude": 23.516382,
+            "extracted_on": "2022-03-17T15:27:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.foli.fi/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-varsinais-suomi-turku-gtfs-864.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-grand-est-compagnie-des-transports-strasbourgeois-cts-gtfs-856.json
+++ b/catalogs/sources/gtfs/schedule/fr-grand-est-compagnie-des-transports-strasbourgeois-cts-gtfs-856.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 856,
+    "data_type": "gtfs",
+    "provider": "Compagnie des Transports Strasbourgeois (CTS)",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Grand Est",
+        "bounding_box": {
+            "minimum_latitude": 48.4655944167,
+            "maximum_latitude": 48.6851596357,
+            "minimum_longitude": 7.586214,
+            "maximum_longitude": 7.8312952816,
+            "extracted_on": "2022-03-17T15:24:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://opendata.cts-strasbourg.fr/fichiers/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-grand-est-compagnie-des-transports-strasbourgeois-cts-gtfs-856.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-occitanie-transports-de-lagglomeration-de-montpellier-tam-gtfs-844.json
+++ b/catalogs/sources/gtfs/schedule/fr-occitanie-transports-de-lagglomeration-de-montpellier-tam-gtfs-844.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 844,
+    "data_type": "gtfs",
+    "provider": "Transports de l'agglomération de Montpellier (TAM)",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Occitanie",
+        "bounding_box": {
+            "minimum_latitude": 43.52431273,
+            "maximum_latitude": 43.75182138,
+            "minimum_longitude": 3.70096418,
+            "maximum_longitude": 4.04086005,
+            "extracted_on": "2022-03-17T15:23:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.montpellier3m.fr/sites/default/files/ressources/TAM_MMM_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-occitanie-transports-de-lagglomeration-de-montpellier-tam-gtfs-844.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-lebateau-gtfs-843.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-lebateau-gtfs-843.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 843,
+    "data_type": "gtfs",
+    "provider": "lebateau",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d’Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.2801358236,
+            "maximum_latitude": 43.2946415641,
+            "minimum_longitude": 5.3070491308,
+            "maximum_longitude": 5.3740901055,
+            "extracted_on": "2022-03-17T15:23:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://tsvc2.pilote3.cityway.fr/api/Export/v1/GetExportedDataFile?ExportFormat=Gtfs&OperatorCode=FRIOUL",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-lebateau-gtfs-843.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-lignes-dazur-gtfs-845.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-lignes-dazur-gtfs-845.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 845,
+    "data_type": "gtfs",
+    "provider": "Lignes d'Azur, Zou! Alpes-Maritimes",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte d'Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.546381,
+            "maximum_latitude": 44.28372,
+            "minimum_longitude": 6.866431,
+            "maximum_longitude": 7.497834,
+            "extracted_on": "2022-03-17T15:23:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://opendata.nicecotedazur.org/data/dataset/export-quotidien-au-format-gtfs-du-reseau-de-transport-lignes-d-azur/resource/aacb4eea-d008-4b13-b17a-848b8ced7e03/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-lignes-dazur-gtfs-845.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-marcoulines-gtfs-842.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-marcoulines-gtfs-842.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 842,
+    "data_type": "gtfs",
+    "provider": "Marcoulines",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d’Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.1737611824,
+            "maximum_latitude": 43.2854629136,
+            "minimum_longitude": 5.3842134427,
+            "maximum_longitude": 5.6238899421,
+            "extracted_on": "2022-03-17T15:23:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://tsvc2.pilote3.cityway.fr/api/Export/v1/GetExportedDataFile?ExportFormat=Gtfs&OperatorCode=MARCOULINE",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-marcoulines-gtfs-842.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-regie-des-transports-metropolitains-rtm-gtfs-841.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-regie-des-transports-metropolitains-rtm-gtfs-841.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 841,
+    "data_type": "gtfs",
+    "provider": "Régie des Transports Métropolitains (RTM)",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d’Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.2126454224,
+            "maximum_latitude": 43.4103181808,
+            "minimum_longitude": 5.2875741342,
+            "maximum_longitude": 5.5261741194,
+            "extracted_on": "2022-03-17T15:23:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://tsvc2.pilote3.cityway.fr/api/Export/v1/GetExportedDataFile?ExportFormat=Gtfs&OperatorCode=RTM",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-regie-des-transports-metropolitains-rtm-gtfs-841.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/gh-greater-accra-ama-department-of-transport-gtfs-881.json
+++ b/catalogs/sources/gtfs/schedule/gh-greater-accra-ama-department-of-transport-gtfs-881.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 881,
+    "data_type": "gtfs",
+    "provider": "AMA Department of Transport",
+    "location": {
+        "country_code": "GH",
+        "subdivision_name": "Greater Accra",
+        "municipality": "Accra",
+        "bounding_box": {
+            "minimum_latitude": 5.5216398,
+            "maximum_latitude": 5.7619486,
+            "minimum_longitude": -0.4242906,
+            "maximum_longitude": 0.0031821,
+            "extracted_on": "2022-03-17T15:29:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/AFDLab4Dev/AccraMobility/raw/master/GTFS/GTFS_Accra.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gh-greater-accra-ama-department-of-transport-gtfs-881.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hu-budapest-weekendbus-gtfs-862.json
+++ b/catalogs/sources/gtfs/schedule/hu-budapest-weekendbus-gtfs-862.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 862,
+    "data_type": "gtfs",
+    "provider": "Weekendbus",
+    "location": {
+        "country_code": "HU",
+        "subdivision_name": "Budapest",
+        "bounding_box": {
+            "minimum_latitude": 47.474535,
+            "maximum_latitude": 47.5615383,
+            "minimum_longitude": 19.1358718,
+            "maximum_longitude": 19.351475,
+            "extracted_on": "2022-03-17T15:27:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://apps.weekendbus.hu/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-budapest-weekendbus-gtfs-862.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hu-pecs-biokom-gtfs-861.json
+++ b/catalogs/sources/gtfs/schedule/hu-pecs-biokom-gtfs-861.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 861,
+    "data_type": "gtfs",
+    "provider": "BIOKOM",
+    "location": {
+        "country_code": "HU",
+        "subdivision_name": "Pécs",
+        "bounding_box": {
+            "minimum_latitude": 46.009066,
+            "maximum_latitude": 46.153928,
+            "minimum_longitude": 18.131841,
+            "maximum_longitude": 18.344572,
+            "extracted_on": "2022-03-17T15:27:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mobilitas.biokom.hu/gtfs",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-pecs-biokom-gtfs-861.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-lombardia-trenord-gtfs-855.json
+++ b/catalogs/sources/gtfs/schedule/it-lombardia-trenord-gtfs-855.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 855,
+    "data_type": "gtfs",
+    "provider": "Trenord",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Lombardia",
+        "municipality": "Milan",
+        "bounding_box": {
+            "minimum_latitude": 44.692304,
+            "maximum_latitude": 46.319667,
+            "minimum_longitude": 8.294914,
+            "maximum_longitude": 10.982471,
+            "extracted_on": "2022-03-17T15:24:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.dati.lombardia.it/download/3z4k-mxz9/application%2Fzip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lombardia-trenord-gtfs-855.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-puglia-autolinee-scoppio-gtfs-848.json
+++ b/catalogs/sources/gtfs/schedule/it-puglia-autolinee-scoppio-gtfs-848.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 848,
+    "data_type": "gtfs",
+    "provider": "Autolinee Scoppio",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Puglia",
+        "municipality": "Bari",
+        "bounding_box": {
+            "minimum_latitude": 40.794452,
+            "maximum_latitude": 40.8932369,
+            "minimum_longitude": 16.7992147,
+            "maximum_longitude": 16.926824,
+            "extracted_on": "2022-03-17T15:24:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://datahub.io/dataset/289cecea-0162-4ef7-bfab-7872299defa8/resource/f2537ad4-4943-433a-a5a8-fc7db433f30b/download/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-puglia-autolinee-scoppio-gtfs-848.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-puglia-comune-di-gioia-del-colle-gtfs-849.json
+++ b/catalogs/sources/gtfs/schedule/it-puglia-comune-di-gioia-del-colle-gtfs-849.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 849,
+    "data_type": "gtfs",
+    "provider": "Comune di Gioia del Colle",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Puglia",
+        "municipality": "Bari",
+        "bounding_box": {
+            "minimum_latitude": 40.782853,
+            "maximum_latitude": 40.8335318,
+            "minimum_longitude": 16.907133,
+            "maximum_longitude": 16.9595962,
+            "extracted_on": "2022-03-17T15:24:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://datahub.io/dataset/289cecea-0162-4ef7-bfab-7872299defa8/resource/e2b2a650-eb84-4153-ae13-697da9c738fc/download/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-puglia-comune-di-gioia-del-colle-gtfs-849.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-puglia-societa-trasporti-provinciale-spa-gtfs-847.json
+++ b/catalogs/sources/gtfs/schedule/it-puglia-societa-trasporti-provinciale-spa-gtfs-847.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 847,
+    "data_type": "gtfs",
+    "provider": "Società Trasporti Provinciale S.p.A.",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Puglia",
+        "municipality": "Bari",
+        "bounding_box": {
+            "minimum_latitude": 40.4827045,
+            "maximum_latitude": 41.174421,
+            "minimum_longitude": 16.4221682,
+            "maximum_longitude": 17.2234622,
+            "extracted_on": "2022-03-17T15:24:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://datahub.io/dataset/289cecea-0162-4ef7-bfab-7872299defa8/resource/8e7992ee-ac03-4b09-a0a9-4a54ba367336/download/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-puglia-societa-trasporti-provinciale-spa-gtfs-847.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-unknown-azienda-trasporti-automobilistici-pubblici-delle-province-di-biella-e-vercelli-atap-gtfs-854.json
+++ b/catalogs/sources/gtfs/schedule/it-unknown-azienda-trasporti-automobilistici-pubblici-delle-province-di-biella-e-vercelli-atap-gtfs-854.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 854,
+    "data_type": "gtfs",
+    "provider": "Azienda Trasporti Automobilistici Pubblici delle Province di Biella e Vercelli (ATAP)",
+    "location": {
+        "country_code": "IT",
+        "bounding_box": {
+            "minimum_latitude": 45.071667,
+            "maximum_latitude": 45.854201329886,
+            "minimum_longitude": 7.6672446355116,
+            "maximum_longitude": 9.0938958624267,
+            "extracted_on": "2022-03-17T15:24:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.magellanoprogetti.it/atap/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-unknown-azienda-trasporti-automobilistici-pubblici-delle-province-di-biella-e-vercelli-atap-gtfs-854.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-unknown-trenitalia-spa-gtfs-840.json
+++ b/catalogs/sources/gtfs/schedule/it-unknown-trenitalia-spa-gtfs-840.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 840,
+    "data_type": "gtfs",
+    "provider": "TRENITALIA S.p.A.",
+    "location": {
+        "country_code": "IT",
+        "bounding_box": {
+            "minimum_latitude": 41.8723701144714,
+            "maximum_latitude": 45.6904287134975,
+            "minimum_longitude": 8.47023620292013,
+            "maximum_longitude": 13.497591158192,
+            "extracted_on": "2022-03-17T15:23:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://dati.toscana.it/dataset/8bb8f8fe-fe7d-41d0-90dc-49f2456180d1/resource/4f85393b-357d-443d-8378-65de4198505f/download/trenitalia.gtfs",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-unknown-trenitalia-spa-gtfs-840.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-aomori-aomori-city-bus-gtfs-874.json
+++ b/catalogs/sources/gtfs/schedule/jp-aomori-aomori-city-bus-gtfs-874.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 874,
+    "data_type": "gtfs",
+    "provider": "Aomori City Bus",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Aomori",
+        "bounding_box": {
+            "minimum_latitude": 40.738089,
+            "maximum_latitude": 40.948587,
+            "minimum_longitude": 140.648288,
+            "maximum_longitude": 140.863932,
+            "extracted_on": "2022-03-17T15:29:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.city.aomori.aomori.jp/kotsu-kanri/koutsu/oshirase/documents/gtfs-aomoricitybus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-aomori-aomori-city-bus-gtfs-874.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-hyogo-kobe-subway-gtfs-872.json
+++ b/catalogs/sources/gtfs/schedule/jp-hyogo-kobe-subway-gtfs-872.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 872,
+    "data_type": "gtfs",
+    "provider": "Kobe Subway",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Hyôgo",
+        "municipality": "Kōbe",
+        "bounding_box": {
+            "minimum_latitude": 34.6521,
+            "maximum_latitude": 34.761831,
+            "minimum_longitude": 135.017,
+            "maximum_longitude": 135.196,
+            "extracted_on": "2022-03-17T15:28:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://codeforkobe.github.io/kobe-transit/kobe_subway_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-hyogo-kobe-subway-gtfs-872.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-yamanasi-yamanashi-gtfs-873.json
+++ b/catalogs/sources/gtfs/schedule/jp-yamanasi-yamanashi-gtfs-873.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 873,
+    "data_type": "gtfs",
+    "provider": "Yamanashi",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Yamanasi",
+        "bounding_box": {
+            "minimum_latitude": 35.121414,
+            "maximum_latitude": 35.865506,
+            "minimum_longitude": 138.303494,
+            "maximum_longitude": 139.155846,
+            "extracted_on": "2022-03-17T15:29:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://opendata.busmaps.jp/yamanashi.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-yamanasi-yamanashi-gtfs-873.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-863.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-863.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 863,
+    "data_type": "gtfs",
+    "provider": "Warszawska Kolej Dojazdowa (WKD)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Mazowieckie",
+        "municipality": "Warsaw",
+        "bounding_box": {
+            "minimum_latitude": 52.100645,
+            "maximum_latitude": 52.22768605033,
+            "minimum_longitude": 20.628435,
+            "maximum_longitude": 21.00040372159,
+            "extracted_on": "2022-03-17T15:27:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/feed/wkd/wkd-latest.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-863.zip?alt=media",
+        "license": "https://mkuran.pl/gtfs/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-beach-cities-transit-gtfs-803.json
+++ b/catalogs/sources/gtfs/schedule/us-california-beach-cities-transit-gtfs-803.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 803,
+    "data_type": "gtfs",
+    "provider": "Beach Cities Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Redondo Beach",
+        "bounding_box": {
+            "minimum_latitude": 33.816115,
+            "maximum_latitude": 33.949355,
+            "minimum_longitude": -118.417662,
+            "maximum_longitude": -118.352743,
+            "extracted_on": "2022-03-17T15:20:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.redondo.org/civicax/filebank/blobdload.aspx?BlobID=33555",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-beach-cities-transit-gtfs-803.zip?alt=media",
+        "license": "https://www.redondo.org/depts/recreation/transit/trip_planner/gtfs_data.asp"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-tracy-tracer-gtfs-877.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-tracy-tracer-gtfs-877.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 877,
+    "data_type": "gtfs",
+    "provider": "City of Tracy (TRACER)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Tracy",
+        "bounding_box": {
+            "minimum_latitude": 37.696589,
+            "maximum_latitude": 37.761837,
+            "minimum_longitude": -121.475665,
+            "maximum_longitude": -121.409294,
+            "extracted_on": "2022-03-17T15:29:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/tracy-ca-us/tracy-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-of-tracy-tracer-gtfs-877.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-glenn-transit-service-gtfs-835.json
+++ b/catalogs/sources/gtfs/schedule/us-california-glenn-transit-service-gtfs-835.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 835,
+    "data_type": "gtfs",
+    "provider": "Glenn Transit Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Chico",
+        "bounding_box": {
+            "minimum_latitude": 39.51782777,
+            "maximum_latitude": 39.75793214,
+            "minimum_longitude": -122.2184688,
+            "maximum_longitude": -121.842293097047,
+            "extracted_on": "2022-03-17T15:22:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/glenn-ca-us/glenn-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-glenn-transit-service-gtfs-835.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-playa-vista-shuttle-gtfs-799.json
+++ b/catalogs/sources/gtfs/schedule/us-california-playa-vista-shuttle-gtfs-799.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 799,
+    "data_type": "gtfs",
+    "provider": "Playa Vista Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.9667191271915,
+            "maximum_latitude": 33.9852910271979,
+            "minimum_longitude": -118.465265246182,
+            "maximum_longitude": -118.396746861953,
+            "extracted_on": "2022-03-17T15:20:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/playavistashuttle-ca-us/playavistashuttle-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-playa-vista-shuttle-gtfs-799.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-rosemead-explorer-gtfs-806.json
+++ b/catalogs/sources/gtfs/schedule/us-california-rosemead-explorer-gtfs-806.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 806,
+    "data_type": "gtfs",
+    "provider": "Rosemead Explorer",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Rosemead",
+        "bounding_box": {
+            "minimum_latitude": 34.036944,
+            "maximum_latitude": 34.083874,
+            "minimum_longitude": -118.103673,
+            "maximum_longitude": -118.065028,
+            "extracted_on": "2022-03-17T15:21:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/rosemead-ca-us/rosemead-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-rosemead-explorer-gtfs-806.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-leandro-links-gtfs-810.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-leandro-links-gtfs-810.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 810,
+    "data_type": "gtfs",
+    "provider": "San Leandro Links",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Leandro",
+        "bounding_box": {
+            "minimum_latitude": 37.6934751076397,
+            "maximum_latitude": 37.722197,
+            "minimum_longitude": -122.186366,
+            "maximum_longitude": -122.15255824133,
+            "extracted_on": "2022-03-17T15:22:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sanleandro-ca-us/sanleandro-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-leandro-links-gtfs-810.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-santa-clarita-transit-gtfs-812.json
+++ b/catalogs/sources/gtfs/schedule/us-california-santa-clarita-transit-gtfs-812.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 812,
+    "data_type": "gtfs",
+    "provider": "Santa Clarita Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Clarita",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-17T15:22:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gitlab.com/LACMTA/gtfs_lax/-/archive/master/gtfs_lax-master.zip?path=santa_clarita",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-santa-clarita-transit-gtfs-812.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-santa-ynez-valley-transit-gtfs-813.json
+++ b/catalogs/sources/gtfs/schedule/us-california-santa-ynez-valley-transit-gtfs-813.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 813,
+    "data_type": "gtfs",
+    "provider": "Santa Ynez Valley Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Barbara",
+        "bounding_box": {
+            "minimum_latitude": 34.59587126,
+            "maximum_latitude": 34.665449,
+            "minimum_longitude": -120.20450894,
+            "maximum_longitude": -120.077077,
+            "extracted_on": "2022-03-17T15:22:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/syvt_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-santa-ynez-valley-transit-gtfs-813.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sierra-madre-gateway-coach-gtfs-829.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sierra-madre-gateway-coach-gtfs-829.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 829,
+    "data_type": "gtfs",
+    "provider": "Sierra Madre Gateway Coach",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Pasadena",
+        "bounding_box": {
+            "minimum_latitude": 34.150285558358,
+            "maximum_latitude": 34.1695312727436,
+            "minimum_longitude": -118.074908013661,
+            "maximum_longitude": -118.040285635729,
+            "extracted_on": "2022-03-17T15:22:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sierramadre-ca-us/sierramadre-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sierra-madre-gateway-coach-gtfs-829.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 815,
+    "data_type": "gtfs",
+    "provider": "Sonoma-Marin Area Rail Transit (SMART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Rosa",
+        "bounding_box": {
+            "minimum_latitude": 37.94781,
+            "maximum_latitude": 38.5098222070014,
+            "minimum_longitude": -122.784085789652,
+            "maximum_longitude": -122.51248,
+            "extracted_on": "2022-03-17T15:22:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-south-county-transit-link-gtfs-817.json
+++ b/catalogs/sources/gtfs/schedule/us-california-south-county-transit-link-gtfs-817.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 817,
+    "data_type": "gtfs",
+    "provider": "South County Transit Link",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Sacremento",
+        "bounding_box": {
+            "minimum_latitude": 38.133123,
+            "maximum_latitude": 38.581806,
+            "minimum_longitude": -121.612919,
+            "maximum_longitude": -121.27221,
+            "extracted_on": "2022-03-17T15:22:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/southcountytransitlink-ca-us/southcountytransitlink-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-south-county-transit-link-gtfs-817.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-taft-maricopa-area-transit-gtfs-821.json
+++ b/catalogs/sources/gtfs/schedule/us-california-taft-maricopa-area-transit-gtfs-821.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 821,
+    "data_type": "gtfs",
+    "provider": "Taft Maricopa Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Taft",
+        "bounding_box": {
+            "minimum_latitude": 35.0559093260118,
+            "maximum_latitude": 35.150436610803,
+            "minimum_longitude": -119.465367621155,
+            "maximum_longitude": -119.398652723801,
+            "extracted_on": "2022-03-17T15:22:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/taft-ca-us/taft-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-taft-maricopa-area-transit-gtfs-821.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-boulder-county-gtfs-880.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-boulder-county-gtfs-880.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 880,
+    "data_type": "gtfs",
+    "provider": "Boulder County",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Boulder",
+        "bounding_box": {
+            "minimum_latitude": 39.951585,
+            "maximum_latitude": 39.96231,
+            "minimum_longitude": -105.594805,
+            "maximum_longitude": -105.512979,
+            "extracted_on": "2022-03-17T15:29:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/bouldercounty-co-us/bouldercounty-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-boulder-county-gtfs-880.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-garden-of-the-gods-gtfs-879.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-garden-of-the-gods-gtfs-879.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 879,
+    "data_type": "gtfs",
+    "provider": "Garden of the Gods",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Colorado Springs",
+        "bounding_box": {
+            "minimum_latitude": 38.8735541951327,
+            "maximum_latitude": 38.8788147871756,
+            "minimum_longitude": -104.878164075535,
+            "maximum_longitude": -104.870172349729,
+            "extracted_on": "2022-03-17T15:29:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/gardenofthegods-co-us/gardenofthegods-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-garden-of-the-gods-gtfs-879.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-prairie-express-transit-gtfs-801.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-prairie-express-transit-gtfs-801.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 801,
+    "data_type": "gtfs",
+    "provider": "Prairie Express Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 40.6105818188916,
+            "maximum_latitude": 40.6432395380018,
+            "minimum_longitude": -103.235552,
+            "maximum_longitude": -103.160681,
+            "extracted_on": "2022-03-17T15:20:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/prairieexpress-co-us/prairieexpress-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-prairie-express-transit-gtfs-801.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-road-runner-transit-gtfs-837.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-road-runner-transit-gtfs-837.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 837,
+    "data_type": "gtfs",
+    "provider": "Road Runner Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 37.1011220008574,
+            "maximum_latitude": 37.272614173906,
+            "minimum_longitude": -107.883097315895,
+            "maximum_longitude": -107.586597082991,
+            "extracted_on": "2022-03-17T15:22:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/roadrunnertransit-co-us/roadrunnertransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-road-runner-transit-gtfs-837.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-roadrunnertransit-gtfs-805.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-roadrunnertransit-gtfs-805.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 805,
+    "data_type": "gtfs",
+    "provider": "RoadrunnerTransit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Ignacio",
+        "bounding_box": {
+            "minimum_latitude": 37.1011220008574,
+            "maximum_latitude": 37.272614173906,
+            "minimum_longitude": -107.883097315895,
+            "maximum_longitude": -107.586597082991,
+            "extracted_on": "2022-03-17T15:21:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/roadrunnertransit-co-us/roadrunnertransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-roadrunnertransit-gtfs-805.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-san-miguel-authority-for-regional-transportation-smart-gtfs-811.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-san-miguel-authority-for-regional-transportation-smart-gtfs-811.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 811,
+    "data_type": "gtfs",
+    "provider": "San Miguel Authority for Regional Transportation (SMART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 37.692905,
+            "maximum_latitude": 38.132049,
+            "minimum_longitude": -108.296074,
+            "maximum_longitude": -107.812829,
+            "extracted_on": "2022-03-17T15:22:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/sanmiguel-co-us/sanmiguel-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-san-miguel-authority-for-regional-transportation-smart-gtfs-811.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-summit-stage-gtfs-820.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-summit-stage-gtfs-820.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 820,
+    "data_type": "gtfs",
+    "provider": "Summit Stage",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 39.222918,
+            "maximum_latitude": 39.6595931217601,
+            "minimum_longitude": -106.302381,
+            "maximum_longitude": -105.871945,
+            "extracted_on": "2022-03-17T15:22:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/summitstage-co-us/summitstage-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-summit-stage-gtfs-820.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-teller-senior-coalition-transit-tsc-transit-gtfs-827.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-teller-senior-coalition-transit-tsc-transit-gtfs-827.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 827,
+    "data_type": "gtfs",
+    "provider": "Teller Senior Coalition Transit (TSC Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "bounding_box": {
+            "minimum_latitude": 38.9366497878941,
+            "maximum_latitude": 39.0139569028692,
+            "minimum_longitude": -105.075360828474,
+            "maximum_longitude": -105.017092668278,
+            "extracted_on": "2022-03-17T15:22:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/tsctransit-co-us/tsctransit-co-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-teller-senior-coalition-transit-tsc-transit-gtfs-827.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-lake-county-connection-gtfs-876.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-lake-county-connection-gtfs-876.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 876,
+    "data_type": "gtfs",
+    "provider": "Lake County Connection",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Fruitland Park",
+        "bounding_box": {
+            "minimum_latitude": 28.53219464,
+            "maximum_latitude": 28.961701,
+            "minimum_longitude": -81.94832,
+            "maximum_longitude": -81.5897915092621,
+            "extracted_on": "2022-03-17T15:29:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.ftis.org/PostFileDownload.aspx?id=160A0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-lake-county-connection-gtfs-876.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-qline-detroit-gtfs-802.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-qline-detroit-gtfs-802.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 802,
+    "data_type": "gtfs",
+    "provider": "Qline Detroit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Detroit",
+        "bounding_box": {
+            "minimum_latitude": 42.32981,
+            "maximum_latitude": 42.3706148199718,
+            "minimum_longitude": -83.0735324639556,
+            "maximum_longitude": -83.045533,
+            "extracted_on": "2022-03-17T15:20:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/qline-mi-us/qline-mi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-qline-detroit-gtfs-802.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-santa-fe-trails-gtfs-839.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-santa-fe-trails-gtfs-839.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 839,
+    "data_type": "gtfs",
+    "provider": "Santa Fe Trails",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "municipality": "Santa Fe",
+        "bounding_box": {
+            "minimum_latitude": 35.585175,
+            "maximum_latitude": 35.695048,
+            "minimum_longitude": -106.060987,
+            "maximum_longitude": -105.909732,
+            "extracted_on": "2022-03-17T15:22:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/santafetrails_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-santa-fe-trails-gtfs-839.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-adirondack-trailways-adp-gtfs-823.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-adirondack-trailways-adp-gtfs-823.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 823,
+    "data_type": "gtfs",
+    "provider": "Adirondack Trailways ADP",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 40.75695,
+            "maximum_latitude": 43.104084,
+            "minimum_longitude": -76.169169,
+            "maximum_longitude": -73.75135,
+            "extracted_on": "2022-03-17T15:22:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Trailways-ADP.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-adirondack-trailways-adp-gtfs-823.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-adirondack-trailways-nyp-gtfs-824.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-adirondack-trailways-nyp-gtfs-824.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 824,
+    "data_type": "gtfs",
+    "provider": "Adirondack Trailways NYP",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 40.75695,
+            "maximum_latitude": 43.162109,
+            "minimum_longitude": -78.871723,
+            "maximum_longitude": -73.9905,
+            "extracted_on": "2022-03-17T15:22:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Trailways-NYP.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-adirondack-trailways-nyp-gtfs-824.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-adirondack-trailways-pine-hill-trailways-gtfs-826.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-adirondack-trailways-pine-hill-trailways-gtfs-826.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 826,
+    "data_type": "gtfs",
+    "provider": "Adirondack Trailways Pine Hill Trailways",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 40.75695,
+            "maximum_latitude": 43.104084,
+            "minimum_longitude": -75.223853,
+            "maximum_longitude": -73.724663,
+            "extracted_on": "2022-03-17T15:22:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Trailways-PHK.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-adirondack-trailways-pine-hill-trailways-gtfs-826.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-new-york-trailways-gtfs-825.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-new-york-trailways-gtfs-825.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 825,
+    "data_type": "gtfs",
+    "provider": "New York Trailways",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 42.0681,
+            "maximum_latitude": 44.92327,
+            "minimum_longitude": -79.062414,
+            "maximum_longitude": -74.945455,
+            "extracted_on": "2022-03-17T15:22:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Trailways-NYT.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-new-york-trailways-gtfs-825.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-regional-transit-service-gtfs-809.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-regional-transit-service-gtfs-809.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 809,
+    "data_type": "gtfs",
+    "provider": "Regional Transit Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Rochester",
+        "bounding_box": {
+            "minimum_latitude": 42.518328,
+            "maximum_latitude": 43.01676,
+            "minimum_longitude": -78.487358,
+            "maximum_longitude": -77.998316,
+            "extracted_on": "2022-03-17T15:22:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/RTS-Wyoming.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-regional-transit-service-gtfs-809.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-regional-transit-service-seneca-rts-seneca-gtfs-808.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-regional-transit-service-seneca-rts-seneca-gtfs-808.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 808,
+    "data_type": "gtfs",
+    "provider": "Regional Transit Service Seneca (RTS Seneca)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 42.869139,
+            "maximum_latitude": 42.91489,
+            "minimum_longitude": -76.988798,
+            "maximum_longitude": -76.791317,
+            "extracted_on": "2022-03-17T15:22:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/RTS-Seneca.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-regional-transit-service-seneca-rts-seneca-gtfs-808.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-rensselaer-county-yankee-trails-gtfs-804.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-rensselaer-county-yankee-trails-gtfs-804.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 804,
+    "data_type": "gtfs",
+    "provider": "Rensselaer County (Yankee Trails",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Albany",
+        "bounding_box": {
+            "minimum_latitude": 42.646334,
+            "maximum_latitude": 42.899666,
+            "minimum_longitude": -73.76139,
+            "maximum_longitude": -73.193236,
+            "extracted_on": "2022-03-17T15:20:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Rensselaer_County_Yankee_Trails.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-rensselaer-county-yankee-trails-gtfs-804.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-schuyler-county-transit-gtfs-814.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-schuyler-county-transit-gtfs-814.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 814,
+    "data_type": "gtfs",
+    "provider": "Schuyler County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Elmira",
+        "bounding_box": {
+            "minimum_latitude": 42.090101,
+            "maximum_latitude": 42.532266,
+            "minimum_longitude": -77.051169,
+            "maximum_longitude": -76.537371,
+            "extracted_on": "2022-03-17T15:22:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Schuyler_County_Public_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-schuyler-county-transit-gtfs-814.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-steuben-area-rides-gtfs-850.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-steuben-area-rides-gtfs-850.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 850,
+    "data_type": "gtfs",
+    "provider": "Steuben Area Rides",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Elmira",
+        "bounding_box": {
+            "minimum_latitude": 42.079788,
+            "maximum_latitude": 42.567846,
+            "minimum_longitude": -77.590352,
+            "maximum_longitude": -77.107801,
+            "extracted_on": "2022-03-17T15:24:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Steuben_Area_Rides.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-steuben-area-rides-gtfs-850.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-steuben-county-transit-gtfs-851.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-steuben-county-transit-gtfs-851.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 851,
+    "data_type": "gtfs",
+    "provider": "Steuben County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Elmira",
+        "bounding_box": {
+            "minimum_latitude": 42.090213,
+            "maximum_latitude": 42.407978,
+            "minimum_longitude": -77.350403,
+            "maximum_longitude": -76.805978,
+            "extracted_on": "2022-03-17T15:24:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Steuben_County_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-steuben-county-transit-gtfs-851.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-village-of-cooperstown-trolly-system-gtfs-870.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-village-of-cooperstown-trolly-system-gtfs-870.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 870,
+    "data_type": "gtfs",
+    "provider": "Village of Cooperstown Trolly System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Otsego",
+        "bounding_box": {
+            "minimum_latitude": 42.68566,
+            "maximum_latitude": 42.717453,
+            "minimum_longitude": -74.937091,
+            "maximum_longitude": -74.922994,
+            "extracted_on": "2022-03-17T15:28:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Village_of_Cooperstown_Trolley_System.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-village-of-cooperstown-trolly-system-gtfs-870.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-watertown-citibus-gtfs-871.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-watertown-citibus-gtfs-871.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 871,
+    "data_type": "gtfs",
+    "provider": "Watertown Citibus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Watertown",
+        "bounding_box": {
+            "minimum_latitude": 43.947218,
+            "maximum_latitude": 43.994343,
+            "minimum_longitude": -75.95417,
+            "maximum_longitude": -75.879929,
+            "extracted_on": "2022-03-17T15:28:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Watertown_Citibus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-watertown-citibus-gtfs-871.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-yates-transit-service-gtfs-875.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-yates-transit-service-gtfs-875.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 875,
+    "data_type": "gtfs",
+    "provider": "Yates Transit Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Yates",
+        "bounding_box": {
+            "minimum_latitude": 42.422427,
+            "maximum_latitude": 42.869131,
+            "minimum_longitude": -77.443207,
+            "maximum_longitude": -76.935196,
+            "extracted_on": "2022-03-17T15:29:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Yates_Transit_Service.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-yates-transit-service-gtfs-875.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-stark-area-regional-transit-authority-sarta-gtfs-818.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-stark-area-regional-transit-authority-sarta-gtfs-818.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 818,
+    "data_type": "gtfs",
+    "provider": "Stark Area Regional Transit Authority (SARTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Canton",
+        "bounding_box": {
+            "minimum_latitude": 40.720235,
+            "maximum_latitude": 41.513986,
+            "minimum_longitude": -81.696054,
+            "maximum_longitude": -81.08672418,
+            "extracted_on": "2022-03-17T15:22:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/stark-area-regional-transit-authority.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-stark-area-regional-transit-authority-sarta-gtfs-818.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-buena-vista-ferry-gtfs-834.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-buena-vista-ferry-gtfs-834.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 834,
+    "data_type": "gtfs",
+    "provider": "Buena Vista Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Albany",
+        "bounding_box": {
+            "minimum_latitude": 44.7696604540249,
+            "maximum_latitude": 44.7701539496516,
+            "minimum_longitude": -123.147180525512,
+            "maximum_longitude": -123.144738622659,
+            "extracted_on": "2022-03-17T15:22:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/buenavistaferry-or-us/buenavistaferry-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-buena-vista-ferry-gtfs-834.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-oregon-department-of-transportation-gtfs-800.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-oregon-department-of-transportation-gtfs-800.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 800,
+    "data_type": "gtfs",
+    "provider": "Oregon Department of Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "bounding_box": {
+            "minimum_latitude": 41.75243,
+            "maximum_latitude": 46.19021,
+            "minimum_longitude": -124.288308,
+            "maximum_longitude": -116.951137,
+            "extracted_on": "2022-03-17T15:20:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.trilliumtransit.com/gtfs_data/point-or-us/point-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-oregon-department-of-transportation-gtfs-800.zip?alt=media",
+        "license": "https://oregon-gtfs.trilliumtransit.com"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-philomath-connection-gtfs-878.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-philomath-connection-gtfs-878.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 878,
+    "data_type": "gtfs",
+    "provider": "Philomath Connection",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Corvallis",
+        "bounding_box": {
+            "minimum_latitude": 44.538819319,
+            "maximum_latitude": 44.568894,
+            "minimum_longitude": -123.377022609,
+            "maximum_longitude": -123.263341,
+            "extracted_on": "2022-03-17T15:29:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/philomathconnection-or-us/philomathconnection-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-philomath-connection-gtfs-878.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-south-clackamas-transportation-district-gtfs-883.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-south-clackamas-transportation-district-gtfs-883.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 883,
+    "data_type": "gtfs",
+    "provider": "South Clackamas Transportation District",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": " Molalla",
+        "bounding_box": {
+            "minimum_latitude": 45.1390469449441,
+            "maximum_latitude": 45.32274907,
+            "minimum_longitude": -122.6915965,
+            "maximum_longitude": -122.5630179,
+            "extracted_on": "2022-03-17T15:29:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/sctd-or-us/sctd-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-south-clackamas-transportation-district-gtfs-883.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-water-avenue-shuttle-gtfs-831.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-water-avenue-shuttle-gtfs-831.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 831,
+    "data_type": "gtfs",
+    "provider": "Water Avenue Shuttle",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Portland",
+        "bounding_box": {
+            "minimum_latitude": 45.504399,
+            "maximum_latitude": 45.5278280333969,
+            "minimum_longitude": -122.666230784074,
+            "maximum_longitude": -122.658678,
+            "extracted_on": "2022-03-17T15:22:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/ceic-or-us/ceic-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-water-avenue-shuttle-gtfs-831.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-wheatland-ferry-gtfs-833.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-wheatland-ferry-gtfs-833.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 833,
+    "data_type": "gtfs",
+    "provider": "Wheatland Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Salem",
+        "bounding_box": {
+            "minimum_latitude": 45.089973820919,
+            "maximum_latitude": 45.0905678833229,
+            "minimum_longitude": -123.046260413675,
+            "maximum_longitude": -123.044224655623,
+            "extracted_on": "2022-03-17T15:22:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/wheatlandferry-or-us/wheatlandferry-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-wheatland-ferry-gtfs-833.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-red-rose-transit-authority-rrta-gtfs-807.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-red-rose-transit-authority-rrta-gtfs-807.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 807,
+    "data_type": "gtfs",
+    "provider": "Red Rose Transit Authority (RRTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Lancaster",
+        "bounding_box": {
+            "minimum_latitude": 39.9714978342735,
+            "maximum_latitude": 40.18634,
+            "minimum_longitude": -76.642207,
+            "maximum_longitude": -75.9562961828993,
+            "extracted_on": "2022-03-17T15:22:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/rrta.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-red-rose-transit-authority-rrta-gtfs-807.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-vermont-tri-valley-transit-gtfs-852.json
+++ b/catalogs/sources/gtfs/schedule/us-vermont-tri-valley-transit-gtfs-852.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 852,
+    "data_type": "gtfs",
+    "provider": "Tri-Valley Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Vermont",
+        "municipality": "Burlington",
+        "bounding_box": {
+            "minimum_latitude": 43.5863615806701,
+            "maximum_latitude": 44.480722,
+            "minimum_longitude": -73.345019,
+            "maximum_longitude": -72.023504,
+            "extracted_on": "2022-03-17T15:24:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/trivalleytransit-vt-us/trivalleytransit-vt-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-vermont-tri-valley-transit-gtfs-852.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-altavista-community-transit-system-gtfs-882.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-altavista-community-transit-system-gtfs-882.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 882,
+    "data_type": "gtfs",
+    "provider": "Altavista Community Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Lynchburg",
+        "bounding_box": {
+            "minimum_latitude": 37.1098467177009,
+            "maximum_latitude": 37.1423273297123,
+            "minimum_longitude": -79.3044038051373,
+            "maximum_longitude": -79.2507950076175,
+            "extracted_on": "2022-03-17T15:29:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/altavista-va-us/altavista-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-altavista-community-transit-system-gtfs-882.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-pony-express-gtfs-828.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-pony-express-gtfs-828.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 828,
+    "data_type": "gtfs",
+    "provider": "Pony Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "bounding_box": {
+            "minimum_latitude": 37.902379,
+            "maximum_latitude": 37.943053,
+            "minimum_longitude": -75.405157,
+            "maximum_longitude": -75.352106,
+            "extracted_on": "2022-03-17T15:22:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ponyexpress-va-us/ponyexpress-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-pony-express-gtfs-828.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-radar-gtfs-832.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-radar-gtfs-832.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 832,
+    "data_type": "gtfs",
+    "provider": "RADAR",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "bounding_box": {
+            "minimum_latitude": 36.626599049548,
+            "maximum_latitude": 37.8216751831567,
+            "minimum_longitude": -80.0216094217242,
+            "maximum_longitude": -79.346863,
+            "extracted_on": "2022-03-17T15:22:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/radar-va-us/radar-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-radar-gtfs-832.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-star-transit-gtfs-819.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-star-transit-gtfs-819.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 819,
+    "data_type": "gtfs",
+    "provider": "STAR Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Hampton",
+        "bounding_box": {
+            "minimum_latitude": 37.1326077109895,
+            "maximum_latitude": 38.0008832180967,
+            "minimum_longitude": -76.0198036350918,
+            "maximum_longitude": -75.3605757430462,
+            "extracted_on": "2022-03-17T15:22:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/startransit-va-us/startransit-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-star-transit-gtfs-819.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-jefferson-transit-authority-gtfs-838.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-jefferson-transit-authority-gtfs-838.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 838,
+    "data_type": "gtfs",
+    "provider": "Jefferson Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 47.459067,
+            "maximum_latitude": 48.136621,
+            "minimum_longitude": -124.422517,
+            "maximum_longitude": -122.4963,
+            "extracted_on": "2022-03-17T15:22:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/jefferson_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-jefferson-transit-authority-gtfs-838.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-people-for-people-gtfs-836.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-people-for-people-gtfs-836.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 836,
+    "data_type": "gtfs",
+    "provider": "People for People",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 46.198738,
+            "maximum_latitude": 47.966069,
+            "minimum_longitude": -120.69641,
+            "maximum_longitude": -117.410392,
+            "extracted_on": "2022-03-17T15:22:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/pfp_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-people-for-people-gtfs-836.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-ruraltransit-gtfs-822.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-ruraltransit-gtfs-822.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 822,
+    "data_type": "gtfs",
+    "provider": "ruralTRANSIT",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": 46.71704,
+            "maximum_latitude": 47.01786,
+            "minimum_longitude": -123.17158,
+            "maximum_longitude": -122.68924,
+            "extracted_on": "2022-03-17T15:22:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/thurston-wa-us/thurston-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-ruraltransit-gtfs-822.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-snoqualmie-valley-transportation-gtfs-816.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-snoqualmie-valley-transportation-gtfs-816.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 816,
+    "data_type": "gtfs",
+    "provider": "Snoqualmie Valley Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Snoqualmie",
+        "bounding_box": {
+            "minimum_latitude": 47.4269639289488,
+            "maximum_latitude": 47.868098,
+            "minimum_longitude": -122.0094309,
+            "maximum_longitude": -121.752252130978,
+            "extracted_on": "2022-03-17T15:22:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.trilliumtransit.com/gtfs/snoqualmie-wa-us/snoqualmie-wa-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-snoqualmie-valley-transportation-gtfs-816.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-squaxin-island-transit-gtfs-846.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-squaxin-island-transit-gtfs-846.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 846,
+    "data_type": "gtfs",
+    "provider": "Squaxin Island Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Olympia",
+        "bounding_box": {
+            "minimum_latitude": 47.006266,
+            "maximum_latitude": 47.2141,
+            "minimum_longitude": -123.396838,
+            "maximum_longitude": -123.031682968139,
+            "extracted_on": "2022-03-17T15:24:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://mjcaction.com/MJC_GTFS_Public/squaxintribe_google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-squaxin-island-transit-gtfs-846.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-metro-ride-gtfs-830.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-metro-ride-gtfs-830.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 830,
+    "data_type": "gtfs",
+    "provider": "Metro Ride",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Wausau",
+        "bounding_box": {
+            "minimum_latitude": 44.9306818900424,
+            "maximum_latitude": 45.0029636867689,
+            "minimum_longitude": -89.6812531115174,
+            "maximum_longitude": -89.5976620952163,
+            "extracted_on": "2022-03-17T15:22:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/wausau-wi-us/wausau-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-metro-ride-gtfs-830.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the ninth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 85 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~