### PR TITLE
fix: Columns behavior in export_to_csv.yml

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -3,6 +3,8 @@ name: Export catalogs to CSV
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   export-to-csv:
@@ -99,8 +101,11 @@ jobs:
             path = CSV_PATH
             columns = CSV_COLUMNS
             catalog = pd.json_normalize(catalog)
-            if columns is not None:
-                catalog = catalog[columns]
+            tmp = pd.DataFrame()
+            for column in columns:
+                if column in catalog:
+                    tmp[column] = catalog[column]
+            catalog = tmp
             if STATIC_REFERENCE in catalog:
                 catalog[STATIC_REFERENCE] = catalog[STATIC_REFERENCE].astype('Int64')
             catalog.to_csv(path, sep=",", index=False)

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -3,8 +3,6 @@ name: Export catalogs to CSV
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   export-to-csv:


### PR DESCRIPTION
**Summary:**

Fixes #116: Export to CSV workflow fails because of the columns

This PR modifies the `export_to_csv.yml` workflow so that the columns are processed one by one only if they exist in at least one source. Eg. if there is no GTFS Realtime source, then the static_reference column won't be added and no exception will be raised.

Changes:
- `export_to_csv.yml` is updated.

**Expected behavior:** 
The workflow should run on push to main without failing.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~