### PR TITLE
feat: Thirteenth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/de-unknown-fluo-grand-est-67-gtfs-1075.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-fluo-grand-est-67-gtfs-1075.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1075,
+    "data_type": "gtfs",
+    "provider": "Fluo Grand Est 67, CTS, DB AG, SBB, THURBO, Breisgau-S-Bahn GmbH, NVBW, Schwarzer Reisen, BBS Mittelschwaben, Probst, Brandner UA, Stadtbus Kempten, Gairing, RBI Regionalbus Isny, RBA Kempten, RBA Lindau, NeuBus, Schwabenbus Dillingen, Schweizerische Bundesbahnen SBB, Schweiz. Schifffahrtsgesellschaft Untersee und Rhein AG, Schweizerische Bodensee-Schiffahrtsgesellschaft AG, Politische Gemeinde Steckborn, SBB GmbH (Grenzverkehr), Bodensee-Schiffsbetriebe GmbH, PostAuto AG, SNCF, Scharnagel Omnibus",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 50.0715138,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 10.7723453,
+            "extracted_on": "2022-03-17T20:37:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwsbahnubahn.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-fluo-grand-est-67-gtfs-1075.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-hofmann-omnibusverkehr-gmbh-gtfs-1082.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-hofmann-omnibusverkehr-gmbh-gtfs-1082.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1082,
+    "data_type": "gtfs",
+    "provider": "Hofmann Omnibusverkehr GmbH",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 49.3883440782054,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 10.3267091141732,
+            "extracted_on": "2022-03-17T21:17:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/kvsh.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-hofmann-omnibusverkehr-gmbh-gtfs-1082.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-ulmer-eisenbahnfreunde-gtfs-1081.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-ulmer-eisenbahnfreunde-gtfs-1081.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1081,
+    "data_type": "gtfs",
+    "provider": "Ulmer Eisenbahnfreunde, Sächsisch-Oberlausitzer Eisenbahngesellschaft, SDG Sächsische Dampfeisenbahngesellschaft mbH, SNCF, vlexx, DB AG, SBB, Nordbahn Eisenbahngesellschaft, Norddeutsche Eisenbahn Gesellschaft, AKN Eisenbahn GmbH, Ostdeutsche Eisenbahn GmbH, NEB Niederbarnimer Eisenbahn, Hanseatische Eisenbahn GmbH, City-Bahn Chemnitz, vogtlandbahn - Die Länderbahn GmbH DLB, trilex - Die Länderbahn GmbH DLB, Mitteldeutsche Regiobahn, DB Regio AG Südost, Freiberger Eisenbahngesellschaft, Arriva Danmark, Abellio Rail NRW GmbH, TRI Train Rental GmbH, National Express, DB Regio AG NRW, eurobahn, Hessische Landesbahn, NordWestBahn, Centralbahn, VIAS Rail GmbH, Rurtalbahn, SNCB, DB RegioNetz Verkehrs GmbH Kurhessenbahn, cantus Verkehrsgesellschaft, metronom, Verkehrsgesellschaft Start Unterelbe mbH, erixx, WestfalenBahn, enno, EVB ELBE-WESER GmbH, Bentheimer Eisenbahn, Abellio Rail Mitteldeutschland GmbH, Dessau-Wörlitzer Eisenbahn, Harzer Schmalspurbahn, DB Regio AG Bayern, alex - Die Länderbahn GmbH DLB, DB Regio AG Bayern, DB RegioNetz Verkehrs GmbH Südostbayernbahn, Bayerische Regiobahn, DB Regio AG Bayern, Bayerische Regiobahn, DB RegioNetz Verkehrs GmbH Südostbayernbahn, Bayerische Regiobahn, Go-Ahead Bayern GmbH, agilis, agilis-Schnellzug, oberpfalz-express - Die Länderbahn GmbH DLB, oberpfalzbahn - Die Länderbahn GmbH DLB, waldbahn - Die Länderbahn GmbH DLB, Erfurter Bahn, Österreichische Bundesbahnen, Museumsbahn, Brohltalbahn, Kasbachtalbahn, Kandertalbahn, Wutachtalbahn, Öchsle-Bahn-Betriebsgesellschaft mbH, Rhön-Zügle, Mainschleifenbahn, Ilztalbahn, Wanderbahn im Regental, Chiemgauer Lokalbahn, BayernBahn GmbH, SÜWEX, CFL, MittelrheinBahn (Trans Regio), Rhenus Veniro, Daadetalbahn, Go-Ahead Baden-Württemberg GmbH, THURBO, DB Regio AG Baden-Württemberg, Hohenzollerische Landesbahn AG, SWEG Bahn Stuttgart GmbH (ehem. Abellio BW), Südwestdeutsche Verkehrs-GmbH, Schwäbische Alb-Bahn, Bodensee-Oberschwaben-Bahn, Erfurter Bahn Express, Süd-Thüringen-Bahn, Süd-Thüringen-Bahn Express, Pressnitztalbahn, Mecklenburgische Bäderbahn Molli, Ceske Drahy, GW Train Regio",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 56.560964286994,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 17.0370883548688,
+            "extracted_on": "2022-03-17T21:16:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwspnv.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-ulmer-eisenbahnfreunde-gtfs-1081.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/fahrplandaten/fahrplandaten-mit-liniennetz"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-unknown-consorci-de-transports-de-mallorca-gtfs-1079.json
+++ b/catalogs/sources/gtfs/schedule/es-unknown-consorci-de-transports-de-mallorca-gtfs-1079.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1079,
+    "data_type": "gtfs",
+    "provider": "CONSORCI DE TRANSPORTS DE MALLORCA, Sagalés-Caldentey, Grupo Ruiz, Moventis, CTM R4, SFM R4, AJUNTAMENT DE CALVIA R4, EMT, AJUNTAMENT DE BUNYOLA R4",
+    "location": {
+        "country_code": "ES",
+        "bounding_box": {
+            "minimum_latitude": 39.31685,
+            "maximum_latitude": 39.920567,
+            "minimum_longitude": 2.35004,
+            "maximum_longitude": 3.459087,
+            "extracted_on": "2022-03-17T20:41:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.tib.org/documents/30683/96569/ctm-mallorca-es.zip/3d94d08e-b214-62d2-7b8c-ef3bebb9a8c0",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-unknown-consorci-de-transports-de-mallorca-gtfs-1079.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-unknown-renfe-cercanias-gtfs-1065.json
+++ b/catalogs/sources/gtfs/schedule/es-unknown-renfe-cercanias-gtfs-1065.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1065,
+    "data_type": "gtfs",
+    "provider": "Renfe Cercanias",
+    "name": "Horarios cercanías — los trenes Cercanías y Rodalies",
+    "location": {
+        "country_code": "ES",
+        "bounding_box": {
+            "minimum_latitude": 36.4680361,
+            "maximum_latitude": 43.58952,
+            "minimum_longitude": -6.2882055,
+            "maximum_longitude": 3.163259,
+            "extracted_on": "2022-03-17T20:33:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.renfe.com/dataset/77525d66-f095-46d0-80c0-37f735d4342f/resource/6f1523c6-a9e3-48e3-9ace-bb107a762be6/download/fomento_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-unknown-renfe-cercanias-gtfs-1065.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-unknown-renfe-feve-gtfs-1064.json
+++ b/catalogs/sources/gtfs/schedule/es-unknown-renfe-feve-gtfs-1064.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1064,
+    "data_type": "gtfs",
+    "provider": "Renfe Feve",
+    "location": {
+        "country_code": "ES",
+        "bounding_box": {
+            "minimum_latitude": 37.60330436302621,
+            "maximum_latitude": 43.73562573974169,
+            "minimum_longitude": -8.23155,
+            "maximum_longitude": -0.7879010031274469,
+            "extracted_on": "2022-03-17T20:31:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.renfe.com/dataset/5f80afa2-798c-46a4-8f96-bca0835b3cf0/resource/e593b825-78c2-45e1-a8ca-9fbea2f3faff/download/horarios-feve.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-unknown-renfe-feve-gtfs-1064.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-ile-de-france-transilien-sncf-gtfs-1069.json
+++ b/catalogs/sources/gtfs/schedule/fr-ile-de-france-transilien-sncf-gtfs-1069.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1069,
+    "data_type": "gtfs",
+    "provider": "Transilien SNCF",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Île-de-France",
+        "municipality": "Paris",
+        "bounding_box": {
+            "minimum_latitude": 48.00718,
+            "maximum_latitude": 49.285257,
+            "minimum_longitude": 1.370633,
+            "maximum_longitude": 3.409411,
+            "extracted_on": "2022-03-17T20:34:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://files.transilien.com/horaires/gtfs/export-TN-GTFS-LAST.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-ile-de-france-transilien-sncf-gtfs-1069.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hu-miskolc-miskolc-varosi-kozlekedesi-mvk-gtfs-1070.json
+++ b/catalogs/sources/gtfs/schedule/hu-miskolc-miskolc-varosi-kozlekedesi-mvk-gtfs-1070.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1070,
+    "data_type": "gtfs",
+    "provider": "Miskolc Városi Közlekedési (MVK)",
+    "location": {
+        "country_code": "HU",
+        "subdivision_name": "Miskolc",
+        "bounding_box": {
+            "minimum_latitude": 48.051575,
+            "maximum_latitude": 48.147408,
+            "minimum_longitude": 20.532918,
+            "maximum_longitude": 20.870524,
+            "extracted_on": "2022-03-17T20:34:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.cdata.hu/mvkzrt.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-miskolc-miskolc-varosi-kozlekedesi-mvk-gtfs-1070.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-lazio-roma-servizi-per-la-mobilita-gtfs-1067.json
+++ b/catalogs/sources/gtfs/schedule/it-lazio-roma-servizi-per-la-mobilita-gtfs-1067.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1067,
+    "data_type": "gtfs",
+    "provider": "Roma Servizi per la Mobilità",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Lazio",
+        "municipality": "Rome",
+        "bounding_box": {
+            "minimum_latitude": 40.852553304742,
+            "maximum_latitude": 43.777784212852,
+            "minimum_longitude": 10.336598623954,
+            "maximum_longitude": 14.770187216088,
+            "extracted_on": "2022-03-17T20:34:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://dati.muovi.roma.it/gtfs/rome_static_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lazio-roma-servizi-per-la-mobilita-gtfs-1067.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-puglia-societa-gestione-multipla-sgm-gtfs-1066.json
+++ b/catalogs/sources/gtfs/schedule/it-puglia-societa-gestione-multipla-sgm-gtfs-1066.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1066,
+    "data_type": "gtfs",
+    "provider": "Società Gestione Multipla (SGM)",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Puglia",
+        "municipality": "Lecce",
+        "bounding_box": {
+            "minimum_latitude": 18.175635,
+            "maximum_latitude": 40.480286,
+            "minimum_longitude": 18.070104,
+            "maximum_longitude": 40.356124,
+            "extracted_on": "2022-03-17T20:33:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://dati.comune.lecce.it/trasporti/gtfs/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-puglia-societa-gestione-multipla-sgm-gtfs-1066.zip?alt=media",
+        "license": "http://creativecommons.org/licenses/by/4.0/deed.it"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-unknown-toremar-toscana-regionale-marittima-gtfs-1068.json
+++ b/catalogs/sources/gtfs/schedule/it-unknown-toremar-toscana-regionale-marittima-gtfs-1068.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1068,
+    "data_type": "gtfs",
+    "provider": "Toremar Toscana Regionale Marittima",
+    "location": {
+        "country_code": "IT",
+        "bounding_box": {
+            "minimum_latitude": 42.2552882589984,
+            "maximum_latitude": 43.5533366636245,
+            "minimum_longitude": 9.83561862429208,
+            "maximum_longitude": 11.1222628089307,
+            "extracted_on": "2022-03-17T20:34:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://dati.toscana.it/dataset/8bb8f8fe-fe7d-41d0-90dc-49f2456180d1/resource/56539a5a-e0be-49eb-b3ac-052a42ad0de0/download/toremar.gtfs",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-unknown-toremar-toscana-regionale-marittima-gtfs-1068.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/nl-unknown-allgo-keolis-gtfs-1077.json
+++ b/catalogs/sources/gtfs/schedule/nl-unknown-allgo-keolis-gtfs-1077.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1077,
+    "data_type": "gtfs",
+    "provider": "allGo (Keolis), Arriva, Blue Amigo, Bravo (Arriva), Bravo (Hermes), Breng, Connexxion, De Lijn, EBS, Westerschelde Ferry, GVB, HTM, Blauwnet, Breng, DB, Eurobahn, NMBS, Arriva, NS, NS International, R-net, Valleilijn, VIAS, Keolis, NIAG, Overal (Connexxion), OV Regio IJsselmond, Qbuzz, RET, Syntus Utrecht, Texelhopper, Transdev, Twents (Keolis), U-OV",
+    "name": "Aggregate",
+    "location": {
+        "country_code": "NL",
+        "bounding_box": {
+            "minimum_latitude": 43.3033199718,
+            "maximum_latitude": 55.67276,
+            "minimum_longitude": -0.1264966,
+            "maximum_longitude": 21.05204,
+            "extracted_on": "2022-03-17T20:39:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.ovapi.nl/gtfs-nl.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nl-unknown-allgo-keolis-gtfs-1077.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/no-unknown-agder-kollektivtrafikk-as-gtfs-1078.json
+++ b/catalogs/sources/gtfs/schedule/no-unknown-agder-kollektivtrafikk-as-gtfs-1078.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1078,
+    "data_type": "gtfs",
+    "provider": "Agder Kollektivtrafikk AS, AtB, Avinor, Boreal Norge AS, Brakar, Bussring, Snelandia, Flåmsbana, FlixBus, Flytoget, Vy, Go-Ahead Nordic, Go Fjords, Havila, Hurtigruten, Gjendebåten AS, Innlandstrafikk, Skibladner, Boreal Norge AS, Norled AS, Boreal Sjø AS, Fjord1 ASA, Kolumbus, AMBU Pendlerrute, The Fjords, Geiranger Fjordservice, Gripruta, FRAM, Sundbåten, Flybussen Norgesbuss, Norsk Industriarbeidermuseum, Nordland fylkeskommune, Vy, NOR-WAY Bussekspress AS, Bygdøyfergen, Oscarsborgfergen, Østfold kollektivtrafikk, Ruter, SJ NORD, SJ AB, Skyss, Kringom, Norled, Lustrabaatane, Farte, Tide AS, Troms fylkestrafikk, Torghatten, Ulriken, Unibuss, VKT, Vy Travel, Vy, Vy Buss",
+    "name": "Norway Aggregated",
+    "location": {
+        "country_code": "NO",
+        "bounding_box": {
+            "minimum_latitude": 53.55194,
+            "maximum_latitude": 78.246751,
+            "minimum_longitude": 4.51278,
+            "maximum_longitude": 31.111965,
+            "extracted_on": "2022-03-17T20:41:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://storage.googleapis.com/marduk-production/outbound/gtfs/rb_norway-aggregated-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/no-unknown-agder-kollektivtrafikk-as-gtfs-1078.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/nz-bay-of-plenty-baybus-gtfs-1071.json
+++ b/catalogs/sources/gtfs/schedule/nz-bay-of-plenty-baybus-gtfs-1071.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1071,
+    "data_type": "gtfs",
+    "provider": "BayBus",
+    "location": {
+        "country_code": "NZ",
+        "subdivision_name": "Bay of Plenty",
+        "bounding_box": {
+            "minimum_latitude": -38.6393150613996,
+            "maximum_latitude": -37.3898234,
+            "minimum_longitude": 175.839138805048,
+            "maximum_longitude": 178.14268788955,
+            "extracted_on": "2022-03-17T20:34:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.dynamis.live/boprc/prod/boprc-nz.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nz-bay-of-plenty-baybus-gtfs-1071.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-malopolskie-wielicka-komunikacja-wewnatrzgminna-gtfs-1072.json
+++ b/catalogs/sources/gtfs/schedule/pl-malopolskie-wielicka-komunikacja-wewnatrzgminna-gtfs-1072.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1072,
+    "data_type": "gtfs",
+    "provider": "Wielicka Komunikacja Wewnątrzgminna",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Malopolskie",
+        "municipality": "Wieliczka",
+        "bounding_box": {
+            "minimum_latitude": 49.934878,
+            "maximum_latitude": 50.0149,
+            "minimum_longitude": 19.99935,
+            "maximum_longitude": 20.1152,
+            "extracted_on": "2022-03-17T20:34:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.pyrfekt.com/feeds/wieliczka_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-malopolskie-wielicka-komunikacja-wewnatrzgminna-gtfs-1072.zip?alt=media",
+        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/sg-unknown-smrt-gtfs-1076.json
+++ b/catalogs/sources/gtfs/schedule/sg-unknown-smrt-gtfs-1076.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1076,
+    "data_type": "gtfs",
+    "provider": "SMRT, SBS Transit (SBST), Land Transport Authority (LTA), Go Ahead Singapore (GAS), Tower Transit (TTS)",
+    "location": {
+        "country_code": "SG",
+        "bounding_box": {
+            "minimum_latitude": 1.251427,
+            "maximum_latitude": 1.49390379286364,
+            "minimum_longitude": 103.61725,
+            "maximum_longitude": 104.0155981,
+            "extracted_on": "2022-03-17T20:37:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://cdn.rushowl.app/rushtrail-app/gtfs-feed/gtfs-feed-lta.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/sg-unknown-smrt-gtfs-1076.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-changhua-total-passenger-common-total-gtfs-1074.json
+++ b/catalogs/sources/gtfs/schedule/tw-changhua-total-passenger-common-total-gtfs-1074.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1074,
+    "data_type": "gtfs",
+    "provider": "Total passenger (common total), NT_南投客運(公總) (Nantou Passenger Transport (Public Service)), NT_全航客運(公總) (All-air passenger (common total))",
+    "location": {
+        "country_code": "TW",
+        "subdivision_name": "Changhua",
+        "bounding_box": {
+            "minimum_latitude": 23.67303,
+            "maximum_latitude": 25.290079,
+            "minimum_longitude": 120.598713,
+            "maximum_longitude": 121.9837549,
+            "extracted_on": "2022-03-17T20:34:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.taichung.gov.tw/bnb/api/gtfs/nt/latest",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-changhua-total-passenger-common-total-gtfs-1074.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-taichung-fengyuan-passenger-transport-gtfs-1083.json
+++ b/catalogs/sources/gtfs/schedule/tw-taichung-fengyuan-passenger-transport-gtfs-1083.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1083,
+    "data_type": "gtfs",
+    "provider": "Fengyuan Passenger Transport, TC_台中客運 (Taichung Passenger Transport), TC_仁友客運 (Renyou Passenger Transport), TC_統聯客運 (Tonglian Passenger Transport), TC_巨業交通 (Juye Traffic), TC_全航客運 (All Air Passenger Transport), TC_和欣客運 (Hexin Passenger Transport), TC_東南客運 (Southeast Passenger Transport),  TC_豐榮客運 (Fengrong Passenger Transport), TC_苗栗客運 (Miaoli Passenger Transport), TC_中台灣客運 (Central Taiwan Passenger Transport), TC_總達客運(公總) (Total passenger (common total)), TC_全航客運(公總) (All-air passenger (common total)), TC_中鹿客運(公總) (Zhonglu Passenger Transport (General)), TC_台中客運(公總) (Taichung Passenger Transport (Common Service)), TC_豐原客運(公總) (Fengyuan Passenger Transport (General)), TC_巨業交通(公總) (Juye Traffic (Public)), TC_彰化客運(公總) (Changhua Passenger Transport (Common Service)), TC_員林客運(公總) (Yuanlin Passenger Transport (General Public Service)), TC_杉林溪遊樂事業(公總) (Shanlinxi Recreation Business (Public Office)), TC_南投客運(公總) (Nantou Passenger Transport (Common Service)), TC_四方公司 (TC_Sifang Company), TC_捷順交通 (Jeshun Transportation), TC_中鹿客運 (Zhonglu Passenger Transport), TC_國光客運(公總) (Guoguang Passenger Transport (General)), TC_國光客運 (Guoguang Passenger Transport), TC_建明客運 (Jianming Passenger Transport), TC_阿羅哈客運(公總) (Aloha Passenger Transport (General)), TC_統聯客運(公總) (Tonglian Passenger Transport (Common Service)), TC_花蓮客運(公總) (Hualien Passenger Transport (General)), TC_總達客運 (Total passenger transport), TC_小黃公車 (Little Yellow Bus), TC_新竹客運(公總) (Hsinchu Passenger Transport (General)), TC_和欣客運(公總) (Hexin Passenger Transport (General Public Service)), TC_臺西客運(公總) (Taixi Passenger Transport (Common Service)\n), TC_大有巴士(公總) (Dayou bus (public bus)), TC_苗栗客運(公總) (Miaoli Passenger Transport (Common Service)), TC_臺中捷運公司 (Taichung MRT Corporation)\n",
+    "location": {
+        "country_code": "TW",
+        "subdivision_name": "Taichung",
+        "bounding_box": {
+            "minimum_latitude": 22.627563,
+            "maximum_latitude": 25.132208,
+            "minimum_longitude": 120.1524,
+            "maximum_longitude": 121.77578,
+            "extracted_on": "2022-03-17T21:18:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.taichung.gov.tw/bnb/api/gtfs/tc/latest",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-taichung-fengyuan-passenger-transport-gtfs-1083.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-unknown-yuanlin-passenger-transport-general-manager-gtfs-1073.json
+++ b/catalogs/sources/gtfs/schedule/tw-unknown-yuanlin-passenger-transport-general-manager-gtfs-1073.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1073,
+    "data_type": "gtfs",
+    "provider": "Yuanlin Passenger Transport (General Manager), CH_中鹿客運(公總) (Zhonglu Passenger Transport (Public Service)), CH_彰化客運(公總) (Changhua Passenger Transport (Public Service))",
+    "location": {
+        "country_code": "TW",
+        "bounding_box": {
+            "minimum_latitude": 23.385829,
+            "maximum_latitude": 25.297518,
+            "minimum_longitude": 120.171053,
+            "maximum_longitude": 121.94879,
+            "extracted_on": "2022-03-17T20:34:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gtfs.taichung.gov.tw/bnb/api/gtfs/ch/latest",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-unknown-yuanlin-passenger-transport-general-manager-gtfs-1073.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-metro-transit-gtfs-1080.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-metro-transit-gtfs-1080.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1080,
+    "data_type": "gtfs",
+    "provider": "Metro Transit, Intercity Transit, City of Seattle, Community Transit, Pierce Transit, Sound Transit, Washington State Ferries, SeattleCenterMonorail, Everett Transit, Seattle Children's Hospital",
+    "name": "Puget Sound Consolidated GTFS",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-17T20:41:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://developer.onebusaway.org/tmp/sound/gtfs/modified/gtfs_puget_sound_consolidated.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-metro-transit-gtfs-1080.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the thirteenth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 20 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~