### PR TITLE
feat: Tenth import, take 2 [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ae-dubayy-road-and-transport-authority-rta-gtfs-904.json
+++ b/catalogs/sources/gtfs/schedule/ae-dubayy-road-and-transport-authority-rta-gtfs-904.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 904,
+    "data_type": "gtfs",
+    "provider": "Road and Transport Authority (RTA)",
+    "location": {
+        "country_code": "AE",
+        "subdivision_name": "Dubayy",
+        "bounding_box": {
+            "minimum_latitude": 24.720541,
+            "maximum_latitude": 25.411596,
+            "minimum_longitude": 54.970379,
+            "maximum_longitude": 56.132683,
+            "extracted_on": "2022-03-17T18:13:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/dubai-rta.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ae-dubayy-road-and-transport-authority-rta-gtfs-904.zip?alt=media",
+        "license": "https://www.dubaipulse.gov.ae/data/rta_gtfs-open/datafiles/605e9d34-cfea-4bed-9b31-3b2ce86c7a25/rta-public-transports#preview"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-sunbus-rockhampton-gtfs-907.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-sunbus-rockhampton-gtfs-907.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 907,
+    "data_type": "gtfs",
+    "provider": "Sunbus Rockhampton",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Rockhampton",
+        "bounding_box": {
+            "minimum_latitude": -23.407899,
+            "maximum_latitude": -23.29363,
+            "minimum_longitude": 150.484343,
+            "maximum_longitude": 150.566926,
+            "extracted_on": "2022-03-17T18:13:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfsrt.api.translink.com.au/GTFS/ROK_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-sunbus-rockhampton-gtfs-907.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/br-rio-grande-do-sul-prefeitura-de-bage-gtfs-930.json
+++ b/catalogs/sources/gtfs/schedule/br-rio-grande-do-sul-prefeitura-de-bage-gtfs-930.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 930,
+    "data_type": "gtfs",
+    "provider": "Prefeitura de Bage",
+    "location": {
+        "country_code": "BR",
+        "subdivision_name": "Rio Grande do Sul",
+        "municipality": "Bagé",
+        "bounding_box": {
+            "minimum_latitude": -31.3831,
+            "maximum_latitude": -31.265915,
+            "minimum_longitude": -54.1463327,
+            "maximum_longitude": -54.0173185,
+            "extracted_on": "2022-03-17T18:20:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/rodrigowindows/GTFS/raw/master/GTFS_Bage.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/br-rio-grande-do-sul-prefeitura-de-bage-gtfs-930.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ch-unknown-lk2-gtfs-914.json
+++ b/catalogs/sources/gtfs/schedule/ch-unknown-lk2-gtfs-914.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 914,
+    "data_type": "gtfs",
+    "provider": "LK2",
+    "location": {
+        "country_code": "CH",
+        "bounding_box": {
+            "minimum_latitude": 47.6262750305982,
+            "maximum_latitude": 47.9837269187185,
+            "minimum_longitude": 8.63220801034985,
+            "maximum_longitude": 9.24936857693156,
+            "extracted_on": "2022-03-17T18:16:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vhb.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ch-unknown-lk2-gtfs-914.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ch-unknown-schweizerische-bundesbahnen-sbb-gtfs-925.json
+++ b/catalogs/sources/gtfs/schedule/ch-unknown-schweizerische-bundesbahnen-sbb-gtfs-925.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 925,
+    "data_type": "gtfs",
+    "provider": "Schweizerische Bundesbahnen SBB",
+    "location": {
+        "country_code": "CH",
+        "bounding_box": {
+            "minimum_latitude": 43.1284124477083,
+            "maximum_latitude": 50.3509872529587,
+            "minimum_longitude": 0.595870494345107,
+            "maximum_longitude": 13.0456759176076,
+            "extracted_on": "2022-03-17T18:20:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://opentransportdata.swiss/en/dataset/timetable-2017-gtfs/permalink",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ch-unknown-schweizerische-bundesbahnen-sbb-gtfs-925.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ci-abidjan-divers-operateurs-gtfs-913.json
+++ b/catalogs/sources/gtfs/schedule/ci-abidjan-divers-operateurs-gtfs-913.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 913,
+    "data_type": "gtfs",
+    "provider": "Divers opérateurs",
+    "location": {
+        "country_code": "CI",
+        "subdivision_name": "Abidjan",
+        "bounding_box": {
+            "minimum_latitude": 5.2368916,
+            "maximum_latitude": 5.5133877,
+            "minimum_longitude": -4.2517667,
+            "maximum_longitude": -3.8355428,
+            "extracted_on": "2022-03-17T18:15:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://git.digitaltransport4africa.org/data/africa/abidjan/raw/master/Donn%C3%A9es/abidjan.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ci-abidjan-divers-operateurs-gtfs-913.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-rvs-gtfs-909.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-rvs-gtfs-909.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 909,
+    "data_type": "gtfs",
+    "provider": "RVS",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Karlsruhe",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 50.7904436115698,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 8.90065156674066,
+            "extracted_on": "2022-03-17T18:15:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/rvs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-rvs-gtfs-909.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-sbg-gtfs-918.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-sbg-gtfs-918.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 918,
+    "data_type": "gtfs",
+    "provider": "SBG",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 48.3963590473668,
+            "minimum_longitude": -13.9746327361978,
+            "maximum_longitude": 9.04428319753852,
+            "extracted_on": "2022-03-17T18:18:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/sbg.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-sbg-gtfs-918.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-tbo-offenburg-gtfs-900.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-tbo-offenburg-gtfs-900.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 900,
+    "data_type": "gtfs",
+    "provider": "TBO Offenburg",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "bounding_box": {
+            "minimum_latitude": 48.2180766249245,
+            "maximum_latitude": 48.6841606522977,
+            "minimum_longitude": 7.4869548376193,
+            "maximum_longitude": 8.14076666779818,
+            "extracted_on": "2022-03-17T18:12:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/tgo.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-tbo-offenburg-gtfs-900.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-tuticket-gtfs-920.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-tuticket-gtfs-920.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 920,
+    "data_type": "gtfs",
+    "provider": "TuTicket",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Tuttlingen",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 48.1768562054834,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 9.00780261384535,
+            "extracted_on": "2022-03-17T18:19:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/tuticket.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-tuticket-gtfs-920.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-volz-gtfs-906.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-volz-gtfs-906.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 906,
+    "data_type": "gtfs",
+    "provider": "VOLZ",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "bounding_box": {
+            "minimum_latitude": -8.28744518406192,
+            "maximum_latitude": 48.8382249569319,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 41.1683072567095,
+            "extracted_on": "2022-03-17T18:13:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vgc.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-volz-gtfs-906.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-barcelona-autos-castellbisbal-gtfs-892.json
+++ b/catalogs/sources/gtfs/schedule/es-barcelona-autos-castellbisbal-gtfs-892.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 892,
+    "data_type": "gtfs",
+    "provider": "Autos Castellbisbal, Mohn, Oliveras, Rosanbus",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Barcelona",
+        "bounding_box": {
+            "minimum_latitude": 41.26251865,
+            "maximum_latitude": 41.51012222,
+            "minimum_longitude": 1.8466579,
+            "maximum_longitude": 2.28936032,
+            "extracted_on": "2022-03-17T18:11:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.ambmobilitat.cat/OpenData/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-barcelona-autos-castellbisbal-gtfs-892.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-etela-karjala-lappeenranta-gtfs-929.json
+++ b/catalogs/sources/gtfs/schedule/fi-etela-karjala-lappeenranta-gtfs-929.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 929,
+    "data_type": "gtfs",
+    "provider": "Lappeenranta",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Etelä-Karjala",
+        "municipality": "Lappeenranta",
+        "bounding_box": {
+            "minimum_latitude": 60.7131718841537,
+            "maximum_latitude": 61.22411680072943,
+            "minimum_longitude": 27.9367494670498,
+            "maximum_longitude": 28.833944718539392,
+            "extracted_on": "2022-03-17T18:20:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/225.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-etela-karjala-lappeenranta-gtfs-929.zip?alt=media",
+        "license": "https://opendata.waltti.fi/docs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-aix-en-bus-gtfs-888.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-aix-en-bus-gtfs-888.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 888,
+    "data_type": "gtfs",
+    "provider": "Aix en Bus",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d’Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.4715535955,
+            "maximum_latitude": 43.6120261474,
+            "minimum_longitude": 5.3320142515,
+            "maximum_longitude": 5.5428163446,
+            "extracted_on": "2022-03-17T18:11:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://tsvc2.pilote3.cityway.fr/api/Export/v1/GetExportedDataFile?ExportFormat=Gtfs&OperatorCode=AIXENBUS",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-aix-en-bus-gtfs-888.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-les-bus-des-cigales-gtfs-889.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-les-bus-des-cigales-gtfs-889.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 889,
+    "data_type": "gtfs",
+    "provider": "Les bus des Cigales",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d’Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.2739556808,
+            "maximum_latitude": 43.3135594005,
+            "minimum_longitude": 5.6084587014,
+            "maximum_longitude": 5.6370043721,
+            "extracted_on": "2022-03-17T18:11:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://tsvc2.pilote3.cityway.fr/api/Export/v1/GetExportedDataFile?ExportFormat=Gtfs&OperatorCode=CIGALES",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-les-bus-des-cigales-gtfs-889.zip?alt=media",
+        "license": "http://opendata.regionpaca.fr/fileadmin/user_upload/tx_ausyopendata/licences/Licence-Ouverte-Open-Licence-ETALAB.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-ulysse-gtfs-890.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-ulysse-gtfs-890.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 890,
+    "data_type": "gtfs",
+    "provider": "Ulysse",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d'Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.4018961743,
+            "maximum_latitude": 43.4050889012,
+            "minimum_longitude": 5.0495503887,
+            "maximum_longitude": 5.0592032719,
+            "extracted_on": "2022-03-17T18:11:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://tsvc2.pilote3.cityway.fr/api/Export/v1/GetExportedDataFile?ExportFormat=Gtfs&OperatorCode=MILSAB",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-ulysse-gtfs-890.zip?alt=media",
+        "license": "http://opendata.regionpaca.fr/fileadmin/user_upload/tx_ausyopendata/licences/Licence-Ouverte-Open-Licence-ETALAB.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hu-pest-budaors-varos-onkormanyzata-gtfs-894.json
+++ b/catalogs/sources/gtfs/schedule/hu-pest-budaors-varos-onkormanyzata-gtfs-894.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 894,
+    "data_type": "gtfs",
+    "provider": "Budaörs Város Önkormányzata",
+    "location": {
+        "country_code": "HU",
+        "subdivision_name": "Pest",
+        "municipality": "Budaörs",
+        "bounding_box": {
+            "minimum_latitude": 47.435411,
+            "maximum_latitude": 47.467701,
+            "minimum_longitude": 18.918696,
+            "maximum_longitude": 18.980891,
+            "extracted_on": "2022-03-17T18:12:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.armadina.hu/transit/budaors.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-pest-budaors-varos-onkormanyzata-gtfs-894.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hu-szeged-dakk-zrt-gtfs-887.json
+++ b/catalogs/sources/gtfs/schedule/hu-szeged-dakk-zrt-gtfs-887.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 887,
+    "data_type": "gtfs",
+    "provider": "DAKK Zrt., SZKT, MÁV-START",
+    "location": {
+        "country_code": "HU",
+        "subdivision_name": "Szeged",
+        "bounding_box": {
+            "minimum_latitude": 46.2021769,
+            "maximum_latitude": 46.4169061,
+            "minimum_longitude": 20.0238029,
+            "maximum_longitude": 20.3392939,
+            "extracted_on": "2022-03-17T18:10:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://szegedimenetrend.hu/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-szeged-dakk-zrt-gtfs-887.zip?alt=media",
+        "license": "http://szegedimenetrend.hu/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/in-andhra-pradesh-hyderabad-multi-modal-transport-system-gtfs-921.json
+++ b/catalogs/sources/gtfs/schedule/in-andhra-pradesh-hyderabad-multi-modal-transport-system-gtfs-921.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 921,
+    "data_type": "gtfs",
+    "provider": "Hyderabad Multi-Modal Transport System",
+    "location": {
+        "country_code": "IN",
+        "subdivision_name": "Andhra Pradesh",
+        "municipality": "Hyderabad",
+        "bounding_box": {
+            "minimum_latitude": 17.263162,
+            "maximum_latitude": 17.724815,
+            "minimum_longitude": 78.282051,
+            "maximum_longitude": 79.154434,
+            "extracted_on": "2022-03-17T18:19:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://drive.google.com/uc?export=download&id=1Hiv3FLp40cLXPPi9Ne8rO8m1W9hjBPs3",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/in-andhra-pradesh-hyderabad-multi-modal-transport-system-gtfs-921.zip?alt=media",
+        "license": "https://hmrl.co.in/open-data.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-campania-azienda-napoletana-mobilita-gtfs-893.json
+++ b/catalogs/sources/gtfs/schedule/it-campania-azienda-napoletana-mobilita-gtfs-893.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 893,
+    "data_type": "gtfs",
+    "provider": "Azienda Napoletana Mobilità",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Campania",
+        "municipality": "Napoli",
+        "bounding_box": {
+            "minimum_latitude": 40.7473379778158,
+            "maximum_latitude": 40.9565233742084,
+            "minimum_longitude": 14.1228713923268,
+            "maximum_longitude": 14.5450041847435,
+            "extracted_on": "2022-03-17T18:12:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.anm.it/google/google-transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-campania-azienda-napoletana-mobilita-gtfs-893.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-puglia-miccolis-spa-gtfs-912.json
+++ b/catalogs/sources/gtfs/schedule/it-puglia-miccolis-spa-gtfs-912.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 912,
+    "data_type": "gtfs",
+    "provider": "Miccolis S.p.A.",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Puglia",
+        "bounding_box": {
+            "minimum_latitude": 40.6336018,
+            "maximum_latitude": 40.7254312,
+            "minimum_longitude": 16.4574659,
+            "maximum_longitude": 16.6271175,
+            "extracted_on": "2022-03-17T18:15:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://dati.comune.matera.it/dataset/d0c92871-38dd-440b-95d1-7155b522d57e/resource/cb97b36d-293e-4dfb-84e3-50ba7e3d9d50/download/gtfs_matera.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-puglia-miccolis-spa-gtfs-912.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-sardegna-arst-spa-trasporti-regionali-della-sardegna-gtfs-895.json
+++ b/catalogs/sources/gtfs/schedule/it-sardegna-arst-spa-trasporti-regionali-della-sardegna-gtfs-895.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 895,
+    "data_type": "gtfs",
+    "provider": "ARST SpA - Trasporti Regionali Della Sardegna",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Sardegna",
+        "municipality": "Cagliari",
+        "bounding_box": {
+            "minimum_latitude": 38.895743,
+            "maximum_latitude": 41.24223,
+            "minimum_longitude": 8.149003,
+            "maximum_longitude": 9.788329,
+            "extracted_on": "2022-03-17T18:12:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.arstspa.info/arst-cagliari-it.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-sardegna-arst-spa-trasporti-regionali-della-sardegna-gtfs-895.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-sicilia-azienda-trasporti-di-messina-atm-gtfs-896.json
+++ b/catalogs/sources/gtfs/schedule/it-sicilia-azienda-trasporti-di-messina-atm-gtfs-896.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 896,
+    "data_type": "gtfs",
+    "provider": "Azienda Trasporti di Messina (ATM)",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Sicilia",
+        "municipality": "Messina",
+        "bounding_box": {
+            "minimum_latitude": 38.0613,
+            "maximum_latitude": 38.2998,
+            "minimum_longitude": 15.4452,
+            "maximum_longitude": 15.6508,
+            "extracted_on": "2022-03-17T18:12:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.atm.messina.it/atm_feed_gtfs/atm_feed_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-sicilia-azienda-trasporti-di-messina-atm-gtfs-896.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-veneto-alilaguna-gtfs-891.json
+++ b/catalogs/sources/gtfs/schedule/it-veneto-alilaguna-gtfs-891.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 891,
+    "data_type": "gtfs",
+    "provider": "Alilaguna",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Veneto",
+        "municipality": "Venice",
+        "bounding_box": {
+            "minimum_latitude": 45.417659,
+            "maximum_latitude": 45.500799,
+            "minimum_longitude": 12.320154,
+            "maximum_longitude": 12.368506,
+            "extracted_on": "2022-03-17T18:11:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.alilaguna.it/attuale/alilaguna.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-veneto-alilaguna-gtfs-891.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/lv-riga-rigas-satiksme-gtfs-884.json
+++ b/catalogs/sources/gtfs/schedule/lv-riga-rigas-satiksme-gtfs-884.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 884,
+    "data_type": "gtfs",
+    "provider": "Rīgas Satiksme",
+    "location": {
+        "country_code": "LV",
+        "subdivision_name": "Rīga",
+        "bounding_box": {
+            "minimum_latitude": 56.85944,
+            "maximum_latitude": 57.07113,
+            "minimum_longitude": 23.90414,
+            "maximum_longitude": 24.37973,
+            "extracted_on": "2022-03-17T18:09:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://saraksti.rigassatiksme.lv/riga/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/lv-riga-rigas-satiksme-gtfs-884.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-lompoc-transit-colt-gtfs-919.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-lompoc-transit-colt-gtfs-919.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 919,
+    "data_type": "gtfs",
+    "provider": "City of Lompoc Transit (COLT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Lompoc",
+        "bounding_box": {
+            "minimum_latitude": 34.421013,
+            "maximum_latitude": 34.715418,
+            "minimum_longitude": -120.475468,
+            "maximum_longitude": -119.703516,
+            "extracted_on": "2022-03-17T18:18:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.cityoflompoc.com/home/showdocument?id=29896",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-of-lompoc-transit-colt-gtfs-919.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-joaquin-regional-transit-district-rtd-gtfs-886.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-joaquin-regional-transit-district-rtd-gtfs-886.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 886,
+    "data_type": "gtfs",
+    "provider": "San Joaquin Regional Transit District (RTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Stockton",
+        "bounding_box": {
+            "minimum_latitude": 37.68719,
+            "maximum_latitude": 38.579931,
+            "minimum_longitude": -121.890123,
+            "maximum_longitude": -120.994762,
+            "extracted_on": "2022-03-17T18:10:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://sjrtd.com/RTD-GTFS/RTD-GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-joaquin-regional-transit-district-rtd-gtfs-886.zip?alt=media",
+        "license": "http://sanjoaquinrtd.com/preview/terms-of-use/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-huntington-area-rapid-transit-hart-gtfs-905.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-huntington-area-rapid-transit-hart-gtfs-905.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 905,
+    "data_type": "gtfs",
+    "provider": "Huntington Area Rapid Transit (HART)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "municipality": "Stamford",
+        "bounding_box": {
+            "minimum_latitude": 40.810878,
+            "maximum_latitude": 40.901946,
+            "minimum_longitude": -73.461939,
+            "maximum_longitude": -73.291059,
+            "extracted_on": "2022-03-17T18:13:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/HART_Huntington_Area_Rapid_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-huntington-area-rapid-transit-hart-gtfs-905.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-connecticut-lower-hudson-valley-transit-gtfs-915.json
+++ b/catalogs/sources/gtfs/schedule/us-connecticut-lower-hudson-valley-transit-gtfs-915.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 915,
+    "data_type": "gtfs",
+    "provider": "Lower Hudson Valley Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Connecticut",
+        "municipality": "Stamford",
+        "bounding_box": {
+            "minimum_latitude": 41.031132,
+            "maximum_latitude": 41.116723,
+            "minimum_longitude": -74.152063,
+            "maximum_longitude": -73.763481,
+            "extracted_on": "2022-03-17T18:16:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Hudson_Link.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-connecticut-lower-hudson-valley-transit-gtfs-915.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-iowa-cyride-gtfs-923.json
+++ b/catalogs/sources/gtfs/schedule/us-iowa-cyride-gtfs-923.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 923,
+    "data_type": "gtfs",
+    "provider": "CyRide",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Iowa",
+        "municipality": "Ames",
+        "bounding_box": {
+            "minimum_latitude": 41.990134,
+            "maximum_latitude": 42.056454,
+            "minimum_longitude": -93.695767,
+            "maximum_longitude": -93.607469,
+            "extracted_on": "2022-03-17T18:19:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.cyride.net/gtf/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-iowa-cyride-gtfs-923.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-mass-transportation-authority-flint-gtfs-926.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-mass-transportation-authority-flint-gtfs-926.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 926,
+    "data_type": "gtfs",
+    "provider": "Mass Transportation Authority Flint",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Flint",
+        "bounding_box": {
+            "minimum_latitude": 42.89283808,
+            "maximum_latitude": 43.12276565,
+            "minimum_longitude": -83.78563875,
+            "maximum_longitude": -83.5996040439,
+            "extracted_on": "2022-03-17T18:20:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.mtaflint.org/wp-content/media/stops.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-mass-transportation-authority-flint-gtfs-926.zip?alt=media",
+        "license": "https://www.mtaflint.org/terms-of-use.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-michigan-university-of-michigan-gtfs-898.json
+++ b/catalogs/sources/gtfs/schedule/us-michigan-university-of-michigan-gtfs-898.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 898,
+    "data_type": "gtfs",
+    "provider": "University of Michigan",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Michigan",
+        "municipality": "Ann Arbor",
+        "bounding_box": {
+            "minimum_latitude": 42.264134,
+            "maximum_latitude": 47.76395,
+            "minimum_longitude": -96.62663,
+            "maximum_longitude": -83.673986,
+            "extracted_on": "2022-03-17T18:12:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ltp.umich.edu/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-michigan-university-of-michigan-gtfs-898.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-nevada-tahoe-transportation-district-gtfs-897.json
+++ b/catalogs/sources/gtfs/schedule/us-nevada-tahoe-transportation-district-gtfs-897.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 897,
+    "data_type": "gtfs",
+    "provider": "Tahoe Transportation District",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Nevada",
+        "bounding_box": {
+            "minimum_latitude": 38.89462,
+            "maximum_latitude": 39.24968406,
+            "minimum_longitude": -120.0101182,
+            "maximum_longitude": -119.73997,
+            "extracted_on": "2022-03-17T18:12:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/tahoe-ca-us/tahoe-ca-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-nevada-tahoe-transportation-district-gtfs-897.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-city-of-long-beach-transportation-gtfs-916.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-city-of-long-beach-transportation-gtfs-916.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 916,
+    "data_type": "gtfs",
+    "provider": "City of Long Beach Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Long Beach",
+        "bounding_box": {
+            "minimum_latitude": 40.584023,
+            "maximum_latitude": 40.593176,
+            "minimum_longitude": -73.701188,
+            "maximum_longitude": -73.577753,
+            "extracted_on": "2022-03-17T18:16:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/City_of_Long_Beach.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-city-of-long-beach-transportation-gtfs-916.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-clarkstown-minitrans-gtfs-911.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-clarkstown-minitrans-gtfs-911.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 911,
+    "data_type": "gtfs",
+    "provider": "Clarkstown MiniTrans",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Clarkstown",
+        "bounding_box": {
+            "minimum_latitude": 41.078817,
+            "maximum_latitude": 41.184912,
+            "minimum_longitude": -74.031866,
+            "maximum_longitude": -73.928075,
+            "extracted_on": "2022-03-17T18:15:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Clarkstown_Mini_Trans.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-clarkstown-minitrans-gtfs-911.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-cortland-county-public-transportation-gtfs-899.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-cortland-county-public-transportation-gtfs-899.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 899,
+    "data_type": "gtfs",
+    "provider": "Cortland County Public Transportation",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Ithaca",
+        "bounding_box": {
+            "minimum_latitude": 42.436517,
+            "maximum_latitude": 42.635431,
+            "minimum_longitude": -76.482758,
+            "maximum_longitude": -75.896614,
+            "extracted_on": "2022-03-17T18:12:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Cortland_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-cortland-county-public-transportation-gtfs-899.zip?alt=media",
+        "license": "https://data.ny.gov/download/77gx-ii52/application/pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-leprechaun-lines-gtfs-910.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-leprechaun-lines-gtfs-910.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 910,
+    "data_type": "gtfs",
+    "provider": "Leprechaun Lines",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "bounding_box": {
+            "minimum_latitude": 41.01756,
+            "maximum_latitude": 41.706467,
+            "minimum_longitude": -73.937671,
+            "maximum_longitude": -73.722478,
+            "extracted_on": "2022-03-17T18:15:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Leprechaun_Connection.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-leprechaun-lines-gtfs-910.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-part-putnam-area-rapid-transit-gtfs-928.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-part-putnam-area-rapid-transit-gtfs-928.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 928,
+    "data_type": "gtfs",
+    "provider": "PART Putnam Area Rapid Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Poughkeepsie",
+        "bounding_box": {
+            "minimum_latitude": 41.329255,
+            "maximum_latitude": 41.516213,
+            "minimum_longitude": -73.810565,
+            "maximum_longitude": -73.536663,
+            "extracted_on": "2022-03-17T18:20:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/PART_Putnam_Area_Rapid_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-part-putnam-area-rapid-transit-gtfs-928.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-sullivan-county-transit-gtfs-927.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-sullivan-county-transit-gtfs-927.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 927,
+    "data_type": "gtfs",
+    "provider": "Sullivan County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Poughkeepsie",
+        "bounding_box": {
+            "minimum_latitude": 41.4776,
+            "maximum_latitude": 41.8347,
+            "minimum_longitude": -75.0515,
+            "maximum_longitude": -74.573345,
+            "extracted_on": "2022-03-17T18:20:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Sullivan_County.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-sullivan-county-transit-gtfs-927.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-transit-orange-newburgh-local-transit-gtfs-924.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-transit-orange-newburgh-local-transit-gtfs-924.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 924,
+    "data_type": "gtfs",
+    "provider": "Transit Orange / Newburgh Local Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "Poughkeepsie",
+        "bounding_box": {
+            "minimum_latitude": 41.430494,
+            "maximum_latitude": 41.528003,
+            "minimum_longitude": -74.074088,
+            "maximum_longitude": -74.00593,
+            "extracted_on": "2022-03-17T18:19:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://s3.amazonaws.com/datatools-511ny/public/Newburgh_Bus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-transit-orange-newburgh-local-transit-gtfs-924.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-asheville-rides-transit-gtfs-903.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-asheville-rides-transit-gtfs-903.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 903,
+    "data_type": "gtfs",
+    "provider": "Asheville Rides Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Asheville",
+        "bounding_box": {
+            "minimum_latitude": 35.4246944256883,
+            "maximum_latitude": 35.644076,
+            "minimum_longitude": -82.632616497733,
+            "maximum_longitude": -82.319173,
+            "extracted_on": "2022-03-17T18:12:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/asheville-nc-us/asheville-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-asheville-rides-transit-gtfs-903.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-portage-area-regional-transportation-authority-parta-gtfs-908.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-portage-area-regional-transportation-authority-parta-gtfs-908.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 908,
+    "data_type": "gtfs",
+    "provider": "Portage Area Regional Transportation Authority (PARTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Akron",
+        "bounding_box": {
+            "minimum_latitude": 41.0669159049735,
+            "maximum_latitude": 41.514242,
+            "minimum_longitude": -81.695549606943,
+            "maximum_longitude": -81.0371718331358,
+            "extracted_on": "2022-03-17T18:13:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://592f5f98-5029-425f-ac4d-0774faecf068.filesusr.com/archives/f64377_81ed397719364abbb0aa6a97a1dbf1c9.zip?dn=12_17google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-portage-area-regional-transportation-authority-parta-gtfs-908.zip?alt=media",
+        "license": "https://www.partaonline.org/gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-ohio-western-reserve-transit-authority-gtfs-922.json
+++ b/catalogs/sources/gtfs/schedule/us-ohio-western-reserve-transit-authority-gtfs-922.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 922,
+    "data_type": "gtfs",
+    "provider": "Western Reserve Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Ohio",
+        "municipality": "Youngstown",
+        "bounding_box": {
+            "minimum_latitude": 40.977121,
+            "maximum_latitude": 41.279698,
+            "minimum_longitude": -80.857996,
+            "maximum_longitude": -80.576094,
+            "extracted_on": "2022-03-17T18:19:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/western-reserve-transit-authority.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-ohio-western-reserve-transit-authority-gtfs-922.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-harney-county-gtfs-931.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-harney-county-gtfs-931.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 931,
+    "data_type": "gtfs",
+    "provider": "Harney County",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Burns",
+        "bounding_box": {
+            "minimum_latitude": 43.226212,
+            "maximum_latitude": 44.421605,
+            "minimum_longitude": -121.30426,
+            "maximum_longitude": -116.20345,
+            "extracted_on": "2022-03-17T18:20:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/harneycounty-or-us/harneycounty-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-harney-county-gtfs-931.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-link-lane-gtfs-932.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-link-lane-gtfs-932.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 932,
+    "data_type": "gtfs",
+    "provider": "Link Lane",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Eugene",
+        "bounding_box": {
+            "minimum_latitude": 43.9664002698976,
+            "maximum_latitude": 44.3116543,
+            "minimum_longitude": -124.11564,
+            "maximum_longitude": -123.092641521866,
+            "extracted_on": "2022-03-17T18:20:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/lcog-or-us/lcog-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-link-lane-gtfs-932.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-oregon-mt-bachelor-gtfs-933.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-mt-bachelor-gtfs-933.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 933,
+    "data_type": "gtfs",
+    "provider": "Mt. Bachelor",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Oregon",
+        "municipality": "Bend",
+        "bounding_box": {
+            "minimum_latitude": 44.003281,
+            "maximum_latitude": 44.0503687550885,
+            "minimum_longitude": -121.678688,
+            "maximum_longitude": -121.326899132784,
+            "extracted_on": "2022-03-17T18:20:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://oregon-gtfs.com/gtfs_data/mtbachelor-or-us/mtbachelor-or-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-mt-bachelor-gtfs-933.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-fort-worth-transit-authority-gtfs-885.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-fort-worth-transit-authority-gtfs-885.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 885,
+    "data_type": "gtfs",
+    "provider": "Fort Worth Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "Fort Worth",
+        "bounding_box": {
+            "minimum_latitude": 32.56359,
+            "maximum_latitude": 32.965685,
+            "minimum_longitude": -97.479404,
+            "maximum_longitude": -97.038021,
+            "extracted_on": "2022-03-17T18:09:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://sched.ridetm.org/gtfs/fwtatransitdata.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-fort-worth-transit-authority-gtfs-885.zip?alt=media",
+        "license": "https://ridetrinitymetro.org/gtfs-data/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-grtc-transit-system-gtfs-902.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-grtc-transit-system-gtfs-902.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 902,
+    "data_type": "gtfs",
+    "provider": "GRTC Transit System ",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Redmond",
+        "bounding_box": {
+            "minimum_latitude": 37.226432,
+            "maximum_latitude": 37.663725,
+            "minimum_longitude": -77.644797,
+            "maximum_longitude": -77.302671,
+            "extracted_on": "2022-03-17T18:12:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/grtc.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-grtc-transit-system-gtfs-902.zip?alt=media",
+        "license": "http://ridegrtc.com/gtfs-files-developer-license-agreement-and-terms-of-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-gtfs-901.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-williamsburg-area-transit-authority-gtfs-901.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 901,
+    "data_type": "gtfs",
+    "provider": "Williamsburg Area Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Hampton",
+        "bounding_box": {
+            "minimum_latitude": 37.19292,
+            "maximum_latitude": 37.41068,
+            "minimum_longitude": -76.82154,
+            "maximum_longitude": -76.51867,
+            "extracted_on": "2022-03-17T18:12:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/williamsburg-va-us/williamsburg-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-williamsburg-area-transit-authority-gtfs-901.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-green-bay-metro-gtfs-917.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-green-bay-metro-gtfs-917.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 917,
+    "data_type": "gtfs",
+    "provider": "Green Bay Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Green Bay",
+        "bounding_box": {
+            "minimum_latitude": 44.43842,
+            "maximum_latitude": 44.547602,
+            "minimum_longitude": -88.109692,
+            "maximum_longitude": -87.922189,
+            "extracted_on": "2022-03-17T18:16:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://github.com/transitland/gtfs-archives-not-hosted-elsewhere/raw/master/green-bay-wi-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-green-bay-metro-gtfs-917.zip?alt=media",
+        "license": "https://greenbaywi.gov/496/Transit-Data-Developer"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the tenth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 50 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~