### PR TITLE
feat: Seventeenth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ar-cordoba-mar-chiquita-srl-gtfs-1146.json
+++ b/catalogs/sources/gtfs/schedule/ar-cordoba-mar-chiquita-srl-gtfs-1146.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1146,
+    "data_type": "gtfs",
+    "provider": "Mar Chiquita SRL",
+    "location": {
+        "country_code": "AR",
+        "subdivision_name": "Córdoba",
+        "bounding_box": {
+            "minimum_latitude": -31.439129,
+            "maximum_latitude": -31.300363,
+            "minimum_longitude": -64.4933,
+            "maximum_longitude": -62.091409,
+            "extracted_on": "2022-03-23T18:32:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mar-chiquita-srl/805/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ar-cordoba-mar-chiquita-srl-gtfs-1146.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-bowen-gtfs-1167.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-bowen-gtfs-1167.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1167,
+    "data_type": "gtfs",
+    "provider": "Bowen",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Bowen",
+        "bounding_box": {
+            "minimum_latitude": -20.018563,
+            "maximum_latitude": -19.970855,
+            "minimum_longitude": 148.225334,
+            "maximum_longitude": 148.265266,
+            "extracted_on": "2022-03-23T18:39:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/5/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-bowen-gtfs-1167.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-gladstone-gtfs-1168.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-gladstone-gtfs-1168.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1168,
+    "data_type": "gtfs",
+    "provider": "Gladstone",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Gladstone",
+        "bounding_box": {
+            "minimum_latitude": -23.960521,
+            "maximum_latitude": -23.838753,
+            "minimum_longitude": 151.21067,
+            "maximum_longitude": 151.370321,
+            "extracted_on": "2022-03-23T18:39:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/8/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-gladstone-gtfs-1168.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-innisfail-gtfs-1163.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-innisfail-gtfs-1163.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1163,
+    "data_type": "gtfs",
+    "provider": "Innisfail",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Innisfail",
+        "bounding_box": {
+            "minimum_latitude": -17.543952,
+            "maximum_latitude": -17.490769,
+            "minimum_longitude": 145.988544,
+            "maximum_longitude": 146.076147,
+            "extracted_on": "2022-03-23T18:38:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/10/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-innisfail-gtfs-1163.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-maleny-landsborough-gtfs-1164.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-maleny-landsborough-gtfs-1164.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1164,
+    "data_type": "gtfs",
+    "provider": "Maleny / Landsborough",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Maleny",
+        "bounding_box": {
+            "minimum_latitude": -26.862165,
+            "maximum_latitude": -26.61763,
+            "minimum_longitude": 152.850518,
+            "maximum_longitude": 152.966059,
+            "extracted_on": "2022-03-23T18:39:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/14/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-maleny-landsborough-gtfs-1164.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-toowoomba-gtfs-1165.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-toowoomba-gtfs-1165.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1165,
+    "data_type": "gtfs",
+    "provider": "Toowoomba",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Toowoomba",
+        "bounding_box": {
+            "minimum_latitude": -27.611151,
+            "maximum_latitude": -27.258647,
+            "minimum_longitude": 151.869525,
+            "maximum_longitude": 152.06874,
+            "extracted_on": "2022-03-23T18:39:06+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/17/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-toowoomba-gtfs-1165.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-townsville-gtfs-1166.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-townsville-gtfs-1166.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1166,
+    "data_type": "gtfs",
+    "provider": "Townsville",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Townsville",
+        "bounding_box": {
+            "minimum_latitude": -19.393504,
+            "maximum_latitude": -19.189667,
+            "minimum_longitude": 146.646356,
+            "maximum_longitude": 146.850212,
+            "extracted_on": "2022-03-23T18:39:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/18/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-townsville-gtfs-1166.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-western-australia-transperth-gtfs-1169.json
+++ b/catalogs/sources/gtfs/schedule/au-western-australia-transperth-gtfs-1169.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1169,
+    "data_type": "gtfs",
+    "provider": "Transperth",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Western Australia",
+        "municipality": "Perth",
+        "bounding_box": {
+            "minimum_latitude": -35.0682822222222,
+            "maximum_latitude": -20.3008238888889,
+            "minimum_longitude": 113.649835555556,
+            "maximum_longitude": 121.893761666667,
+            "extracted_on": "2022-03-23T18:41:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/transperth/2/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-western-australia-transperth-gtfs-1169.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-wroute-gtfs-1174.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-wroute-gtfs-1174.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1174,
+    "data_type": "gtfs",
+    "provider": "wroute",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Waterloo",
+        "bounding_box": {
+            "minimum_latitude": 43.3135361,
+            "maximum_latitude": 43.54418,
+            "minimum_longitude": -80.44126,
+            "maximum_longitude": -79.8221389,
+            "extracted_on": "2022-03-23T18:44:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/wroute/1159/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-wroute-gtfs-1174.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-prince-edward-island-t3-transit-gtfs-1206.json
+++ b/catalogs/sources/gtfs/schedule/ca-prince-edward-island-t3-transit-gtfs-1206.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1206,
+    "data_type": "gtfs",
+    "provider": "T3 Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Prince Edward Island",
+        "municipality": "Charlottetown",
+        "bounding_box": {
+            "minimum_latitude": 46.23483,
+            "maximum_latitude": 46.2938664,
+            "minimum_longitude": -63.1869936,
+            "maximum_longitude": -63.1010613,
+            "extracted_on": "2022-03-23T18:56:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/t3-transit/591/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-prince-edward-island-t3-transit-gtfs-1206.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-agence-metropolitaine-de-transport-crt-lanaudiere-gtfs-1181.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-agence-metropolitaine-de-transport-crt-lanaudiere-gtfs-1181.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1181,
+    "data_type": "gtfs",
+    "provider": "Agence métropolitaine de transport CRT Lanaudière",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.5896918011493,
+            "maximum_latitude": 46.6840634802217,
+            "minimum_longitude": -74.2264320002107,
+            "maximum_longitude": -73.170542359712,
+            "extracted_on": "2022-03-23T18:45:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/agence-metropolitaine-de-transport/134/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-agence-metropolitaine-de-transport-crt-lanaudiere-gtfs-1181.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-agence-metropolitaine-de-transport-gtfs-1179.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-agence-metropolitaine-de-transport-gtfs-1179.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1179,
+    "data_type": "gtfs",
+    "provider": "Agence métropolitaine de transport",
+    "name": "Express",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.4582983759636,
+            "maximum_latitude": 45.4982652034138,
+            "minimum_longitude": -73.5661781803096,
+            "maximum_longitude": -73.4418601064298,
+            "extracted_on": "2022-03-23T18:45:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/agence-metropolitaine-de-transport/129/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-agence-metropolitaine-de-transport-gtfs-1179.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-mrc-de-deux-montagnes-gtfs-1182.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-mrc-de-deux-montagnes-gtfs-1182.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1182,
+    "data_type": "gtfs",
+    "provider": "MRC de Deux-Montagnes",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Montreal",
+        "bounding_box": {
+            "minimum_latitude": 45.4605386048701,
+            "maximum_latitude": 45.5615424554029,
+            "minimum_longitude": -74.2064314458575,
+            "maximum_longitude": -73.8928390350279,
+            "extracted_on": "2022-03-23T18:45:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/agence-metropolitaine-de-transport/141/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-mrc-de-deux-montagnes-gtfs-1182.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-mrc-les-moulins-gtfs-1180.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-mrc-les-moulins-gtfs-1180.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1180,
+    "data_type": "gtfs",
+    "provider": "MRC les Moulins",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "bounding_box": {
+            "minimum_latitude": 45.5542,
+            "maximum_latitude": 45.80231,
+            "minimum_longitude": -73.842682,
+            "maximum_longitude": -73.498242,
+            "extracted_on": "2022-03-23T18:45:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/agence-metropolitaine-de-transport/142/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-mrc-les-moulins-gtfs-1180.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/co-distrito-capital-de-bogota-simur-bogota-gtfs-1204.json
+++ b/catalogs/sources/gtfs/schedule/co-distrito-capital-de-bogota-simur-bogota-gtfs-1204.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1204,
+    "data_type": "gtfs",
+    "provider": "SIMUR Bogota ",
+    "location": {
+        "country_code": "CO",
+        "subdivision_name": "Distrito Capital de Bogotá",
+        "bounding_box": {
+            "minimum_latitude": 4.4683111547019,
+            "maximum_latitude": 4.8168176729958,
+            "minimum_longitude": -74.2149329,
+            "maximum_longitude": -74.00431399641,
+            "extracted_on": "2022-03-23T18:56:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/simur-bogota/973/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/co-distrito-capital-de-bogota-simur-bogota-gtfs-1204.zip?alt=media",
+        "license": "http://www.simur.gov.co/gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-ostalbmobil-verkehrsverbund-gtfs-1202.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-ostalbmobil-verkehrsverbund-gtfs-1202.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1202,
+    "data_type": "gtfs",
+    "provider": "OstalbMobil – Verkehrsverbund",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Ostalbkreis",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 48.945571,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 10.436735,
+            "extracted_on": "2022-03-23T18:53:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ostalbmobil-verkehrsverbund/1236/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-ostalbmobil-verkehrsverbund-gtfs-1202.zip?alt=media",
+        "license": "https://www.nvbw.de/aufgaben/digitale-mobilitaet/lizenz/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-verkehrsverbund-rhein-neckar-gtfs-1173.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-verkehrsverbund-rhein-neckar-gtfs-1173.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1173,
+    "data_type": "gtfs",
+    "provider": "Verkehrsverbund Rhein-Neckar",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
+        "municipality": "Mannheim",
+        "bounding_box": {
+            "minimum_latitude": 48.9785761,
+            "maximum_latitude": 50.0404441,
+            "minimum_longitude": 7.2480389,
+            "maximum_longitude": 10.1944321,
+            "extracted_on": "2022-03-23T18:44:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/verkehrsverbund-rhein-neckar/1076/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-verkehrsverbund-rhein-neckar-gtfs-1173.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-burgerbus-leupoldsgrun-landkreis-hof-gtfs-1152.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-burgerbus-leupoldsgrun-landkreis-hof-gtfs-1152.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1152,
+    "data_type": "gtfs",
+    "provider": "Bürgerbus Leupoldsgrün (Landkreis Hof)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "municipality": "Leupoldsgrün",
+        "bounding_box": {
+            "minimum_latitude": 50.267313,
+            "maximum_latitude": 50.330725,
+            "minimum_longitude": 11.74581,
+            "maximum_longitude": 11.850072,
+            "extracted_on": "2022-03-23T18:33:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/b-rgerbus-leupoldsgr-n-landkreis-hof/1126/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-burgerbus-leupoldsgrun-landkreis-hof-gtfs-1152.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-thuringen-verkehrsverbund-mittelthuringen-vmt-gtfs-1172.json
+++ b/catalogs/sources/gtfs/schedule/de-thuringen-verkehrsverbund-mittelthuringen-vmt-gtfs-1172.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1172,
+    "data_type": "gtfs",
+    "provider": "Verkehrsverbund Mittelthüringen (VMT)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Thüringen",
+        "bounding_box": {
+            "minimum_latitude": 50.035311,
+            "maximum_latitude": 52.594718,
+            "minimum_longitude": 9.446892,
+            "maximum_longitude": 12.48745,
+            "extracted_on": "2022-03-23T18:42:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/verkehrsverbund-mittelth-ringen/1080/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-thuringen-verkehrsverbund-mittelthuringen-vmt-gtfs-1172.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-db-gtfs-1139.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-db-gtfs-1139.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1139,
+    "data_type": "gtfs",
+    "provider": "DB, SBB, EC, ÖBB, NS, DSB, MAV, CD, PKP, RE, DPN, RZD, SWX, CFL",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": 41.900492,
+            "maximum_latitude": 56.150076,
+            "minimum_longitude": 1.850178,
+            "maximum_longitude": 37.579809,
+            "extracted_on": "2022-03-23T18:31:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/deutsche-bahn/837/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-db-gtfs-1139.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-filsland-verkehrsverbund-gtfs-1183.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-filsland-verkehrsverbund-gtfs-1183.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1183,
+    "data_type": "gtfs",
+    "provider": "Filsland Verkehrsverbund",
+    "location": {
+        "country_code": "DE",
+        "bounding_box": {
+            "minimum_latitude": 48.398673,
+            "maximum_latitude": 48.806872,
+            "minimum_longitude": 9.41129,
+            "maximum_longitude": 10.02201,
+            "extracted_on": "2022-03-23T18:45:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/filsland-verkehrsverbund/1185/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-filsland-verkehrsverbund-gtfs-1183.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/dz-unknown-societe-nationale-des-transports-ferroviaires-sntf-algeria-gtfs-1199.json
+++ b/catalogs/sources/gtfs/schedule/dz-unknown-societe-nationale-des-transports-ferroviaires-sntf-algeria-gtfs-1199.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1199,
+    "data_type": "gtfs",
+    "provider": "Société Nationale des Transports Ferroviaires (SNTF Algeria)",
+    "location": {
+        "country_code": "DZ",
+        "bounding_box": {
+            "minimum_latitude": 35.538055,
+            "maximum_latitude": 36.895996,
+            "minimum_longitude": -0.638956,
+            "maximum_longitude": 7.758861,
+            "extracted_on": "2022-03-23T18:52:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/societe-nationale-des-transports-ferroviaires/1084/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/dz-unknown-societe-nationale-des-transports-ferroviaires-sntf-algeria-gtfs-1199.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-bizkaia-bizkaibus-gtfs-1135.json
+++ b/catalogs/sources/gtfs/schedule/es-bizkaia-bizkaibus-gtfs-1135.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1135,
+    "data_type": "gtfs",
+    "provider": "Bizkaibus",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Bizkaia",
+        "municipality": "Bilbao",
+        "bounding_box": {
+            "minimum_latitude": 42.9891535017202,
+            "maximum_latitude": 43.4318410207912,
+            "minimum_longitude": -3.43867522739185,
+            "maximum_longitude": -2.38826715430665,
+            "extracted_on": "2022-03-23T18:30:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/bizkaibus/653/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-bizkaia-bizkaibus-gtfs-1135.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-bizkaia-el-transbordador-de-vizcaya-gtfs-1162.json
+++ b/catalogs/sources/gtfs/schedule/es-bizkaia-el-transbordador-de-vizcaya-gtfs-1162.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1162,
+    "data_type": "gtfs",
+    "provider": "El Transbordador de Vizcaya",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Bizkaia",
+        "municipality": "Bilbao",
+        "bounding_box": {
+            "minimum_latitude": 43.3228,
+            "maximum_latitude": 43.323612,
+            "minimum_longitude": -3.018,
+            "maximum_longitude": -3.016314,
+            "extracted_on": "2022-03-23T18:38:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/transbordador-vizcaya/660/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-bizkaia-el-transbordador-de-vizcaya-gtfs-1162.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-bizkaia-la-union-gtfs-1196.json
+++ b/catalogs/sources/gtfs/schedule/es-bizkaia-la-union-gtfs-1196.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1196,
+    "data_type": "gtfs",
+    "provider": "La Union",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Bizkaia",
+        "municipality": "Bilbao",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 43.359077,
+            "minimum_longitude": -3.073337,
+            "maximum_longitude": 0.0,
+            "extracted_on": "2022-03-23T18:52:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/la-union/659/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-bizkaia-la-union-gtfs-1196.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-bizkaia-metro-bilbao-gtfs-1200.json
+++ b/catalogs/sources/gtfs/schedule/es-bizkaia-metro-bilbao-gtfs-1200.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1200,
+    "data_type": "gtfs",
+    "provider": "Metro Bilbao",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Bizkaia",
+        "municipality": "Bilbao",
+        "bounding_box": {
+            "minimum_latitude": 43.23521,
+            "maximum_latitude": 43.40162,
+            "minimum_longitude": -3.03896,
+            "maximum_longitude": -2.88125,
+            "extracted_on": "2022-03-23T18:53:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/metro-bilbao/656/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-bizkaia-metro-bilbao-gtfs-1200.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-gipuzkoa-dbus-gtfs-1191.json
+++ b/catalogs/sources/gtfs/schedule/es-gipuzkoa-dbus-gtfs-1191.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1191,
+    "data_type": "gtfs",
+    "provider": "dBus",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Gipuzkoa ",
+        "municipality": "San Sebastián ",
+        "bounding_box": {
+            "minimum_latitude": 43.2777689602104,
+            "maximum_latitude": 43.32593880362474,
+            "minimum_longitude": -2.0455710983006994,
+            "maximum_longitude": -1.9187707349818064,
+            "extracted_on": "2022-03-23T18:51:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/compania-del-tranvia-de-san-sebastian/702/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-gipuzkoa-dbus-gtfs-1191.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-kainuu-kajaani-gtfs-1136.json
+++ b/catalogs/sources/gtfs/schedule/fi-kainuu-kajaani-gtfs-1136.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1136,
+    "data_type": "gtfs",
+    "provider": "Kajaani",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Kainuu",
+        "municipality": "Kajaani",
+        "bounding_box": {
+            "minimum_latitude": 63.9509976744237,
+            "maximum_latitude": 64.3282317234578,
+            "minimum_longitude": 26.857811209272167,
+            "maximum_longitude": 28.0382467006859,
+            "extracted_on": "2022-03-23T18:30:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/city-of-kajaani/1103/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-kainuu-kajaani-gtfs-1136.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-hauts-de-france-reseau-de-transport-transpole-de-la-metropole-europeenne-de-lille-gtfs-1201.json
+++ b/catalogs/sources/gtfs/schedule/fr-hauts-de-france-reseau-de-transport-transpole-de-la-metropole-europeenne-de-lille-gtfs-1201.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1201,
+    "data_type": "gtfs",
+    "provider": "Réseau de transport Transpole de la Métropole Européenne de Lille",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Hauts-de-France",
+        "municipality": "Lille",
+        "bounding_box": {
+            "minimum_latitude": 50.528149,
+            "maximum_latitude": 50.788235,
+            "minimum_longitude": 2.801618,
+            "maximum_longitude": 3.273467,
+            "extracted_on": "2022-03-23T18:53:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/metropole-europeenne-de-lille/1202/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-hauts-de-france-reseau-de-transport-transpole-de-la-metropole-europeenne-de-lille-gtfs-1201.zip?alt=media",
+        "license": "https://opendata.lillemetropole.fr/explore/dataset/transport_arret_transpole-point/?disjunctive.filename&disjunctive.commune"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-ile-de-france-star-gtfs-1159.json
+++ b/catalogs/sources/gtfs/schedule/fr-ile-de-france-star-gtfs-1159.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1159,
+    "data_type": "gtfs",
+    "provider": "STAR",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Île-de-France",
+        "municipality": "Paris",
+        "bounding_box": {
+            "minimum_latitude": 47.959332,
+            "maximum_latitude": 48.2997,
+            "minimum_longitude": -1.945373,
+            "maximum_longitude": -1.478264,
+            "extracted_on": "2022-03-23T18:34:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/star/208/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-ile-de-france-star-gtfs-1159.zip?alt=media",
+        "license": "https://data.explore.star.fr/explore/dataset/tco-busmetro-horaires-gtfs-versions-td/information/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-ter-pays-de-la-loire-gtfs-1153.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-ter-pays-de-la-loire-gtfs-1153.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1153,
+    "data_type": "gtfs",
+    "provider": "TER Pays de la Loire",
+    "name": "Trains régionaux",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Pays-de-la-Loire",
+        "bounding_box": {
+            "minimum_latitude": 46.1527013855,
+            "maximum_latitude": 49.1765435198,
+            "minimum_longitude": -4.4789179163,
+            "maximum_longitude": 2.3198944238,
+            "extracted_on": "2022-03-23T18:33:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/1072/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-ter-pays-de-la-loire-gtfs-1153.zip?alt=media",
+        "license": "http://opendatacommons.org/licenses/odbl/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-unknown-ter-sncf-gtfs-1205.json
+++ b/catalogs/sources/gtfs/schedule/fr-unknown-ter-sncf-gtfs-1205.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1205,
+    "data_type": "gtfs",
+    "provider": "TER SNCF",
+    "location": {
+        "country_code": "FR",
+        "bounding_box": {
+            "minimum_latitude": 42.419967,
+            "maximum_latitude": 51.030466,
+            "minimum_longitude": -4.763926,
+            "maximum_longitude": 8.2796,
+            "extracted_on": "2022-03-23T18:56:09+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/sncf/1069/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-unknown-ter-sncf-gtfs-1205.zip?alt=media",
+        "license": "https://data.sncf.com/pages/cgu/A1#A1"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/gr-thessaloniki-trainose-gtfs-1161.json
+++ b/catalogs/sources/gtfs/schedule/gr-thessaloniki-trainose-gtfs-1161.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1161,
+    "data_type": "gtfs",
+    "provider": "TRAINOSE",
+    "location": {
+        "country_code": "GR",
+        "subdivision_name": "Thessaloniki",
+        "bounding_box": {
+            "minimum_latitude": 37.64566,
+            "maximum_latitude": 42.71287,
+            "minimum_longitude": 21.41504,
+            "maximum_longitude": 26.62184,
+            "extracted_on": "2022-03-23T18:38:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/trainose/1193/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gr-thessaloniki-trainose-gtfs-1161.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hr-grad-zagreb-zagrebacki-elektricni-tramvaj-zet-gtfs-1184.json
+++ b/catalogs/sources/gtfs/schedule/hr-grad-zagreb-zagrebacki-elektricni-tramvaj-zet-gtfs-1184.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1184,
+    "data_type": "gtfs",
+    "provider": "Zagrebački Električni Tramvaj (ZET)",
+    "location": {
+        "country_code": "HR",
+        "subdivision_name": "Grad Zagreb",
+        "bounding_box": {
+            "minimum_latitude": 45.567096,
+            "maximum_latitude": 45.96829,
+            "minimum_longitude": 15.733412,
+            "maximum_longitude": 16.229453,
+            "extracted_on": "2022-03-23T18:46:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/zet-zagreba-ki-elektri-ni-tramvaj/1007/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hr-grad-zagreb-zagrebacki-elektricni-tramvaj-zet-gtfs-1184.zip?alt=media",
+        "license": "https://www.zet.hr/odredbe/datoteke-u-gtfs-formatu/669"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/il-unknown-ministry-of-transport-and-road-safety-gtfs-1134.json
+++ b/catalogs/sources/gtfs/schedule/il-unknown-ministry-of-transport-and-road-safety-gtfs-1134.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1134,
+    "data_type": "gtfs",
+    "provider": "Ministry of Transport and Road Safety ",
+    "location": {
+        "country_code": "IL",
+        "bounding_box": {
+            "minimum_latitude": 29.492446,
+            "maximum_latitude": 33.283674,
+            "minimum_longitude": 34.284672,
+            "maximum_longitude": 35.839108,
+            "extracted_on": "2022-03-23T18:30:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ministry-of-transport-and-road-safety/820/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/il-unknown-ministry-of-transport-and-road-safety-gtfs-1134.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-lombardia-airpullmann-gtfs-1185.json
+++ b/catalogs/sources/gtfs/schedule/it-lombardia-airpullmann-gtfs-1185.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1185,
+    "data_type": "gtfs",
+    "provider": "Airpullmann",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Lombardia",
+        "municipality": "Milan",
+        "bounding_box": {
+            "minimum_latitude": 45.4938828184547,
+            "maximum_latitude": 45.741949,
+            "minimum_longitude": 8.89007716567612,
+            "maximum_longitude": 9.21534086871719,
+            "extracted_on": "2022-03-23T18:47:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/air-pullman-s-p-a/1233/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lombardia-airpullmann-gtfs-1185.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-piemonte-bus-company-srl-gtfs-1194.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-bus-company-srl-gtfs-1194.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1194,
+    "data_type": "gtfs",
+    "provider": "Bus Company S.r.l., Gunetto Autolinee S.r.l., Bus Company S.r.l., GelosoBus S.r.l., RT Piemonte S.r.l., Autolinee Nuova Benese S.r.l., Autolinee Allasia S.r.l., Nuova S.A.A.R. S.r.l., SAV Autolinee S.r.l., S.A.C. S.r.l., Autolinee Valle Pesio S.r.l., ACTP S.r.l., Nuova Beccaria S.r.l., Giors S.n.c., Consorzio Trasporti GRANDA BUS",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Piemonte",
+        "municipality": "Cuneo",
+        "bounding_box": {
+            "minimum_latitude": 43.8792200012265,
+            "maximum_latitude": 45.2725800012072,
+            "minimum_longitude": 6.93821999981286,
+            "maximum_longitude": 8.47731999998803,
+            "extracted_on": "2022-03-23T18:52:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/cuneo/622/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-bus-company-srl-gtfs-1194.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-piemonte-bus-regione-piemonte-gtfs-1138.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-bus-regione-piemonte-gtfs-1138.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1138,
+    "data_type": "gtfs",
+    "provider": "Bus Regione Piemonte",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Piemonte",
+        "bounding_box": {
+            "minimum_latitude": 43.891129,
+            "maximum_latitude": 46.41969,
+            "minimum_longitude": 6.658442,
+            "maximum_longitude": 9.176198,
+            "extracted_on": "2022-03-23T18:31:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/cuneo/1191/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-bus-regione-piemonte-gtfs-1138.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-piemonte-gruppo-torinese-trasporti-gtfs-1142.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-gruppo-torinese-trasporti-gtfs-1142.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1142,
+    "data_type": "gtfs",
+    "provider": "Gruppo Torinese Trasporti",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Piemonte",
+        "municipality": "Turin",
+        "bounding_box": {
+            "minimum_latitude": 44.3852,
+            "maximum_latitude": 45.55424,
+            "minimum_longitude": 7.19198,
+            "maximum_longitude": 8.45961,
+            "extracted_on": "2022-03-23T18:32:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/gruppo-torinese-trasporti/51/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-gruppo-torinese-trasporti-gtfs-1142.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-piemonte-regione-piemonte-gtfs-1154.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-regione-piemonte-gtfs-1154.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1154,
+    "data_type": "gtfs",
+    "provider": "Regione Piemonte",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Piemonte",
+        "bounding_box": {
+            "minimum_latitude": 43.891129,
+            "maximum_latitude": 46.41969,
+            "minimum_longitude": 6.658442,
+            "maximum_longitude": 9.176198,
+            "extracted_on": "2022-03-23T18:33:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/regione-piemonte/1192/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-regione-piemonte-gtfs-1154.zip?alt=media",
+        "license": "http://www.dati.piemonte.it/catalogodati/dato/100939-.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-piemonte-trenitalia-piemonte-gtfs-1170.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-trenitalia-piemonte-gtfs-1170.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1170,
+    "data_type": "gtfs",
+    "provider": "Trenitalia Piemonte",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Piemonte",
+        "bounding_box": {
+            "minimum_latitude": 43.789494,
+            "maximum_latitude": 46.115411,
+            "minimum_longitude": 6.657883,
+            "maximum_longitude": 9.238299,
+            "extracted_on": "2022-03-23T18:41:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/trenitalia-dtr-piemonte/931/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-trenitalia-piemonte-gtfs-1170.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-puglia-mobilita-e-trasporti-molfetta-gtfs-1147.json
+++ b/catalogs/sources/gtfs/schedule/it-puglia-mobilita-e-trasporti-molfetta-gtfs-1147.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1147,
+    "data_type": "gtfs",
+    "provider": "Mobilità e Trasporti Molfetta",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Puglia",
+        "municipality": "Molfetta",
+        "bounding_box": {
+            "minimum_latitude": 41.1724305772135,
+            "maximum_latitude": 41.2143614292278,
+            "minimum_longitude": 16.5415012977306,
+            "maximum_longitude": 16.613556,
+            "extracted_on": "2022-03-23T18:32:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mobilita-e-trasporti-molfetta/411/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-puglia-mobilita-e-trasporti-molfetta-gtfs-1147.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-collegamenti-marittimi-grimaldi-gtfs-1192.json
+++ b/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-collegamenti-marittimi-grimaldi-gtfs-1192.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1192,
+    "data_type": "gtfs",
+    "provider": "Collegamenti marittimi Grimaldi",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Regione Autonoma della Sardegna",
+        "bounding_box": {
+            "minimum_latitude": 35.78928874574407,
+            "maximum_latitude": 44.411405000188,
+            "minimum_longitude": -5.803751351906152,
+            "maximum_longitude": 15.0918573,
+            "extracted_on": "2022-03-23T18:51:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/collegamenti-marittimi-moby/1163/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-regione-autonoma-della-sardegna-collegamenti-marittimi-grimaldi-gtfs-1192.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-consorzio-trasporti-e-mobilita-ctm-cagliari-gtfs-1193.json
+++ b/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-consorzio-trasporti-e-mobilita-ctm-cagliari-gtfs-1193.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1193,
+    "data_type": "gtfs",
+    "provider": "Consorzio Trasporti e Mobilità (CTM Cagliari)",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Regione Autonoma della Sardegna",
+        "municipality": "Cagliari",
+        "bounding_box": {
+            "minimum_latitude": 39.186884464,
+            "maximum_latitude": 39.3098295692,
+            "minimum_longitude": 8.96281474474,
+            "maximum_longitude": 9.3399880924,
+            "extracted_on": "2022-03-23T18:52:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ctm-cagliari/1098/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-regione-autonoma-della-sardegna-consorzio-trasporti-e-mobilita-ctm-cagliari-gtfs-1193.zip?alt=media",
+        "license": "http://dati.regione.sardegna.it/dataset/quadri-orari-ctm"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-unknown-autolinee-mugello-valdisieve-gtfs-1177.json
+++ b/catalogs/sources/gtfs/schedule/it-unknown-autolinee-mugello-valdisieve-gtfs-1177.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1177,
+    "data_type": "gtfs",
+    "provider": "Autolinee Mugello Valdisieve",
+    "location": {
+        "country_code": "IT",
+        "bounding_box": {
+            "minimum_latitude": 43.7199842176331,
+            "maximum_latitude": 44.2223466120114,
+            "minimum_longitude": 11.0681514414699,
+            "maximum_longitude": 11.7987536850543,
+            "extracted_on": "2022-03-23T18:45:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/autolinee-mugello-valdisieve/750/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-unknown-autolinee-mugello-valdisieve-gtfs-1177.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-shizuoka-shimada-local-voluntary-operation-bus-gtfs-1149.json
+++ b/catalogs/sources/gtfs/schedule/jp-shizuoka-shimada-local-voluntary-operation-bus-gtfs-1149.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1149,
+    "data_type": "gtfs",
+    "provider": "Shimada Local Voluntary Operation Bus",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Shizuoka",
+        "municipality": "Shimada",
+        "bounding_box": {
+            "minimum_latitude": 34.68244,
+            "maximum_latitude": 35.0380483,
+            "minimum_longitude": 138.0763843,
+            "maximum_longitude": 138.237775,
+            "extracted_on": "2022-03-23T18:32:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/opentransit/588/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-shizuoka-shimada-local-voluntary-operation-bus-gtfs-1149.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/no-oslo-ruter-gtfs-1156.json
+++ b/catalogs/sources/gtfs/schedule/no-oslo-ruter-gtfs-1156.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1156,
+    "data_type": "gtfs",
+    "provider": "Ruter, Ãstfold kollektivtrafikk, Hedmark trafikk, Opplandstrafikk",
+    "location": {
+        "country_code": "NO",
+        "subdivision_name": "Oslo",
+        "bounding_box": {
+            "minimum_latitude": 58.8791012,
+            "maximum_latitude": 63.4361997,
+            "minimum_longitude": 5.3215386,
+            "maximum_longitude": 12.8117226,
+            "extracted_on": "2022-03-23T18:33:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ruter/240/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/no-oslo-ruter-gtfs-1156.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/nz-unknown-intercity-group-gtfs-1144.json
+++ b/catalogs/sources/gtfs/schedule/nz-unknown-intercity-group-gtfs-1144.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1144,
+    "data_type": "gtfs",
+    "provider": "InterCity Group",
+    "location": {
+        "country_code": "NZ",
+        "bounding_box": {
+            "minimum_latitude": -46.4118867,
+            "maximum_latitude": -34.990532,
+            "minimum_longitude": 167.714045,
+            "maximum_longitude": 178.020433,
+            "extracted_on": "2022-03-23T18:32:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/intercity-group/744/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nz-unknown-intercity-group-gtfs-1144.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-bielawa-dzierzoniow-gtfs-1151.json
+++ b/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-bielawa-dzierzoniow-gtfs-1151.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1151,
+    "data_type": "gtfs",
+    "provider": "Komunikacja Miejska Bielawa Dzierżoniów",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Dolnoslaskie",
+        "municipality": "Bielawa",
+        "bounding_box": {
+            "minimum_latitude": 50.59326,
+            "maximum_latitude": 50.75193,
+            "minimum_longitude": 16.52527,
+            "maximum_longitude": 16.85735,
+            "extracted_on": "2022-03-23T18:33:03+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/przyjazdy-pl/1206/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-dolnoslaskie-komunikacja-miejska-bielawa-dzierzoniow-gtfs-1151.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-plock-gtfs-1150.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-plock-gtfs-1150.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1150,
+    "data_type": "gtfs",
+    "provider": "Komunikacja Miejska Płock",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Mazowieckie",
+        "municipality": "Plock",
+        "bounding_box": {
+            "minimum_latitude": 52.40001,
+            "maximum_latitude": 52.7391306798103,
+            "minimum_longitude": 19.4006725,
+            "maximum_longitude": 20.1042322,
+            "extracted_on": "2022-03-23T18:33:00+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/przyjazdy-pl-plock/1211/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-komunikacja-miejska-plock-gtfs-1150.zip?alt=media",
+        "license": "https://gtfs.pl/gtfs/plock"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-rybnik-ztz-rybnik-gtfs-1176.json
+++ b/catalogs/sources/gtfs/schedule/pl-rybnik-ztz-rybnik-gtfs-1176.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1176,
+    "data_type": "gtfs",
+    "provider": "ZTZ Rybnik",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Rybnik",
+        "municipality": "Śląskie",
+        "bounding_box": {
+            "minimum_latitude": 50.00251964423,
+            "maximum_latitude": 50.19273439418,
+            "minimum_longitude": 18.286475,
+            "maximum_longitude": 18.69397495643,
+            "extracted_on": "2022-03-23T18:44:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ztz-rybnik/1114/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-rybnik-ztz-rybnik-gtfs-1176.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-warminsko-mazurskie-zdzit-olsztyn-gtfs-1175.json
+++ b/catalogs/sources/gtfs/schedule/pl-warminsko-mazurskie-zdzit-olsztyn-gtfs-1175.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1175,
+    "data_type": "gtfs",
+    "provider": "ZDZiT Olsztyn",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Warmińsko-mazurskie",
+        "municipality": "Olsztyn",
+        "bounding_box": {
+            "minimum_latitude": 53.58403497,
+            "maximum_latitude": 53.987067,
+            "minimum_longitude": 20.28459222,
+            "maximum_longitude": 20.746555,
+            "extracted_on": "2022-03-23T18:44:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/zdzit-olsztyn/993/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-warminsko-mazurskie-zdzit-olsztyn-gtfs-1175.zip?alt=media",
+        "license": "https://www.zdzit.olsztyn.eu/pl/transport-publiczny/dane-rozkladowe"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pt-lisboa-rodoviaria-de-lisboa-gtfs-1155.json
+++ b/catalogs/sources/gtfs/schedule/pt-lisboa-rodoviaria-de-lisboa-gtfs-1155.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1155,
+    "data_type": "gtfs",
+    "provider": "Rodoviária de Lisboa",
+    "location": {
+        "country_code": "PT",
+        "subdivision_name": "Lisboa",
+        "bounding_box": {
+            "minimum_latitude": 38.7434172392276,
+            "maximum_latitude": 38.9770062842821,
+            "minimum_longitude": -9.29831878012572,
+            "maximum_longitude": -9.02670437706732,
+            "extracted_on": "2022-03-23T18:33:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/rodoviaria-de-lisboa/998/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-lisboa-rodoviaria-de-lisboa-gtfs-1155.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ru-sankt-peterburg-peterburgskii-metropoliten-petersburg-metro-gtfs-1186.json
+++ b/catalogs/sources/gtfs/schedule/ru-sankt-peterburg-peterburgskii-metropoliten-petersburg-metro-gtfs-1186.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1186,
+    "data_type": "gtfs",
+    "provider": "Петербургский метрополитен - Petersburg Metro",
+    "location": {
+        "country_code": "RU",
+        "subdivision_name": "Sankt-Peterburg",
+        "bounding_box": {
+            "minimum_latitude": 59.550571,
+            "maximum_latitude": 60.363597,
+            "minimum_longitude": 28.971031,
+            "maximum_longitude": 31.278776,
+            "extracted_on": "2022-03-23T18:50:21+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/saint-petersburg/826/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ru-sankt-peterburg-peterburgskii-metropoliten-petersburg-metro-gtfs-1186.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-western-chiang-mai-gtfs-1137.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-western-chiang-mai-gtfs-1137.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1137,
+    "data_type": "gtfs",
+    "provider": "Western Chiang Mai",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai",
+        "bounding_box": {
+            "minimum_latitude": 18.6505627,
+            "maximum_latitude": 19.3744147,
+            "minimum_longitude": 98.9841306,
+            "maximum_longitude": 99.5178118,
+            "extracted_on": "2022-03-23T18:31:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/coopthai-nct/799/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-western-chiang-mai-gtfs-1137.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tn-medenine-srtmedenine-gtfs-1158.json
+++ b/catalogs/sources/gtfs/schedule/tn-medenine-srtmedenine-gtfs-1158.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1158,
+    "data_type": "gtfs",
+    "provider": "SRTMedenine",
+    "location": {
+        "country_code": "TN",
+        "subdivision_name": "Médenine",
+        "bounding_box": {
+            "minimum_latitude": 32.010672,
+            "maximum_latitude": 34.722848,
+            "minimum_longitude": 9.983225,
+            "maximum_longitude": 11.5514679,
+            "extracted_on": "2022-03-23T18:33:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/srtmedenine/1204/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tn-medenine-srtmedenine-gtfs-1158.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arizona-mountain-line-gtfs-1148.json
+++ b/catalogs/sources/gtfs/schedule/us-arizona-mountain-line-gtfs-1148.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1148,
+    "data_type": "gtfs",
+    "provider": "Mountain Line",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arizona",
+        "municipality": "Flagstaff",
+        "bounding_box": {
+            "minimum_latitude": 35.142631,
+            "maximum_latitude": 35.330199,
+            "minimum_longitude": -111.710555,
+            "maximum_longitude": -111.573353,
+            "extracted_on": "2022-03-23T18:32:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mountain-line/243/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arizona-mountain-line-gtfs-1148.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-arkansas-rock-region-metro-gtfs-1190.json
+++ b/catalogs/sources/gtfs/schedule/us-arkansas-rock-region-metro-gtfs-1190.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1190,
+    "data_type": "gtfs",
+    "provider": "Rock Region Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Arkansas",
+        "municipality": "Little Rock",
+        "bounding_box": {
+            "minimum_latitude": 34.504759,
+            "maximum_latitude": 34.903348,
+            "minimum_longitude": -92.497724,
+            "maximum_longitude": -92.115707,
+            "extracted_on": "2022-03-23T18:51:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/central-arkansas-transit-authority/334/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-arkansas-rock-region-metro-gtfs-1190.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-altamont-corridor-express-gtfs-1133.json
+++ b/catalogs/sources/gtfs/schedule/us-california-altamont-corridor-express-gtfs-1133.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1133,
+    "data_type": "gtfs",
+    "provider": "Altamont Corridor Express",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Stockton",
+        "bounding_box": {
+            "minimum_latitude": 37.329568,
+            "maximum_latitude": 37.957058,
+            "minimum_longitude": -122.007598,
+            "maximum_longitude": -121.263664,
+            "extracted_on": "2022-03-23T18:28:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/altamont-corridor-express/823/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-altamont-corridor-express-gtfs-1133.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-blue-gold-fleet-gtfs-1178.json
+++ b/catalogs/sources/gtfs/schedule/us-california-blue-gold-fleet-gtfs-1178.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1178,
+    "data_type": "gtfs",
+    "provider": "Blue & Gold Fleet",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.662676,
+            "maximum_latitude": 38.10127,
+            "minimum_longitude": -122.41209,
+            "maximum_longitude": -122.25692,
+            "extracted_on": "2022-03-23T18:45:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/blue-gold-fleet/824/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-blue-gold-fleet-gtfs-1178.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-long-beach-transit-lbt-gtfs-1198.json
+++ b/catalogs/sources/gtfs/schedule/us-california-long-beach-transit-lbt-gtfs-1198.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1198,
+    "data_type": "gtfs",
+    "provider": "Long Beach Transit (LBT)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Long Beach",
+        "bounding_box": {
+            "minimum_latitude": 33.742939,
+            "maximum_latitude": 34.069347,
+            "minimum_longitude": -118.447726,
+            "maximum_longitude": -118.063516,
+            "extracted_on": "2022-03-23T18:52:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/long-beach-transit/704/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-long-beach-transit-lbt-gtfs-1198.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-san-francisco-bay-ferry-gtfs-1195.json
+++ b/catalogs/sources/gtfs/schedule/us-california-san-francisco-bay-ferry-gtfs-1195.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1195,
+    "data_type": "gtfs",
+    "provider": "San Francisco Bay Ferry",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "San Francisco",
+        "bounding_box": {
+            "minimum_latitude": 37.662676,
+            "maximum_latitude": 38.10127,
+            "minimum_longitude": -122.41209,
+            "maximum_longitude": -122.25692,
+            "extracted_on": "2022-03-23T18:52:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/golden-gate-bridge-highway-transportation-district/344/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-san-francisco-bay-ferry-gtfs-1195.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-i-ride-trolley-i-ride-gtfs-1143.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-i-ride-trolley-i-ride-gtfs-1143.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1143,
+    "data_type": "gtfs",
+    "provider": "I-RIDE Trolley (I-RIDE)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Orlando",
+        "bounding_box": {
+            "minimum_latitude": 28.386124,
+            "maximum_latitude": 28.485502523023698,
+            "minimum_longitude": -81.489451,
+            "maximum_longitude": -81.450202,
+            "extracted_on": "2022-03-23T18:32:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/i-ride-trolley/909/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-i-ride-trolley-i-ride-gtfs-1143.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-florida-sanford-trolley-gtfs-1157.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-sanford-trolley-gtfs-1157.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1157,
+    "data_type": "gtfs",
+    "provider": "Sanford Trolley",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Florida",
+        "municipality": "Sanford",
+        "bounding_box": {
+            "minimum_latitude": 28.807973368798734,
+            "maximum_latitude": 28.813954863341745,
+            "minimum_longitude": -81.298514,
+            "maximum_longitude": -81.25601599140168,
+            "extracted_on": "2022-03-23T18:33:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/sanford-trolley/947/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-sanford-trolley-gtfs-1157.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-georgia-grta-gtfs-1141.json
+++ b/catalogs/sources/gtfs/schedule/us-georgia-grta-gtfs-1141.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1141,
+    "data_type": "gtfs",
+    "provider": "GRTA",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Georgia",
+        "municipality": "Atlanta",
+        "bounding_box": {
+            "minimum_latitude": 33.381316,
+            "maximum_latitude": 34.181736,
+            "minimum_longitude": -84.773527,
+            "maximum_longitude": -83.907051,
+            "extracted_on": "2022-03-23T18:31:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/grta/66/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-georgia-grta-gtfs-1141.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-metra-gtfs-1187.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-metra-gtfs-1187.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1187,
+    "data_type": "gtfs",
+    "provider": "Metra",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Chicago",
+        "bounding_box": {
+            "minimum_latitude": 41.4183333,
+            "maximum_latitude": 42.5858333,
+            "minimum_longitude": -88.6175,
+            "maximum_longitude": -87.5477778,
+            "extracted_on": "2022-03-23T18:50:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/metra/169/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-metra-gtfs-1187.zip?alt=media",
+        "license": "https://metrarail.com/developers"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-citilink-gtfs-1140.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-citilink-gtfs-1140.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1140,
+    "data_type": "gtfs",
+    "provider": "Citilink",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "Fort Wayne",
+        "bounding_box": {
+            "minimum_latitude": 41.006285,
+            "maximum_latitude": 41.190369,
+            "minimum_longitude": -85.27113,
+            "maximum_longitude": -85.013817,
+            "extracted_on": "2022-03-23T18:31:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/fort-wayne-citilink/378/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-citilink-gtfs-1140.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-kansas-the-jo-gtfs-1160.json
+++ b/catalogs/sources/gtfs/schedule/us-kansas-the-jo-gtfs-1160.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1160,
+    "data_type": "gtfs",
+    "provider": "The JO",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Kansas",
+        "municipality": "Johnson County",
+        "bounding_box": {
+            "minimum_latitude": 38.9007720170609,
+            "maximum_latitude": 38.9559226310118,
+            "minimum_longitude": -95.2634120264484,
+            "maximum_longitude": -94.7252041850774,
+            "extracted_on": "2022-03-23T18:34:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/the-jo/632/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-kansas-the-jo-gtfs-1160.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-maryland-saint-marys-transit-system-gtfs-1203.json
+++ b/catalogs/sources/gtfs/schedule/us-maryland-saint-marys-transit-system-gtfs-1203.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1203,
+    "data_type": "gtfs",
+    "provider": "Saint Mary's Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Maryland",
+        "bounding_box": {
+            "minimum_latitude": 38.108913,
+            "maximum_latitude": 38.500123,
+            "minimum_longitude": -76.832048,
+            "maximum_longitude": -76.365933,
+            "extracted_on": "2022-03-23T18:54:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/saint-marys-transit-system/1147/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-maryland-saint-marys-transit-system-gtfs-1203.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-missouri-madison-county-transit-gtfs-1145.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-madison-county-transit-gtfs-1145.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1145,
+    "data_type": "gtfs",
+    "provider": "Madison County Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Missouri",
+        "municipality": "St. Louis",
+        "bounding_box": {
+            "minimum_latitude": 38.624521,
+            "maximum_latitude": 38.964669,
+            "minimum_longitude": -90.280942,
+            "maximum_longitude": -89.697,
+            "extracted_on": "2022-03-23T18:32:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/madison-county-transit/1146/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-missouri-madison-county-transit-gtfs-1145.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-nebraska-startran-gtfs-1188.json
+++ b/catalogs/sources/gtfs/schedule/us-nebraska-startran-gtfs-1188.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1188,
+    "data_type": "gtfs",
+    "provider": "StarTran",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Nebraska",
+        "municipality": "Lincoln",
+        "bounding_box": {
+            "minimum_latitude": 40.7191025396787,
+            "maximum_latitude": 40.8814743304285,
+            "minimum_longitude": -96.7955738344476,
+            "maximum_longitude": -96.5915007479686,
+            "extracted_on": "2022-03-23T18:50:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/startran/781/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-nebraska-startran-gtfs-1188.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-south-carolina-the-comet-gtfs-1197.json
+++ b/catalogs/sources/gtfs/schedule/us-south-carolina-the-comet-gtfs-1197.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1197,
+    "data_type": "gtfs",
+    "provider": "The Comet",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "South Carolina",
+        "municipality": "Columbia",
+        "bounding_box": {
+            "minimum_latitude": 33.83011,
+            "maximum_latitude": 34.293952,
+            "minimum_longitude": -81.604142,
+            "maximum_longitude": -80.3393590826346,
+            "extracted_on": "2022-03-23T18:52:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/thecomet-sc-us/thecomet-sc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-south-carolina-the-comet-gtfs-1197.zip?alt=media",
+        "license": "http://data.trilliumtransit.com/gtfs/thecomet-sc-us/thecomet-sc-us.zip"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-utah-uta-gtfs-1171.json
+++ b/catalogs/sources/gtfs/schedule/us-utah-uta-gtfs-1171.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1171,
+    "data_type": "gtfs",
+    "provider": "UTA",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Utah",
+        "municipality": "Salt Lake City",
+        "bounding_box": {
+            "minimum_latitude": 39.975518,
+            "maximum_latitude": 41.528157,
+            "minimum_longitude": -112.325431,
+            "maximum_longitude": -111.546827,
+            "extracted_on": "2022-03-23T18:42:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/utah-transportation-authority/59/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-utah-uta-gtfs-1171.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-blacksburg-transit-gtfs-1189.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-blacksburg-transit-gtfs-1189.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1189,
+    "data_type": "gtfs",
+    "provider": "Blacksburg Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Blacksburg",
+        "bounding_box": {
+            "minimum_latitude": 37.1264581159626,
+            "maximum_latitude": 37.2561040375295,
+            "minimum_longitude": -80.4504797131109,
+            "maximum_longitude": -80.3700000268221,
+            "extracted_on": "2022-03-23T18:51:05+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/blacksburg-transit/359/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-blacksburg-transit-gtfs-1189.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the seventeenth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 74 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~