### PR TITLE
feat: Eleventh import

### DIFF
--- a/catalogs/sources/gtfs/schedule/au-australian-capital-territory-canberra-metro-operations-gtfs-935.json
+++ b/catalogs/sources/gtfs/schedule/au-australian-capital-territory-canberra-metro-operations-gtfs-935.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 935,
+    "data_type": "gtfs",
+    "provider": "Canberra Metro Operations",
+    "name": "Light Rail",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Australian Capital Territory",
+        "municipality": "Canberra",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-17T18:49:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transport.act.gov.au/googletransit/google_transit_lr.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-australian-capital-territory-canberra-metro-operations-gtfs-935.zip?alt=media",
+        "license": "https://creativecommons.org/licenses/by/4.0/legalcode"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-australian-capital-territory-transport-canberra-gtfs-936.json
+++ b/catalogs/sources/gtfs/schedule/au-australian-capital-territory-transport-canberra-gtfs-936.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 936,
+    "data_type": "gtfs",
+    "provider": "Transport Canberra",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Australian Capital Territory",
+        "municipality": "Canberra",
+        "bounding_box": {
+            "minimum_latitude": -35.476552,
+            "maximum_latitude": -35.146514,
+            "minimum_longitude": 148.993368,
+            "maximum_longitude": 149.190329,
+            "extracted_on": "2022-03-17T18:49:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transport.act.gov.au/googletransit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-australian-capital-territory-transport-canberra-gtfs-936.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-milton-transit-gtfs-994.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-milton-transit-gtfs-994.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 994,
+    "data_type": "gtfs",
+    "provider": "Milton Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Milton",
+        "bounding_box": {
+            "minimum_latitude": 43.48015,
+            "maximum_latitude": 43.54222,
+            "minimum_longitude": -79.89257,
+            "maximum_longitude": -79.82503,
+            "extracted_on": "2022-03-17T18:59:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.arcgis.com/sharing/rest/content/items/673292c1fb2c451d93aeb357e6c92bdf/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-milton-transit-gtfs-994.zip?alt=media",
+        "license": "http://www.milton.ca/en/resourcesGeneral/Open_Data/Milton_Open_Data_Terms_V1.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/cl-region-metropolitana-de-santiago-santiago-dptm-gtfs-987.json
+++ b/catalogs/sources/gtfs/schedule/cl-region-metropolitana-de-santiago-santiago-dptm-gtfs-987.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 987,
+    "data_type": "gtfs",
+    "provider": "Santiago DPTM",
+    "location": {
+        "country_code": "CL",
+        "subdivision_name": "Región Metropolitana de Santiago",
+        "bounding_box": {
+            "minimum_latitude": -34.170505,
+            "maximum_latitude": -33.3193344989227,
+            "minimum_longitude": -70.8739929374727,
+            "maximum_longitude": -70.4936019970485,
+            "extracted_on": "2022-03-17T18:57:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.dtpm.cl/descargas/gtfs/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/cl-region-metropolitana-de-santiago-santiago-dptm-gtfs-987.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-madrid-cercanias-madrid-gtfs-993.json
+++ b/catalogs/sources/gtfs/schedule/es-madrid-cercanias-madrid-gtfs-993.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 993,
+    "data_type": "gtfs",
+    "provider": "Cercanías Madrid",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Madrid",
+        "bounding_box": {
+            "minimum_latitude": 40.3322393619552,
+            "maximum_latitude": 40.5172566213243,
+            "minimum_longitude": -3.83657,
+            "maximum_longitude": -3.54249327469938,
+            "extracted_on": "2022-03-17T18:59:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.arcgis.com/sharing/rest/content/items/868df0e58fca47e79b942902dffd7da0/data",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-madrid-cercanias-madrid-gtfs-993.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-auvergne-rhone-alpes-cars-region-auvergne-rhone-alpes-transisere-gtfs-985.json
+++ b/catalogs/sources/gtfs/schedule/fr-auvergne-rhone-alpes-cars-region-auvergne-rhone-alpes-transisere-gtfs-985.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 985,
+    "data_type": "gtfs",
+    "provider": "Cars Région Auvergne-Rhône-Alpes (Transisère)",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Auvergne-Rhône-Alpes",
+        "bounding_box": {
+            "minimum_latitude": 44.5635712669,
+            "maximum_latitude": 45.8759465251,
+            "minimum_longitude": 4.7583478521,
+            "maximum_longitude": 6.2925805509,
+            "extracted_on": "2022-03-17T18:56:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.itinisere.fr/fr/donnees-open-data/169/OpenData/Download?fileName=CG38.GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-auvergne-rhone-alpes-cars-region-auvergne-rhone-alpes-transisere-gtfs-985.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-grasse-sillages-scolaire-gtfs-996.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-grasse-sillages-scolaire-gtfs-996.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 996,
+    "data_type": "gtfs",
+    "provider": "Grasse Sillages Scolaire",
+    "name": "Communauté urbaine du Pays de Grasse - Réveils Scolaires de Grasse",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d'Azur",
+        "municipality": "Grasse",
+        "bounding_box": {
+            "minimum_latitude": 43.5779703,
+            "maximum_latitude": 43.8824131,
+            "minimum_longitude": 6.642123,
+            "maximum_longitude": 6.979752,
+            "extracted_on": "2022-03-17T19:00:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-en-pays-de-grasse/20210203-152443/20210101-gtfs-sillagesscolaire.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-grasse-sillages-scolaire-gtfs-996.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-sillages-urbain-gtfs-997.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-sillages-urbain-gtfs-997.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 997,
+    "data_type": "gtfs",
+    "provider": "Sillages Urbain",
+    "name": "Sillages Urbain - Communauté urbaine du Pays de Grasse",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d'Azur",
+        "municipality": "Grasse",
+        "bounding_box": {
+            "minimum_latitude": 43.54788106,
+            "maximum_latitude": 43.8470147,
+            "minimum_longitude": 6.6423514,
+            "maximum_longitude": 6.979752,
+            "extracted_on": "2022-03-17T19:00:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://static.data.gouv.fr/resources/lignes-regulieres-de-transports-en-pays-de-grasse/20210203-152533/20210101-gtfs-sillagesurbain.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-sillages-urbain-gtfs-997.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-ulysse-gtfs-988.json
+++ b/catalogs/sources/gtfs/schedule/fr-provence-alpes-cote-dazur-ulysse-gtfs-988.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 988,
+    "data_type": "gtfs",
+    "provider": "Ulysse",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Provence-Alpes-Côte-d’Azur",
+        "bounding_box": {
+            "minimum_latitude": 43.3304313591,
+            "maximum_latitude": 43.6476558034,
+            "minimum_longitude": 4.7512716748,
+            "maximum_longitude": 5.4418369486,
+            "extracted_on": "2022-03-17T18:57:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.data.gouv.fr/fr/datasets/r/e8a86701-6359-45de-bee5-95e648ec04e3",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-provence-alpes-cote-dazur-ulysse-gtfs-988.zip?alt=media",
+        "license": "http://opendata.regionpaca.fr/fileadmin/user_upload/tx_ausyopendata/licences/Licence-Ouverte-Open-Licence-ETALAB.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/gb-westminster-transport-for-london-gtfs-995.json
+++ b/catalogs/sources/gtfs/schedule/gb-westminster-transport-for-london-gtfs-995.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 995,
+    "data_type": "gtfs",
+    "provider": "Transport For London",
+    "location": {
+        "country_code": "GB",
+        "subdivision_name": "Westminster",
+        "municipality": "London",
+        "bounding_box": {
+            "minimum_latitude": 51.342593,
+            "maximum_latitude": 51.705208,
+            "minimum_longitude": -0.611247,
+            "maximum_longitude": 0.329851,
+            "extracted_on": "2022-03-17T19:00:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://storage.googleapis.com/teleport-gtfs/tflgtfs_nobus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gb-westminster-transport-for-london-gtfs-995.zip?alt=media",
+        "license": "https://tfl.gov.uk/corporate/terms-and-conditions/transport-data-service"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/gb-windsor-and-maidenhead-french-brothers-ltd-gtfs-986.json
+++ b/catalogs/sources/gtfs/schedule/gb-windsor-and-maidenhead-french-brothers-ltd-gtfs-986.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 986,
+    "data_type": "gtfs",
+    "provider": "French Brothers Ltd",
+    "location": {
+        "country_code": "GB",
+        "subdivision_name": "Windsor and Maidenhead",
+        "bounding_box": {
+            "minimum_latitude": 51.382099,
+            "maximum_latitude": 51.528599,
+            "minimum_longitude": -0.7013,
+            "maximum_longitude": -0.3425,
+            "extracted_on": "2022-03-17T18:56:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.frenchbrothers.co.uk/link/transport/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gb-windsor-and-maidenhead-french-brothers-ltd-gtfs-986.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hu-budapest-budapesti-kozlekedesi-kozpont-bkk-gtfs-990.json
+++ b/catalogs/sources/gtfs/schedule/hu-budapest-budapesti-kozlekedesi-kozpont-bkk-gtfs-990.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 990,
+    "data_type": "gtfs",
+    "provider": "Budapesti Közlekedési Központ (BKK)",
+    "location": {
+        "country_code": "HU",
+        "subdivision_name": "Budapest",
+        "bounding_box": {
+            "minimum_latitude": 47.174793,
+            "maximum_latitude": 47.661038,
+            "minimum_longitude": 18.879511,
+            "maximum_longitude": 19.357892,
+            "extracted_on": "2022-03-17T18:57:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.bkk.hu/gtfs/budapest_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-budapest-budapesti-kozlekedesi-kozpont-bkk-gtfs-990.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-donegal-dohertys-coach-travel-gtfs-973.json
+++ b/catalogs/sources/gtfs/schedule/ie-donegal-dohertys-coach-travel-gtfs-973.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 973,
+    "data_type": "gtfs",
+    "provider": "Doherty's Coach Travel",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Donegal",
+        "bounding_box": {
+            "minimum_latitude": 54.9057785354346,
+            "maximum_latitude": 55.0259670933947,
+            "minimum_longitude": -8.44209184411169,
+            "maximum_longitude": -7.69465582858512,
+            "extracted_on": "2022-03-17T18:54:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_sdoherty.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-donegal-dohertys-coach-travel-gtfs-973.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-donegal-mangan-tours-gtfs-962.json
+++ b/catalogs/sources/gtfs/schedule/ie-donegal-mangan-tours-gtfs-962.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 962,
+    "data_type": "gtfs",
+    "provider": "Mangan Tours",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Donegal",
+        "bounding_box": {
+            "minimum_latitude": 54.948494051375,
+            "maximum_latitude": 55.1834976704306,
+            "minimum_longitude": -8.19100353869718,
+            "maximum_longitude": -7.72926877875234,
+            "extracted_on": "2022-03-17T18:53:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_mangan.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-donegal-mangan-tours-gtfs-962.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-donegal-mc-ginley-coach-travel-gtfs-965.json
+++ b/catalogs/sources/gtfs/schedule/ie-donegal-mc-ginley-coach-travel-gtfs-965.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 965,
+    "data_type": "gtfs",
+    "provider": "Mc Ginley Coach Travel",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Donegal",
+        "municipality": "Donegal",
+        "bounding_box": {
+            "minimum_latitude": 53.3510291485058,
+            "maximum_latitude": 55.2512801001395,
+            "minimum_longitude": -8.31855852053064,
+            "maximum_longitude": -6.24104561004998,
+            "extracted_on": "2022-03-17T18:53:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_mcginley.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-donegal-mc-ginley-coach-travel-gtfs-965.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-donegal-mcgeehan-coaches-gtfs-964.json
+++ b/catalogs/sources/gtfs/schedule/ie-donegal-mcgeehan-coaches-gtfs-964.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 964,
+    "data_type": "gtfs",
+    "provider": "McGeehan Coaches",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Donegal",
+        "municipality": "Donegal",
+        "bounding_box": {
+            "minimum_latitude": 54.6324574841512,
+            "maximum_latitude": 54.9537214691017,
+            "minimum_longitude": -8.72452879071827,
+            "maximum_longitude": -7.72926877875234,
+            "extracted_on": "2022-03-17T18:53:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_mcgeehan.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-donegal-mcgeehan-coaches-gtfs-964.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-aircoach-gtfs-937.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-aircoach-gtfs-937.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 937,
+    "data_type": "gtfs",
+    "provider": "Aircoach",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 51.9007494706183,
+            "maximum_latitude": 54.5950542821334,
+            "minimum_longitude": -9.0457442109723,
+            "maximum_longitude": -5.93626793243387,
+            "extracted_on": "2022-03-17T18:49:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_aircoach.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-aircoach-gtfs-937.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-airport-hopper-gtfs-946.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-airport-hopper-gtfs-946.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 946,
+    "data_type": "gtfs",
+    "provider": "Airport Hopper",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 52.9712655911391,
+            "maximum_latitude": 53.3445012930664,
+            "minimum_longitude": -9.42599581425359,
+            "maximum_longitude": -6.26095892242016,
+            "extracted_on": "2022-03-17T18:51:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_dualway.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-airport-hopper-gtfs-946.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-dublin-bus-gtfs-947.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-dublin-bus-gtfs-947.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 947,
+    "data_type": "gtfs",
+    "provider": "Dublin Bus",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.0706777792662,
+            "maximum_latitude": 53.6061962793708,
+            "minimum_longitude": -6.61486549616597,
+            "maximum_longitude": -6.05331095872249,
+            "extracted_on": "2022-03-17T18:51:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_dublinbus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-dublin-bus-gtfs-947.zip?alt=media",
+        "license": "https://data.gov.ie/licence"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-dublin-bus-nitelink-gtfs-970.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-dublin-bus-nitelink-gtfs-970.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 970,
+    "data_type": "gtfs",
+    "provider": "Dublin Bus Nitelink",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.1288008733297,
+            "maximum_latitude": 53.6061235042063,
+            "minimum_longitude": -6.50107776361442,
+            "maximum_longitude": -6.05479868457993,
+            "extracted_on": "2022-03-17T18:53:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_nitelink.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-dublin-bus-nitelink-gtfs-970.zip?alt=media",
+        "license": "https://data.gov.ie/licence"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-express-bus-gtfs-948.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-express-bus-gtfs-948.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 948,
+    "data_type": "gtfs",
+    "provider": "Express Bus",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.32695728198,
+            "maximum_latitude": 53.4290389183803,
+            "minimum_longitude": -6.41942316227849,
+            "maximum_longitude": -6.24104561004998,
+            "extracted_on": "2022-03-17T18:51:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_expressbus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-express-bus-gtfs-948.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-go-ahead-ireland-gtfs-953.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-go-ahead-ireland-gtfs-953.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 953,
+    "data_type": "gtfs",
+    "provider": "Go Ahead Ireland",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 52.9914608999955,
+            "maximum_latitude": 53.6061962793708,
+            "minimum_longitude": -7.4881039990534,
+            "maximum_longitude": -6.06077172768607,
+            "extracted_on": "2022-03-17T18:52:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_goahead.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-go-ahead-ireland-gtfs-953.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-kearns-transport-gtfs-958.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-kearns-transport-gtfs-958.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 958,
+    "data_type": "gtfs",
+    "provider": "Kearns Transport",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.0916852457123,
+            "maximum_latitude": 53.4546320083705,
+            "minimum_longitude": -9.08556987440759,
+            "maximum_longitude": -6.21781200815433,
+            "extracted_on": "2022-03-17T18:52:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_kearns.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-kearns-transport-gtfs-958.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-luas-gtfs-961.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-luas-gtfs-961.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 961,
+    "data_type": "gtfs",
+    "provider": "Luas",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.2420514158783,
+            "maximum_latitude": 53.3722378096588,
+            "minimum_longitude": -6.43776755755447,
+            "maximum_longitude": -6.14283520678566,
+            "extracted_on": "2022-03-17T18:53:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_luas.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-luas-gtfs-961.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-mortons-coaches-gtfs-969.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-mortons-coaches-gtfs-969.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 969,
+    "data_type": "gtfs",
+    "provider": "Morton's Coaches",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.3456456323913,
+            "maximum_latitude": 53.3505207924011,
+            "minimum_longitude": -6.29430817848441,
+            "maximum_longitude": -6.19561865504754,
+            "extracted_on": "2022-03-17T18:53:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_mortons.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-mortons-coaches-gtfs-969.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-pj-martley-gtfs-971.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-pj-martley-gtfs-971.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 971,
+    "data_type": "gtfs",
+    "provider": "PJ Martley",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.0329101330143,
+            "maximum_latitude": 53.347888338898,
+            "minimum_longitude": -7.32688452037354,
+            "maximum_longitude": -6.2135835670217,
+            "extracted_on": "2022-03-17T18:53:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_pjmartley.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-pj-martley-gtfs-971.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-swords-express-gtfs-975.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-swords-express-gtfs-975.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 975,
+    "data_type": "gtfs",
+    "provider": "Swords Express",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 53.3390907478423,
+            "maximum_latitude": 53.471172402602,
+            "minimum_longitude": -6.25832951343416,
+            "maximum_longitude": -6.20442181305556,
+            "extracted_on": "2022-03-17T18:54:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_swordsexpress.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-swords-express-gtfs-975.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-dublin-wexford-bus-gtfs-977.json
+++ b/catalogs/sources/gtfs/schedule/ie-dublin-wexford-bus-gtfs-977.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 977,
+    "data_type": "gtfs",
+    "provider": "Wexford Bus",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Dublin",
+        "municipality": "Dublin",
+        "bounding_box": {
+            "minimum_latitude": 52.1728366888382,
+            "maximum_latitude": 53.4290389183803,
+            "minimum_longitude": -7.17302647886266,
+            "maximum_longitude": -6.04707041486504,
+            "extracted_on": "2022-03-17T18:54:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_wexfordbus.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-dublin-wexford-bus-gtfs-977.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-galway-burkesbus-gtfs-940.json
+++ b/catalogs/sources/gtfs/schedule/ie-galway-burkesbus-gtfs-940.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 940,
+    "data_type": "gtfs",
+    "provider": "Burkesbus",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Galway",
+        "bounding_box": {
+            "minimum_latitude": 53.2743070673253,
+            "maximum_latitude": 53.6238977830951,
+            "minimum_longitude": -9.22194264128034,
+            "maximum_longitude": -8.74367591321727,
+            "extracted_on": "2022-03-17T18:50:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_burkes.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-galway-burkesbus-gtfs-940.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-galway-city-direct-gtfs-942.json
+++ b/catalogs/sources/gtfs/schedule/ie-galway-city-direct-gtfs-942.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 942,
+    "data_type": "gtfs",
+    "provider": "City Direct",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Galway",
+        "bounding_box": {
+            "minimum_latitude": 52.636104016225,
+            "maximum_latitude": 53.2787146901614,
+            "minimum_longitude": -9.14904035848576,
+            "maximum_longitude": -7.21457767574752,
+            "extracted_on": "2022-03-17T18:50:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_citydirect.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-galway-city-direct-gtfs-942.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-galway-farragher-international-travel-services-gtfs-949.json
+++ b/catalogs/sources/gtfs/schedule/ie-galway-farragher-international-travel-services-gtfs-949.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 949,
+    "data_type": "gtfs",
+    "provider": "Farragher International Travel Services",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Galway",
+        "municipality": "Galway",
+        "bounding_box": {
+            "minimum_latitude": 53.2594074006315,
+            "maximum_latitude": 53.6542840811682,
+            "minimum_longitude": -9.07432411216613,
+            "maximum_longitude": -8.55390063525592,
+            "extracted_on": "2022-03-17T18:51:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_farragher.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-galway-farragher-international-travel-services-gtfs-949.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-kerry-tralee-peoples-bus-service-gtfs-976.json
+++ b/catalogs/sources/gtfs/schedule/ie-kerry-tralee-peoples-bus-service-gtfs-976.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 976,
+    "data_type": "gtfs",
+    "provider": "Tralee People's Bus Service",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Kerry",
+        "municipality": "Tralee",
+        "bounding_box": {
+            "minimum_latitude": 52.2539089262081,
+            "maximum_latitude": 52.2851657438809,
+            "minimum_longitude": -9.7378097240467,
+            "maximum_longitude": -9.67499074443952,
+            "extracted_on": "2022-03-17T18:54:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_tralee.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-kerry-tralee-peoples-bus-service-gtfs-976.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-kilkenny-buggys-coaches-gtfs-939.json
+++ b/catalogs/sources/gtfs/schedule/ie-kilkenny-buggys-coaches-gtfs-939.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 939,
+    "data_type": "gtfs",
+    "provider": "Buggys Coaches",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Kilkenny",
+        "municipality": "Kilkenny",
+        "bounding_box": {
+            "minimum_latitude": 52.6385046915703,
+            "maximum_latitude": 52.8021109492409,
+            "minimum_longitude": -7.33430891583251,
+            "maximum_longitude": -7.21009711420439,
+            "extracted_on": "2022-03-17T18:49:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_buggy.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-kilkenny-buggys-coaches-gtfs-939.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-kilkenny-jj-kavanagh-sons-gtfs-956.json
+++ b/catalogs/sources/gtfs/schedule/ie-kilkenny-jj-kavanagh-sons-gtfs-956.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 956,
+    "data_type": "gtfs",
+    "provider": "J.J Kavanagh & Sons",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Kilkenny",
+        "municipality": "Kilkenny",
+        "bounding_box": {
+            "minimum_latitude": 52.6385046915703,
+            "maximum_latitude": 53.4290389183803,
+            "minimum_longitude": -7.34806544534402,
+            "maximum_longitude": -6.24104561004998,
+            "extracted_on": "2022-03-17T18:52:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_jjkavanagh.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-kilkenny-jj-kavanagh-sons-gtfs-956.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-kilkenny-michael-kilbride-gtfs-968.json
+++ b/catalogs/sources/gtfs/schedule/ie-kilkenny-michael-kilbride-gtfs-968.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 968,
+    "data_type": "gtfs",
+    "provider": "Michael Kilbride",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Kilkenny",
+        "municipality": "Kilkenny",
+        "bounding_box": {
+            "minimum_latitude": 52.3943416109005,
+            "maximum_latitude": 52.6544606730028,
+            "minimum_longitude": -7.25204928162085,
+            "maximum_longitude": -6.92398459557208,
+            "extracted_on": "2022-03-17T18:53:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_mkilbride.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-kilkenny-michael-kilbride-gtfs-968.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-kilkenny-suirway-gtfs-974.json
+++ b/catalogs/sources/gtfs/schedule/ie-kilkenny-suirway-gtfs-974.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 974,
+    "data_type": "gtfs",
+    "provider": "Suirway",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Kilkenny",
+        "municipality": "Waterford",
+        "bounding_box": {
+            "minimum_latitude": 52.1453282602916,
+            "maximum_latitude": 52.2921665796918,
+            "minimum_longitude": -7.31870647083098,
+            "maximum_longitude": -6.97228574661138,
+            "extracted_on": "2022-03-17T18:54:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_suirway.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-kilkenny-suirway-gtfs-974.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-limerick-catherine-madigan-gtfs-944.json
+++ b/catalogs/sources/gtfs/schedule/ie-limerick-catherine-madigan-gtfs-944.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 944,
+    "data_type": "gtfs",
+    "provider": "Catherine Madigan",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Limerick",
+        "municipality": "Limerick",
+        "bounding_box": {
+            "minimum_latitude": 52.4215188000856,
+            "maximum_latitude": 52.569253000558,
+            "minimum_longitude": -9.15506531226756,
+            "maximum_longitude": -8.90705383466746,
+            "extracted_on": "2022-03-17T18:51:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_cmadigan.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-limerick-catherine-madigan-gtfs-944.zip?alt=media",
+        "license": "https://data.gov.ie/licence"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-limerick-joseph-foley-gtfs-957.json
+++ b/catalogs/sources/gtfs/schedule/ie-limerick-joseph-foley-gtfs-957.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 957,
+    "data_type": "gtfs",
+    "provider": "Joseph Foley",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Limerick",
+        "bounding_box": {
+            "minimum_latitude": 52.3507188998702,
+            "maximum_latitude": 52.458045511682,
+            "minimum_longitude": -8.68270490263191,
+            "maximum_longitude": -8.52752676735609,
+            "extracted_on": "2022-03-17T18:52:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_josfoley.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-limerick-joseph-foley-gtfs-957.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-louth-halpenny-transport-gtfs-954.json
+++ b/catalogs/sources/gtfs/schedule/ie-louth-halpenny-transport-gtfs-954.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 954,
+    "data_type": "gtfs",
+    "provider": "Halpenny Transport",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Louth",
+        "municipality": "Dundalk",
+        "bounding_box": {
+            "minimum_latitude": 53.9638021303039,
+            "maximum_latitude": 54.0069937600197,
+            "minimum_longitude": -6.42618734675643,
+            "maximum_longitude": -6.36557298397909,
+            "extracted_on": "2022-03-17T18:52:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_halpenny.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-louth-halpenny-transport-gtfs-954.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-mayo-local-link-mayo-gtfs-960.json
+++ b/catalogs/sources/gtfs/schedule/ie-mayo-local-link-mayo-gtfs-960.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 960,
+    "data_type": "gtfs",
+    "provider": "Local Link Mayo",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Mayo",
+        "bounding_box": {
+            "minimum_latitude": 51.6044879359929,
+            "maximum_latitude": 55.3798801892074,
+            "minimum_longitude": -10.4534592218867,
+            "maximum_longitude": -6.03669632249174,
+            "extracted_on": "2022-03-17T18:53:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_locallink.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-mayo-local-link-mayo-gtfs-960.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-mayo-mcgrath-coaches-gtfs-966.json
+++ b/catalogs/sources/gtfs/schedule/ie-mayo-mcgrath-coaches-gtfs-966.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 966,
+    "data_type": "gtfs",
+    "provider": "McGrath Coaches",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Mayo",
+        "bounding_box": {
+            "minimum_latitude": 53.8541053154823,
+            "maximum_latitude": 54.3312669177582,
+            "minimum_longitude": -9.97175001404824,
+            "maximum_longitude": -9.15357021535132,
+            "extracted_on": "2022-03-17T18:53:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_mcgrath.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-mayo-mcgrath-coaches-gtfs-966.zip?alt=media",
+        "license": "https://data.gov.ie/licence"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-bus-eireann-gtfs-941.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-bus-eireann-gtfs-941.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 941,
+    "data_type": "gtfs",
+    "provider": "Bus Éireann",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 51.4826084796849,
+            "maximum_latitude": 55.0044762847017,
+            "minimum_longitude": -10.2719935744817,
+            "maximum_longitude": -6.03669632249174,
+            "extracted_on": "2022-03-17T18:50:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_buseireann.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-bus-eireann-gtfs-941.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-bus-feda-teoranta-gtfs-950.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-bus-feda-teoranta-gtfs-950.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 950,
+    "data_type": "gtfs",
+    "provider": "Bus Feda Teoranta",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 53.2736007915826,
+            "maximum_latitude": 55.2512801001395,
+            "minimum_longitude": -9.07045731403827,
+            "maximum_longitude": -7.26146771794948,
+            "extracted_on": "2022-03-17T18:51:48+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_fedateoranta.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-bus-feda-teoranta-gtfs-950.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-citylink-gtfs-943.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-citylink-gtfs-943.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 943,
+    "data_type": "gtfs",
+    "provider": "Citylink",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 51.8489757069344,
+            "maximum_latitude": 53.5564907728219,
+            "minimum_longitude": -10.1119327202063,
+            "maximum_longitude": -6.24168630800514,
+            "extracted_on": "2022-03-17T18:51:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_citylink.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-citylink-gtfs-943.zip?alt=media",
+        "license": "https://data.gov.ie/licence"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-collins-coaches-gtfs-945.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-collins-coaches-gtfs-945.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 945,
+    "data_type": "gtfs",
+    "provider": "Collins Coaches",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 53.3426061451661,
+            "maximum_latitude": 53.9905991867939,
+            "minimum_longitude": -6.71903646812129,
+            "maximum_longitude": -6.22686447149742,
+            "extracted_on": "2022-03-17T18:51:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_collins.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-collins-coaches-gtfs-945.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-doyle-shipping-group-gtfs-951.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-doyle-shipping-group-gtfs-951.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 951,
+    "data_type": "gtfs",
+    "provider": "Doyle Shipping Group",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 51.4769677464466,
+            "maximum_latitude": 55.2628260491634,
+            "minimum_longitude": -10.2122046529085,
+            "maximum_longitude": -5.55041816798297,
+            "extracted_on": "2022-03-17T18:51:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_ferries.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-doyle-shipping-group-gtfs-951.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-finnegan-bray-ltd-gtfs-952.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-finnegan-bray-ltd-gtfs-952.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 952,
+    "data_type": "gtfs",
+    "provider": "Finnegan-Bray Ltd",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 53.0807694770795,
+            "maximum_latitude": 53.3491854981702,
+            "minimum_longitude": -6.25982192079981,
+            "maximum_longitude": -6.06105065068814,
+            "extracted_on": "2022-03-17T18:51:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_finnegans.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-finnegan-bray-ltd-gtfs-952.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-irish-rail-gtfs-955.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-irish-rail-gtfs-955.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 955,
+    "data_type": "gtfs",
+    "provider": "Irish Rail",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 51.8488986544995,
+            "maximum_latitude": 54.5955296727986,
+            "minimum_longitude": -9.6988711196451,
+            "maximum_longitude": -5.91733062030943,
+            "extracted_on": "2022-03-17T18:52:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_irishrail.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-irish-rail-gtfs-955.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-jjbernard-kavanagh-gtfs-938.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-jjbernard-kavanagh-gtfs-938.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 938,
+    "data_type": "gtfs",
+    "provider": "JJ/Bernard Kavanagh",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 52.3542494811836,
+            "maximum_latitude": 53.3481432679383,
+            "minimum_longitude": -8.19894432308927,
+            "maximum_longitude": -6.25331643588362,
+            "extracted_on": "2022-03-17T18:49:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_bkavanagh.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-jjbernard-kavanagh-gtfs-938.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-kenneallys-bus-service-gtfs-959.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-kenneallys-bus-service-gtfs-959.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 959,
+    "data_type": "gtfs",
+    "provider": "Kenneally's Bus Service",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 52.1622535776184,
+            "maximum_latitude": 53.4290389183803,
+            "minimum_longitude": -8.64941337529017,
+            "maximum_longitude": -6.2289291585258,
+            "extracted_on": "2022-03-17T18:53:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_kenneallys.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-kenneallys-bus-service-gtfs-959.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-matthews-coach-hire-gtfs-963.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-matthews-coach-hire-gtfs-963.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 963,
+    "data_type": "gtfs",
+    "provider": "Matthews Coach Hire",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 53.3052114068601,
+            "maximum_latitude": 54.0012223109462,
+            "minimum_longitude": -6.40043403605937,
+            "maximum_longitude": -6.21668053124508,
+            "extracted_on": "2022-03-17T18:53:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_matthews.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-matthews-coach-hire-gtfs-963.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-unknown-slieve-bloom-coach-tours-gtfs-972.json
+++ b/catalogs/sources/gtfs/schedule/ie-unknown-slieve-bloom-coach-tours-gtfs-972.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 972,
+    "data_type": "gtfs",
+    "provider": "Slieve Bloom Coach Tours",
+    "location": {
+        "country_code": "IE",
+        "bounding_box": {
+            "minimum_latitude": 52.6529685210019,
+            "maximum_latitude": 53.5350084719684,
+            "minimum_longitude": -7.72739432027064,
+            "maximum_longitude": -7.10808822303544,
+            "extracted_on": "2022-03-17T18:53:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_sbloom.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-unknown-slieve-bloom-coach-tours-gtfs-972.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ie-wexford-michael-gray-coach-hire-gtfs-967.json
+++ b/catalogs/sources/gtfs/schedule/ie-wexford-michael-gray-coach-hire-gtfs-967.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 967,
+    "data_type": "gtfs",
+    "provider": "Michael Gray Coach Hire",
+    "location": {
+        "country_code": "IE",
+        "subdivision_name": "Wexford",
+        "bounding_box": {
+            "minimum_latitude": 52.3255001293318,
+            "maximum_latitude": 52.5140111366602,
+            "minimum_longitude": -6.49455439314659,
+            "maximum_longitude": -6.28324030116455,
+            "extracted_on": "2022-03-17T18:53:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transportforireland.ie/transitData/google_transit_mgray.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-wexford-michael-gray-coach-hire-gtfs-967.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-atp-nuoro-gtfs-991.json
+++ b/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-atp-nuoro-gtfs-991.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 991,
+    "data_type": "gtfs",
+    "provider": "ATP Nuoro",
+    "name": "Quadri orari ATP Nuoro",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Regione Autonoma della Sardegna",
+        "bounding_box": {
+            "minimum_latitude": 40.3073487,
+            "maximum_latitude": 40.370735,
+            "minimum_longitude": 9.2593768,
+            "maximum_longitude": 9.386304,
+            "extracted_on": "2022-03-17T18:57:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.atpnuoro.it/media/files/dati_atpnu.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-regione-autonoma-della-sardegna-atp-nuoro-gtfs-991.zip?alt=media",
+        "license": "https://creativecommons.org/licenses/by/4.0/deed.it"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-sicilia-amat-palermo-spa-gtfs-989.json
+++ b/catalogs/sources/gtfs/schedule/it-sicilia-amat-palermo-spa-gtfs-989.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 989,
+    "data_type": "gtfs",
+    "provider": "AMAT Palermo S.P.A.",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Sicilia",
+        "municipality": "Palermo",
+        "bounding_box": {
+            "minimum_latitude": 38.0507730433,
+            "maximum_latitude": 38.21045333,
+            "minimum_longitude": 13.25067982,
+            "maximum_longitude": 13.44867,
+            "extracted_on": "2022-03-17T18:57:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.comune.palermo.it/gtfs/amat_feed_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-sicilia-amat-palermo-spa-gtfs-989.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-trentino-alto-adige-trentino-trasporti-spa-tt-gtfs-978.json
+++ b/catalogs/sources/gtfs/schedule/it-trentino-alto-adige-trentino-trasporti-spa-tt-gtfs-978.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 978,
+    "data_type": "gtfs",
+    "provider": "Trentino Trasporti SpA (TT)",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Trentino-Alto Adige",
+        "bounding_box": {
+            "minimum_latitude": 45.836852,
+            "maximum_latitude": 46.177651,
+            "minimum_longitude": 10.95153,
+            "maximum_longitude": 11.184697,
+            "extracted_on": "2022-03-17T18:54:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.trentinotrasporti.it/opendata/google_transit_urbano_tte.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-trentino-alto-adige-trentino-trasporti-spa-tt-gtfs-978.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-gunma-nagai-transport-gtfs-984.json
+++ b/catalogs/sources/gtfs/schedule/jp-gunma-nagai-transport-gtfs-984.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 984,
+    "data_type": "gtfs",
+    "provider": "永井運輸株式会社 (Nagai Transport)",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Gunma",
+        "municipality": "Maebashi",
+        "bounding_box": {
+            "minimum_latitude": 36.370488,
+            "maximum_latitude": 36.387287,
+            "minimum_longitude": 139.107665,
+            "maximum_longitude": 139.119483,
+            "extracted_on": "2022-03-17T18:55:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nagai-unyu.net/rosen/GTFS/nagai/GTFS-JP_nagaibus-gunma-jp.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-gunma-nagai-transport-gtfs-984.zip?alt=media",
+        "license": "https://www.nagai-unyu.net/open-data/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/lv-riga-valsts-sia-autotransporta-direkcija-atd-gtfs-992.json
+++ b/catalogs/sources/gtfs/schedule/lv-riga-valsts-sia-autotransporta-direkcija-atd-gtfs-992.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 992,
+    "data_type": "gtfs",
+    "provider": "Valsts SIA Autotransporta Direkcija (ATD)",
+    "location": {
+        "country_code": "LV",
+        "subdivision_name": "Rīga",
+        "bounding_box": {
+            "minimum_latitude": 55.6756659,
+            "maximum_latitude": 58.0485012,
+            "minimum_longitude": 20.9879606,
+            "maximum_longitude": 28.1816125,
+            "extracted_on": "2022-03-17T18:59:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.atd.lv/sites/default/files/GTFS/gtfs-latvia-lv.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/lv-riga-valsts-sia-autotransporta-direkcija-atd-gtfs-992.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/nz-otago-otago-regional-council-orc-gtfs-983.json
+++ b/catalogs/sources/gtfs/schedule/nz-otago-otago-regional-council-orc-gtfs-983.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 983,
+    "data_type": "gtfs",
+    "provider": "Otago Regional Council (ORC)",
+    "location": {
+        "country_code": "NZ",
+        "subdivision_name": "Otago",
+        "bounding_box": {
+            "minimum_latitude": -45.9503128,
+            "maximum_latitude": -44.93829,
+            "minimum_longitude": 168.625274,
+            "maximum_longitude": 170.7265822,
+            "extracted_on": "2022-03-17T18:55:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.orc.govt.nz/transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nz-otago-otago-regional-council-orc-gtfs-983.zip?alt=media",
+        "license": "https://creativecommons.org/licenses/by/4.0/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-mpk-wroclaw-gtfs-980.json
+++ b/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-mpk-wroclaw-gtfs-980.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 980,
+    "data_type": "gtfs",
+    "provider": "MPK Wrocław",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Dolnoslaskie",
+        "municipality": "Wroclaw",
+        "bounding_box": {
+            "minimum_latitude": 50.97974058,
+            "maximum_latitude": 51.265518,
+            "minimum_longitude": 16.695853,
+            "maximum_longitude": 17.2855453,
+            "extracted_on": "2022-03-17T18:54:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.wroclaw.pl/open-data/87b09b32-f076-4475-8ec9-6020ed1f9ac0/OtwartyWroclaw_rozklad_jazdy_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-dolnoslaskie-mpk-wroclaw-gtfs-980.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-sevibusdla-dlugoleka-gtfs-979.json
+++ b/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-sevibusdla-dlugoleka-gtfs-979.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 979,
+    "data_type": "gtfs",
+    "provider": "Sevibus/DLA Długołęka",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Dolnośląskie",
+        "bounding_box": {
+            "minimum_latitude": 50.997837,
+            "maximum_latitude": 51.26444116,
+            "minimum_longitude": 16.7834535,
+            "maximum_longitude": 17.2855453,
+            "extracted_on": "2022-03-17T18:54:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.wroclaw.pl/open-data/87b09b32-f076-4475-8ec9-6020ed1f9ac0/1513602900.0_OtwartyWroclaw_rozklad_jazdy_GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-dolnoslaskie-sevibusdla-dlugoleka-gtfs-979.zip?alt=media",
+        "license": "http://www.wroclaw.pl/open-data/index.php/warunki-korzystania"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-wielkopolskie-zarzad-transportu-miejskiego-poznan-ztm-poznan-gtfs-982.json
+++ b/catalogs/sources/gtfs/schedule/pl-wielkopolskie-zarzad-transportu-miejskiego-poznan-ztm-poznan-gtfs-982.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 982,
+    "data_type": "gtfs",
+    "provider": "Zarząd Transportu Miejskiego Poznań (ZTM Poznań)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Wielkopolskie",
+        "municipality": "Poznań",
+        "bounding_box": {
+            "minimum_latitude": 52.15166197,
+            "maximum_latitude": 52.58722581,
+            "minimum_longitude": 16.481194,
+            "maximum_longitude": 17.2769318451,
+            "extracted_on": "2022-03-17T18:55:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.ztm.poznan.pl/pl/dla-deweloperow/getGTFSFile",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-wielkopolskie-zarzad-transportu-miejskiego-poznan-ztm-poznan-gtfs-982.zip?alt=media",
+        "license": "https://www.ztm.poznan.pl/pl/dla-deweloperow/index"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-981.json
+++ b/catalogs/sources/gtfs/schedule/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-981.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 981,
+    "data_type": "gtfs",
+    "provider": "Zarząd Dróg i Transportu Miejskiego (ZDiTM)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Zachodniopomorskie",
+        "municipality": "Szczecin",
+        "bounding_box": {
+            "minimum_latitude": 53.28248,
+            "maximum_latitude": 53.594587,
+            "minimum_longitude": 14.309758,
+            "maximum_longitude": 14.782657,
+            "extracted_on": "2022-03-17T18:55:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.zditm.szczecin.pl/rozklady/GTFS/latest/google_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-981.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pt-setubal-sulfertagus-gtfs-934.json
+++ b/catalogs/sources/gtfs/schedule/pt-setubal-sulfertagus-gtfs-934.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 934,
+    "data_type": "gtfs",
+    "provider": "SulFertagus",
+    "location": {
+        "country_code": "PT",
+        "subdivision_name": "Setúbal",
+        "bounding_box": {
+            "minimum_latitude": 38.5191872983267,
+            "maximum_latitude": 38.6666922615115,
+            "minimum_longitude": -9.19681336866042,
+            "maximum_longitude": -9.0132153696308,
+            "extracted_on": "2022-03-17T18:49:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/21/gtfs_21.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-setubal-sulfertagus-gtfs-934.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-changhua-yl-bus-gtfs-998.json
+++ b/catalogs/sources/gtfs/schedule/tw-changhua-yl-bus-gtfs-998.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 998,
+    "data_type": "gtfs",
+    "provider": "YL_員林客運(公總) (YL-Bus)",
+    "location": {
+        "country_code": "TW",
+        "subdivision_name": "Changhua",
+        "municipality": "Yuanlin City",
+        "bounding_box": {
+            "minimum_latitude": 23.385829,
+            "maximum_latitude": 25.284729,
+            "minimum_longitude": 120.15701,
+            "maximum_longitude": 121.926085,
+            "extracted_on": "2022-03-17T19:00:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.taichung.gov.tw/bnb/api/gtfs/yl/latest",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-changhua-yl-bus-gtfs-998.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the eleventh part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 65 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~