### PR TITLE
feat: Store exported CSV in CGP

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -131,4 +131,5 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@main
         with:
           path: sources.csv
-          destination: mdb-csv/sources.csv
+          destination: mdb-csv
+          parent: false

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -9,15 +9,12 @@ on:
 jobs:
   export-to-csv:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -37,7 +34,7 @@ jobs:
             import os
             import json
 
-            CSV_PATH = "./catalog_sources.csv"
+            CSV_PATH = "./sources.csv"
             CSV_COLUMNS = [
               'mdb_source_id',
               'data_type',
@@ -113,5 +110,25 @@ jobs:
       - name: Upload the catalog of sources CSV artifact
         uses: actions/upload-artifact@v1
         with:
-          name: catalog-sources-csv-v${{ github.run_id }}.${{ github.run_number }}
-          path: ./catalog_sources.csv
+          name: sources.csv
+          path: sources.csv
+  store-csv:
+    needs: [ export-to-csv ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download the catalog of sources CSV artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: sources.csv
+          path: sources.csv
+      - name: Set up and authorize Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
+      - name: Upload csv to Google Cloud Storage
+        id: upload-csv
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: sources.csv
+          destination: mdb-csv/sources.csv

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -3,8 +3,6 @@ name: Export catalogs to CSV
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   export-to-csv:


### PR DESCRIPTION
**Summary:**

Fixes #28: Add GitHub action to export a CSV

This PR adds a job to the `export_to_csv.yml` workflow to store the CSV in a GCP bucket.

Changes:

- `export_to_csv.yml` to add the job

**Expected behavior:** 

The CSV is exported as an artifact and updated in the GCP bucket when code or data is merged in main.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~