### PR TITLE
feat: Sixteenth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ca-new-brunswick-codiac-transport-gtfs-1111.json
+++ b/catalogs/sources/gtfs/schedule/ca-new-brunswick-codiac-transport-gtfs-1111.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1111,
+    "data_type": "gtfs",
+    "provider": "Codiac Transport",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "New Brunswick",
+        "municipality": "Moncton",
+        "bounding_box": {
+            "minimum_latitude": 46.0419242705062,
+            "maximum_latitude": 46.165235,
+            "minimum_longitude": -64.8910137946018,
+            "maximum_longitude": -64.6976506529838,
+            "extracted_on": "2022-03-22T14:56:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www7.moncton.ca/opendata/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-new-brunswick-codiac-transport-gtfs-1111.zip?alt=media",
+        "license": "https://catalogue-moncton.opendata.arcgis.com/datasets/transit-files-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-freiburger-verkehrs-ag-vag-gtfs-1115.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-freiburger-verkehrs-ag-vag-gtfs-1115.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1115,
+    "data_type": "gtfs",
+    "provider": "Freiburger Verkehrs AG (VAG), R.A.S.T. Reisen (RAST), Tuniberg Express, ",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Freiburg",
+        "bounding_box": {
+            "minimum_latitude": 47.9352229574323,
+            "maximum_latitude": 48.0571089944315,
+            "minimum_longitude": 7.59018024693184,
+            "maximum_longitude": 7.91547817766248,
+            "extracted_on": "2022-03-22T14:56:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.vag-freiburg.de/fileadmin/gtfs/VAGFR.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-freiburger-verkehrs-ag-vag-gtfs-1115.zip?alt=media",
+        "license": "https://www.vag-freiburg.de/service-infos/downloads/gtfs-daten"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-andalucia-empresa-malaguena-de-transportes-emt-gtfs-1113.json
+++ b/catalogs/sources/gtfs/schedule/es-andalucia-empresa-malaguena-de-transportes-emt-gtfs-1113.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1113,
+    "data_type": "gtfs",
+    "provider": "Empresa Malagueña de Transportes (EMT)",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Andalucía",
+        "bounding_box": {
+            "minimum_latitude": 36.646365,
+            "maximum_latitude": 36.780029,
+            "minimum_longitude": -4.576132,
+            "maximum_longitude": -4.335785,
+            "extracted_on": "2022-03-22T14:56:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://datosabiertos.malaga.eu/recursos/transporte/EMT/lineasYHorarios/google_transit_txt.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-andalucia-empresa-malaguena-de-transportes-emt-gtfs-1113.zip?alt=media",
+        "license": "http://datosabiertos.malaga.eu/dataset/lineas-y-horarios-bus-google-transit"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-etela-savo-mikkeli-gtfs-1130.json
+++ b/catalogs/sources/gtfs/schedule/fi-etela-savo-mikkeli-gtfs-1130.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1130,
+    "data_type": "gtfs",
+    "provider": "Mikkeli",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Etelä-Savo",
+        "municipality": "Mikkeli",
+        "bounding_box": {
+            "minimum_latitude": 61.3048549967638,
+            "maximum_latitude": 62.1599661034743,
+            "minimum_longitude": 26.461659,
+            "maximum_longitude": 28.184238,
+            "extracted_on": "2022-03-22T15:00:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/227.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-etela-savo-mikkeli-gtfs-1130.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-kymenlaakso-kymen-charterline-oy-gtfs-1127.json
+++ b/catalogs/sources/gtfs/schedule/fi-kymenlaakso-kymen-charterline-oy-gtfs-1127.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1127,
+    "data_type": "gtfs",
+    "provider": "KYMEN CHARTERLINE OY, Jyrkilä Oy, Kaakon Kumipyörät Oy, Liikenne Vuorela Oy, Oy Pohjolan liikenne Ab, Savonlinja Oy",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Kymenlaakso",
+        "municipality": "Kotka",
+        "bounding_box": {
+            "minimum_latitude": 60.4296786499054,
+            "maximum_latitude": 60.8236947812167,
+            "minimum_longitude": 26.4564528153735,
+            "maximum_longitude": 27.84075185766017,
+            "extracted_on": "2022-03-22T15:00:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/217.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-kymenlaakso-kymen-charterline-oy-gtfs-1127.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-kymenlaakso-tilaustaksit-k-sydanmaanlakka-ky-gtfs-1128.json
+++ b/catalogs/sources/gtfs/schedule/fi-kymenlaakso-tilaustaksit-k-sydanmaanlakka-ky-gtfs-1128.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1128,
+    "data_type": "gtfs",
+    "provider": "Tilaustaksit K. Sydänmaanlakka Ky, KYMEN CHARTERLINE OY, Kari Väisänen Ky, Matkatoimisto Matka-Majuri Ky, Linja-autoliikenne P. Puolakka Ky, Linjaliikenne Martti Laurila Oy, Oy Pohjolan Liikenne Ab, Elimäen Liikenne Oy, Anjalankosken Linja Oy",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Kymenlaakso",
+        "municipality": "Kouvola",
+        "bounding_box": {
+            "minimum_latitude": 60.4628470725349,
+            "maximum_latitude": 61.2536682287698,
+            "minimum_longitude": 26.170947401343813,
+            "maximum_longitude": 27.401959,
+            "extracted_on": "2022-03-22T15:00:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/219.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-kymenlaakso-tilaustaksit-k-sydanmaanlakka-ky-gtfs-1128.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-paijat-hame-haarasilta-toivo-samuli-gtfs-1129.json
+++ b/catalogs/sources/gtfs/schedule/fi-paijat-hame-haarasilta-toivo-samuli-gtfs-1129.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1129,
+    "data_type": "gtfs",
+    "provider": "Haarasilta Toivo Samuli, Järvisen Liikenne Oy, Koiviston Auto Oy, Lehtimäen Liikenne Oy, Bus Travel Oy Reissu Ruoti, Tilausliikenne Kuisma Ky",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Päijät-Häme",
+        "municipality": "Lahti",
+        "bounding_box": {
+            "minimum_latitude": 60.6772517226169,
+            "maximum_latitude": 61.5800619928604,
+            "minimum_longitude": 25.2492841801289,
+            "maximum_longitude": 26.2609529033383,
+            "extracted_on": "2022-03-22T15:00:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/223.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-paijat-hame-haarasilta-toivo-samuli-gtfs-1129.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-pohjanmaa-invataksi-niemi-oy-gtfs-1131.json
+++ b/catalogs/sources/gtfs/schedule/fi-pohjanmaa-invataksi-niemi-oy-gtfs-1131.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1131,
+    "data_type": "gtfs",
+    "provider": "Invataksi Niemi Oy",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Pohjanmaa",
+        "municipality": "Vaasa",
+        "bounding_box": {
+            "minimum_latitude": 62.907248,
+            "maximum_latitude": 63.30417287,
+            "minimum_longitude": 21.51908047,
+            "maximum_longitude": 22.37872582,
+            "extracted_on": "2022-03-22T15:00:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/249.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-pohjanmaa-invataksi-niemi-oy-gtfs-1131.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-pos-ely-joensuu-gtfs-1125.json
+++ b/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-pos-ely-joensuu-gtfs-1125.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1125,
+    "data_type": "gtfs",
+    "provider": "POS-ELY Joensuu",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Pohjois-Karjala",
+        "municipality": "Joensuu",
+        "bounding_box": {
+            "minimum_latitude": 61.8669,
+            "maximum_latitude": 63.67867124415436,
+            "minimum_longitude": 27.190477,
+            "maximum_longitude": 30.936747,
+            "extracted_on": "2022-03-22T14:58:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/183.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-pohjois-karjala-pos-ely-joensuu-gtfs-1125.zip?alt=media",
+        "license": "https://opendata.waltti.fi/getting-started"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-unknown-finferries-gtfs-1114.json
+++ b/catalogs/sources/gtfs/schedule/fi-unknown-finferries-gtfs-1114.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1114,
+    "data_type": "gtfs",
+    "provider": "Finferries, Alandstrafiken, Rosita Oy, JS Ferryway Ltd Oy, Kuljetus-Savolainen Oy, Archipelago Lines Oy, Sundqvist Investments Oy Ab, Pörtö Line, Nordic Coast Line, Yksityinen, HSL, Vitharun, Espoon kaupunki, Suomen saaristokuljetus, Norsöline, JT-Line Oy, A&S Ravintolat, Merisataman lauttaliikenne, NJK Blekholmen, Ferra Oy, City Cruisers, Aava Lines Oy, Helsingin Risteilypalvelut/TMSJ Group Oy",
+    "location": {
+        "country_code": "FI",
+        "bounding_box": {
+            "minimum_latitude": 59.7865148075,
+            "maximum_latitude": 66.5802673946,
+            "minimum_longitude": 19.5364379883,
+            "maximum_longitude": 29.5712215851,
+            "extracted_on": "2022-03-22T14:56:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://lautta.net/db/gtfs/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-unknown-finferries-gtfs-1114.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-doubs-ginko-gtfs-1116.json
+++ b/catalogs/sources/gtfs/schedule/fr-doubs-ginko-gtfs-1116.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1116,
+    "data_type": "gtfs",
+    "provider": "Ginko",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Doubs",
+        "municipality": "Besançon",
+        "bounding_box": {
+            "minimum_latitude": 47.11750793457031,
+            "maximum_latitude": 47.37153625488281,
+            "minimum_longitude": 5.791347980499268,
+            "maximum_longitude": 6.201003,
+            "extracted_on": "2022-03-22T14:56:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://api.ginko.voyage/gtfs-ginko.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-doubs-ginko-gtfs-1116.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-grand-est-communaute-urbaine-du-grand-nancy-gtfs-1112.json
+++ b/catalogs/sources/gtfs/schedule/fr-grand-est-communaute-urbaine-du-grand-nancy-gtfs-1112.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1112,
+    "data_type": "gtfs",
+    "provider": "Communauté urbaine du Grand Nancy ",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Grand-Est",
+        "municipality": "Nancy",
+        "bounding_box": {
+            "minimum_latitude": 48.610365,
+            "maximum_latitude": 48.731698,
+            "minimum_longitude": 6.108618,
+            "maximum_longitude": 6.273911,
+            "extracted_on": "2022-03-22T14:56:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.data.gouv.fr/fr/datasets/r/e7e78cd7-e186-4923-a272-9713fbc28b45",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-grand-est-communaute-urbaine-du-grand-nancy-gtfs-1112.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-grand-est-reseau-stan-gtfs-1117.json
+++ b/catalogs/sources/gtfs/schedule/fr-grand-est-reseau-stan-gtfs-1117.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1117,
+    "data_type": "gtfs",
+    "provider": "Réseau STAN",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Grand-Est",
+        "municipality": "Grand Nancy",
+        "bounding_box": {
+            "minimum_latitude": 48.610313,
+            "maximum_latitude": 48.731663,
+            "minimum_longitude": 6.107901,
+            "maximum_longitude": 6.27393,
+            "extracted_on": "2022-03-22T14:56:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/grand-nancy/1068/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-grand-est-reseau-stan-gtfs-1117.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/nz-wellington-metlink-gtfs-1132.json
+++ b/catalogs/sources/gtfs/schedule/nz-wellington-metlink-gtfs-1132.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1132,
+    "data_type": "gtfs",
+    "provider": "Metlink ",
+    "location": {
+        "country_code": "NZ",
+        "subdivision_name": "Wellington",
+        "bounding_box": {
+            "minimum_latitude": -41.34810413999999,
+            "maximum_latitude": -40.623161,
+            "minimum_longitude": 174.7220021,
+            "maximum_longitude": 175.6842552,
+            "extracted_on": "2022-03-22T15:00:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://static.opendata.metlink.org.nz/v1/gtfs/full.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nz-wellington-metlink-gtfs-1132.zip?alt=media",
+        "license": "http://www.metlink.org.nz/customer-services/general-transit-feed-specification/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-lomianki-gtfs-1123.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-lomianki-gtfs-1123.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1123,
+    "data_type": "gtfs",
+    "provider": "Komunikacja Miejska Łomianki",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Mazowieckie",
+        "municipality": "Łomianki",
+        "bounding_box": {
+            "minimum_latitude": 52.321374,
+            "maximum_latitude": 52.3676929,
+            "minimum_longitude": 20.81735906974,
+            "maximum_longitude": 20.910699,
+            "extracted_on": "2022-03-22T14:58:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/feed/kml/kml-latest.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-komunikacja-miejska-lomianki-gtfs-1123.zip?alt=media",
+        "license": "https://mkuran.pl/gtfs/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pt-regiao-autonoma-da-madeira-horarios-do-funchal-transportes-publicos-gtfs-1119.json
+++ b/catalogs/sources/gtfs/schedule/pt-regiao-autonoma-da-madeira-horarios-do-funchal-transportes-publicos-gtfs-1119.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1119,
+    "data_type": "gtfs",
+    "provider": "Horários do Funchal - Transportes Públicos, S.A",
+    "name": "Interurbano, Urbano",
+    "location": {
+        "country_code": "PT",
+        "subdivision_name": "Região Autónoma da Madeira",
+        "municipality": "Funchal",
+        "bounding_box": {
+            "minimum_latitude": 32.634288566692625,
+            "maximum_latitude": 32.83195586714723,
+            "minimum_longitude": -16.975529589342795,
+            "maximum_longitude": -16.7672157287598,
+            "extracted_on": "2022-03-22T14:57:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.horariosdofunchal.pt/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-regiao-autonoma-da-madeira-horarios-do-funchal-transportes-publicos-gtfs-1119.zip?alt=media",
+        "license": "http://www.horariosdofunchal.pt/index.php?option=com_content&task=view&id=2022"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/rs-nisavski-okrug-nis-ekspres-gtfs-1120.json
+++ b/catalogs/sources/gtfs/schedule/rs-nisavski-okrug-nis-ekspres-gtfs-1120.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1120,
+    "data_type": "gtfs",
+    "provider": "Niš-ekspres, Lasta a.d. Beograd, Strela-Obrenovac",
+    "location": {
+        "country_code": "RS",
+        "subdivision_name": "Nišavski okrug",
+        "municipality": "Niš",
+        "bounding_box": {
+            "minimum_latitude": 43.292787,
+            "maximum_latitude": 43.3499466,
+            "minimum_longitude": 21.7838066,
+            "maximum_longitude": 22.005344,
+            "extracted_on": "2022-03-22T14:57:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://data.gov.rs/en/datasets/r/b8fdbafe-10af-4b1a-a647-5f50e1dd33fb",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/rs-nisavski-okrug-nis-ekspres-gtfs-1120.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-lampoon-pattana-transport-gtfs-1124.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-lampoon-pattana-transport-gtfs-1124.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1124,
+    "data_type": "gtfs",
+    "provider": "Lampoon Pattana Transport ",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai",
+        "bounding_box": {
+            "minimum_latitude": 17.89,
+            "maximum_latitude": 18.801641,
+            "minimum_longitude": 98.604592,
+            "maximum_longitude": 99.0452953,
+            "extracted_on": "2022-03-22T14:58:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/lampoon-pattana-transport/796/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-lampoon-pattana-transport-gtfs-1124.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tr-kocaeli-kocaeli-gtfs-1122.json
+++ b/catalogs/sources/gtfs/schedule/tr-kocaeli-kocaeli-gtfs-1122.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1122,
+    "data_type": "gtfs",
+    "provider": "Kocaeli",
+    "location": {
+        "country_code": "TR",
+        "subdivision_name": "Kocaeli",
+        "municipality": "Izmit",
+        "bounding_box": {
+            "minimum_latitude": 40.429585,
+            "maximum_latitude": 41.191651,
+            "minimum_longitude": 29.2075127363205,
+            "maximum_longitude": 30.3461293723107,
+            "extracted_on": "2022-03-22T14:58:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://kocaeli.bel.tr/webfiles/userfiles/files/birimler/bilgi-islem-dairesi-baskanligi/kocaeli-gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tr-kocaeli-kocaeli-gtfs-1122.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-brightline-trains-llc-gtfs-1126.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-brightline-trains-llc-gtfs-1126.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1126,
+    "data_type": "gtfs",
+    "provider": "Brightline Trains LLC",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "bounding_box": {
+            "minimum_latitude": 25.7799682617,
+            "maximum_latitude": 26.712015152,
+            "minimum_longitude": -80.195640564,
+            "maximum_longitude": -80.0553588867,
+            "extracted_on": "2022-03-22T15:00:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://feed.gobrightline.com/bl_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-brightline-trains-llc-gtfs-1126.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-georgia-regional-transportation-authority-grta-xpress-gtfs-1118.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-georgia-regional-transportation-authority-grta-xpress-gtfs-1118.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1118,
+    "data_type": "gtfs",
+    "provider": "Georgia Regional Transportation Authority (GRTA Xpress)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.381316,
+            "maximum_latitude": 34.181736,
+            "minimum_longitude": -84.773527,
+            "maximum_longitude": -83.907051,
+            "extracted_on": "2022-03-22T14:56:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://gamobility.info/GTFS/Google_Transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-georgia-regional-transportation-authority-grta-xpress-gtfs-1118.zip?alt=media",
+        "license": "http://atlantaregional.com/File%20Library/Transportation/Transit/Developers-Agreement-for-Web.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-york-roosevelt-island-operating-corporation-tramway-rioc-tramway-gtfs-1109.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-roosevelt-island-operating-corporation-tramway-rioc-tramway-gtfs-1109.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1109,
+    "data_type": "gtfs",
+    "provider": "Roosevelt Island Operating Corporation Tramway (RIOC Tramway)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New York",
+        "municipality": "New York City",
+        "bounding_box": {
+            "minimum_latitude": 40.753414,
+            "maximum_latitude": 40.768884,
+            "minimum_longitude": -73.964219,
+            "maximum_longitude": -73.942912,
+            "extracted_on": "2022-03-22T14:55:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/7707/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-roosevelt-island-operating-corporation-tramway-rioc-tramway-gtfs-1109.zip?alt=media",
+        "license": "https://github.com/laidig/rioc-gtfs/blob/master/README.md"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1110.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1110.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1110,
+    "data_type": "gtfs",
+    "provider": "Wave Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Wilmington",
+        "bounding_box": {
+            "minimum_latitude": 34.036147,
+            "maximum_latitude": 34.326726,
+            "minimum_longitude": -78.057393,
+            "maximum_longitude": -77.820191,
+            "extracted_on": "2022-03-22T14:56:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.wavetransit.com/gtransit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-1110.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-tennessee-knoxville-area-transit-kat-gtfs-1121.json
+++ b/catalogs/sources/gtfs/schedule/us-tennessee-knoxville-area-transit-kat-gtfs-1121.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1121,
+    "data_type": "gtfs",
+    "provider": "Knoxville Area Transit (KAT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Tennessee",
+        "municipality": "Knoxville",
+        "bounding_box": {
+            "minimum_latitude": 35.906341,
+            "maximum_latitude": 36.044794,
+            "minimum_longitude": -84.103075,
+            "maximum_longitude": -83.839573,
+            "extracted_on": "2022-03-22T14:57:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.knoxvilletn.gov/UserFiles/Servers/Server_109478/File/KAT/gtfs-kat.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-tennessee-knoxville-area-transit-kat-gtfs-1121.zip?alt=media",
+        "license": "http://www.knoxvilletn.gov/government/opendata/knoxville_area_transit_kat_gtfs_feed"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the sixteenth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 24 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~