### PR TITLE
fix: Modifies cronjob workflow to fix memory error

### DIFF
--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -182,7 +182,9 @@ jobs:
                       file_log = (
                           f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
                       )
-              with open(os.path.join(ROOT, DATASETS, DOWNLOAD_REPORTS, f"{base}.txt"), "w") as fp:
+              report_path = os.path.join(ROOT, DOWNLOAD_REPORTS, f"{base}.txt")
+              os.makedirs(os.path.dirname(report_path), exist_ok=True)
+              with open(report_path, "w") as fp:
                   fp.write(file_log)
       - name: Set up and authorize Cloud
         uses: google-github-actions/auth@v0
@@ -195,12 +197,12 @@ jobs:
           path: datasets/${{ matrix.hash }}
           destination: mdb-latest
           parent: false
-      - name: Persist Download datasets report artifact
+      - name: Persist Download Reports artifact
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: download_datasets_report
-          path: ./download_datasets_report.txt
+          name: download_reports
+          path: download_reports
   validate-latest:
     needs: [ get-urls, store-datasets ]
     runs-on: ubuntu-latest
@@ -268,11 +270,13 @@ jobs:
                       file_log = (
                           f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
                       )
-              with open(os.path.join(ROOT, DATASETS, LATEST_REPORTS, f"{base}.txt"), "w") as fp:
+              report_path = os.path.join(ROOT, LATEST_REPORTS, f"{base}.txt")
+              os.makedirs(os.path.dirname(report_path), exist_ok=True)
+              with open(report_path, "w") as fp:
                   fp.write(file_log)
-      - name: Persist Validate latest datasets report artifact
+      - name: Persist Latest Reports artifact
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: validate_latest_report
-          path: ./validate_latest_report.txt
+          name: latest_reports
+          path: latest_reports

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -3,6 +3,8 @@ name: Store latest datasets cronjob
 on:
   schedule:
     - cron: "0 0 * * *"
+  pull_request:
+    branches: [ main ]
 
 jobs:
   get-urls:
@@ -22,6 +24,7 @@ jobs:
         run: |
           import os
           import json
+          import hashlib
           import numpy as np
 
           # OS constants
@@ -41,6 +44,7 @@ jobs:
           INCLUDE = "include"
           DATA = "data"
           BASE = "base"
+          HASH = "hash"
 
           # Report constants
           GET_URLS_REPORT = "get_urls_report.txt"
@@ -82,7 +86,10 @@ jobs:
                   urls_data_string = urls_data_string + json.dumps(
                       file_information, separators=(",", ":")
                   )
-              job_data = {DATA: urls_data_string.replace("}{", "} {")}
+              job_data = {
+                  HASH: hashlib.sha1(urls_data_string.encode("utf-8")).hexdigest(),
+                  DATA: urls_data_string.replace("}{", "} {")
+              }
               urls_data.append(job_data)
           matrix_data = {INCLUDE: urls_data}
 
@@ -108,7 +115,7 @@ jobs:
           path: ./get_urls_report.txt
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-  download-datasets:
+  store-datasets:
     needs: [ get-urls ]
     runs-on: ubuntu-latest
     strategy:
@@ -119,28 +126,18 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest wheel numpy
-          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get update
-          sudo apt-get install gdal-bin python3-gdal
-          sudo apt-get install libgdal-dev
-          pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="-I/usr/include/gdal"
-          sudo apt-get install libspatialindex-dev
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Validate and download the datasets
         shell: python
         run: |
           import os
           import json
-          import gtfs_kit
           import requests
+          from zipfile import ZipFile
 
           # OS constants
           ROOT = os.getcwd()
           DATASETS = "datasets"
+          FOLDER = """${{ matrix.hash }}"""
 
           # Jobs constants
           BASE = "base"
@@ -155,61 +152,36 @@ jobs:
               base = job_json[BASE]
               url = job_json[DIRECT_DOWNLOAD]
 
-              # Make sure that the dataset is a readable GTFS Schedule dataset
-              is_readable = True
+              # Download the dataset
+              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
+              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+              is_downloadable = True
               try:
-                  gtfs_kit.read_feed(url, dist_units="km")
+                  zip_file_req = requests.get(url, allow_redirects=True)
+                  zip_file_req.raise_for_status()
               except Exception as e:
-                  is_readable = False
+                  is_downloadable = False
                   file_log = (
-                      f"{base}: FAILURE! Exception {e} found while parsing the GTFS dataset with the GTFS kit library. "
-                      f"The dataset must be a valid GTFS zip file or URL.\n"
+                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
                   )
 
-              # Download the dataset
-              if is_readable:
-                  zip_path = os.path.join(ROOT, DATASETS, f"{base}.zip")
-                  os.makedirs(os.path.dirname(zip_path), exist_ok=True)
-                  is_downloadable = True
+              if is_downloadable:
+                  zip_file = zip_file_req.content
+                  with open(zip_path, "wb") as f:
+                      f.write(zip_file)
+                  # Make sure that the download file is a zip file
                   try:
-                      zip_file_req = requests.get(url, allow_redirects=True)
-                      zip_file_req.raise_for_status()
-                  except Exception as e:
-                      is_downloadable = False
+                      ZipFile(zip_path, "r")
                       file_log = (
-                          f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
+                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
                       )
-
-                  if is_downloadable:
-                      zip_file = zip_file_req.content
-                      with open(zip_path, "wb") as f:
-                          f.write(zip_file)
+                  except Exception as e:
+                      os.remove(zip_path)
                       file_log = (
-                          f"{base}: SUCCESS! A readable GTFS dataset was downloaded.\n"
+                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
                       )
               with open(DOWNLOAD_DATASETS_REPORT, "a") as fp:
                   fp.write(file_log)
-      - name: Persist datasets artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: datasets
-          path: datasets
-      - name: Persist Download datasets report artifact
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: download_datasets_report
-          path: ./download_datasets_report.txt
-  store-datasets:
-    needs: [ download-datasets ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download datasets artifact
-        uses: actions/download-artifact@master
-        with:
-          name: datasets
-          path: datasets
       - name: Set up and authorize Cloud
         uses: google-github-actions/auth@v0
         with:
@@ -218,9 +190,15 @@ jobs:
         id: upload-datasets
         uses: google-github-actions/upload-cloud-storage@main
         with:
-          path: datasets
+          path: datasets/${{ matrix.hash }}
           destination: mdb-latest
           parent: false
+      - name: Persist Download datasets report artifact
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: download_datasets_report
+          path: ./download_datasets_report.txt
   validate-latest:
     needs: [ get-urls, store-datasets ]
     runs-on: ubuntu-latest
@@ -232,17 +210,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest wheel numpy
-          sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-          sudo apt-get update
-          sudo apt-get install gdal-bin python3-gdal
-          sudo apt-get install libgdal-dev
-          pip install GDAL==$(gdal-config --version) --global-option=build_ext --global-option="-I/usr/include/gdal"
-          sudo apt-get install libspatialindex-dev
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Validate the latest datasets
         shell: python
         run: |
@@ -250,6 +217,11 @@ jobs:
           import json
           import gtfs_kit
           import requests
+
+          # OS constants
+          ROOT = os.getcwd()
+          DATASETS = "datasets"
+          FOLDER = """${{ matrix.hash }}"""
 
           # Jobs constants
           BASE = "base"
@@ -264,17 +236,34 @@ jobs:
               base = job_json[BASE]
               url = job_json[LATEST]
 
-              # Make sure that the uploaded latest dataset is a readable GTFS Schedule dataset
+              # Download the dataset
+              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
+              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+              is_downloadable = True
               try:
-                  gtfs_kit.read_feed(url, dist_units="km")
-                  file_log = (
-                      f"{base}: SUCCESS! The latest dataset is a readable GTFS dataset.\n"
-                  )
+                  zip_file_req = requests.get(url, allow_redirects=True)
+                  zip_file_req.raise_for_status()
               except Exception as e:
+                  is_downloadable = False
                   file_log = (
-                      f"{base}: FAILURE! Exception {e} found while parsing the GTFS dataset with the GTFS kit library. "
-                      f"The dataset must be a valid GTFS zip file or URL.\n"
+                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
                   )
+
+              if is_downloadable:
+                  zip_file = zip_file_req.content
+                  with open(zip_path, "wb") as f:
+                      f.write(zip_file)
+                  # Make sure that the download file is a zip file
+                  try:
+                      ZipFile(zip_path, "r")
+                      file_log = (
+                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
+                      )
+                  except Exception as e:
+                      os.remove(zip_path)
+                      file_log = (
+                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
+                      )
               with open(VALIDATE_LATEST_REPORT, "a") as fp:
                   fp.write(file_log)
       - name: Persist Validate latest datasets report artifact

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -142,13 +142,11 @@ jobs:
           ROOT = os.getcwd()
           DATASETS = "datasets"
           FOLDER = """${{ matrix.hash }}"""
+          DOWNLOAD_REPORTS = "download_reports"
 
           # Jobs constants
           BASE = "base"
           DIRECT_DOWNLOAD = "direct_download"
-
-          # Report constants
-          DOWNLOAD_DATASETS_REPORT = "download_datasets_report.txt"
 
           jobs = """${{ matrix.data }}""".split()
           for job in jobs:
@@ -184,7 +182,7 @@ jobs:
                       file_log = (
                           f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
                       )
-              with open(DOWNLOAD_DATASETS_REPORT, "a") as fp:
+              with open(os.path.join(ROOT, DATASETS, DOWNLOAD_REPORTS, f"{base}.txt"), "w") as fp:
                   fp.write(file_log)
       - name: Set up and authorize Cloud
         uses: google-github-actions/auth@v0
@@ -223,20 +221,18 @@ jobs:
         run: |
           import os
           import json
-          import gtfs_kit
           import requests
+          from zipfile import ZipFile
 
           # OS constants
           ROOT = os.getcwd()
           DATASETS = "datasets"
           FOLDER = """${{ matrix.hash }}"""
+          LATEST_REPORTS = "latest_reports"
 
           # Jobs constants
           BASE = "base"
           LATEST = "latest"
-
-          # Report constants
-          VALIDATE_LATEST_REPORT = "validate_latest_report.txt"
 
           jobs = """${{ matrix.data }}""".split()
           for job in jobs:
@@ -272,7 +268,7 @@ jobs:
                       file_log = (
                           f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
                       )
-              with open(VALIDATE_LATEST_REPORT, "a") as fp:
+              with open(os.path.join(ROOT, DATASETS, LATEST_REPORTS, f"{base}.txt"), "w") as fp:
                   fp.write(file_log)
       - name: Persist Validate latest datasets report artifact
         if: always()

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -3,8 +3,6 @@ name: Store latest datasets cronjob
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
-    branches: [ main ]
 
 jobs:
   get-urls:

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -126,6 +126,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel requests
       - name: Validate and download the datasets
         shell: python
         run: |
@@ -210,6 +214,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel requests
       - name: Validate the latest datasets
         shell: python
         run: |


### PR DESCRIPTION
**Summary:**

Fixes #108: Cronjob is failing, probably because of a memory error

This PR modifies the `store_latest_dataset_cronjob.yml` workflow so that:
- The dataset artifact is not persisted anymore
- We validate that the dataset is a zip file using python `zipfile` library (not GTFS Kit anymore)

Changes:
- `store_latest_dataset_cronjob.yml` is updated.

**Expected behavior:** 
The cronjob should run daily without failing.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~