### PR TITLE
feat: Eighteenth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ar-buenos-aires-colectivos-buenos-aires-gtfs-1220.json
+++ b/catalogs/sources/gtfs/schedule/ar-buenos-aires-colectivos-buenos-aires-gtfs-1220.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1220,
+    "data_type": "gtfs",
+    "provider": "Colectivos Buenos Aires",
+    "location": {
+        "country_code": "AR",
+        "subdivision_name": "Buenos Aires",
+        "bounding_box": {
+            "minimum_latitude": -35.182685,
+            "maximum_latitude": -34.042402,
+            "minimum_longitude": -60.97663,
+            "maximum_longitude": -57.730345,
+            "extracted_on": "2022-03-23T23:10:49+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/colectivos-buenos-aires/1037/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ar-buenos-aires-colectivos-buenos-aires-gtfs-1220.zip?alt=media",
+        "license": "https://data.buenosaires.gob.ar/dataset/colectivos-gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/at-wien-wiener-linien-gtfs-1213.json
+++ b/catalogs/sources/gtfs/schedule/at-wien-wiener-linien-gtfs-1213.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1213,
+    "data_type": "gtfs",
+    "provider": "Wiener Linien",
+    "location": {
+        "country_code": "AT",
+        "subdivision_name": "Wien",
+        "bounding_box": {
+            "minimum_latitude": 47.9995020902886,
+            "maximum_latitude": 48.3011051975429,
+            "minimum_longitude": 16.1982145929827,
+            "maximum_longitude": 16.5494289196638,
+            "extracted_on": "2022-03-23T23:05:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.wien.gv.at/data/zip/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/at-wien-wiener-linien-gtfs-1213.zip?alt=media",
+        "license": "https://www.data.gv.at/katalog/dataset/ab4a73b6-1c2d-42e1-b4d9-049e04889cf0"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1214.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1214.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1214,
+    "data_type": "gtfs",
+    "provider": "TransLink Brisbane ",
+    "name": "Airlie Beach ",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Airlie Beach ",
+        "bounding_box": {
+            "minimum_latitude": -20.406011,
+            "maximum_latitude": -20.264272,
+            "minimum_longitude": 148.57356,
+            "maximum_longitude": 148.785562,
+            "extracted_on": "2022-03-23T23:05:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/4/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-brisbane-gtfs-1214.zip?alt=media",
+        "license": "https://data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/2f002735-7373-46f0-b63d-8ba3a0b28f65"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1215.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1215.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1215,
+    "data_type": "gtfs",
+    "provider": "TransLink Brisbane ",
+    "name": "Bundaberg",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Bundaberg",
+        "bounding_box": {
+            "minimum_latitude": -24.92194,
+            "maximum_latitude": -24.695965,
+            "minimum_longitude": 152.239464,
+            "maximum_longitude": 152.492233,
+            "extracted_on": "2022-03-23T23:05:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/6/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-brisbane-gtfs-1215.zip?alt=media",
+        "license": "https://data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/699184c3-8c0e-44db-8a83-7e23709aefbe"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1216.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1216.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1216,
+    "data_type": "gtfs",
+    "provider": "TransLink Brisbane ",
+    "name": "Gympie",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Gympie",
+        "bounding_box": {
+            "minimum_latitude": -26.223348,
+            "maximum_latitude": -25.901583,
+            "minimum_longitude": 152.639085,
+            "maximum_longitude": 153.091887,
+            "extracted_on": "2022-03-23T23:05:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/9/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-brisbane-gtfs-1216.zip?alt=media",
+        "license": "https://data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/254f67be-ea12-4da1-8475-c5424359290e"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1217.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1217.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1217,
+    "data_type": "gtfs",
+    "provider": "TransLink Brisbane ",
+    "name": "Kilcoy",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Kilcoy",
+        "bounding_box": {
+            "minimum_latitude": -27.1031,
+            "maximum_latitude": -26.923223,
+            "minimum_longitude": 152.564827,
+            "maximum_longitude": 152.962316,
+            "extracted_on": "2022-03-23T23:05:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/11/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-brisbane-gtfs-1217.zip?alt=media",
+        "license": "https://data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/254f67be-ea12-4da1-8475-c5424359290e"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1218.json
+++ b/catalogs/sources/gtfs/schedule/au-queensland-translink-brisbane-gtfs-1218.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1218,
+    "data_type": "gtfs",
+    "provider": "TransLink Brisbane ",
+    "name": "Yeppoon",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Queensland",
+        "municipality": "Yeppoon",
+        "bounding_box": {
+            "minimum_latitude": -23.638604,
+            "maximum_latitude": -23.099315,
+            "minimum_longitude": 150.387628,
+            "maximum_longitude": 150.826186,
+            "extracted_on": "2022-03-23T23:05:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink/20/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-queensland-translink-brisbane-gtfs-1218.zip?alt=media",
+        "license": "https://data.qld.gov.au/dataset/general-transit-feed-specification-gtfs-qconnect/resource/254f67be-ea12-4da1-8475-c5424359290e"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/be-unknown-societe-regionale-wallonne-du-transport-gtfs-1212.json
+++ b/catalogs/sources/gtfs/schedule/be-unknown-societe-regionale-wallonne-du-transport-gtfs-1212.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1212,
+    "data_type": "gtfs",
+    "provider": "Société Régionale Wallonne du Transport",
+    "location": {
+        "country_code": "BE",
+        "bounding_box": {
+            "minimum_latitude": 49.506805,
+            "maximum_latitude": 50.883023,
+            "minimum_longitude": 2.87512,
+            "maximum_longitude": 6.384263,
+            "extracted_on": "2022-03-23T23:03:12+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/be-unknown-societe-regionale-wallonne-du-transport-gtfs-1212.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-british-columbia-translink-vancouver-gtfs-1222.json
+++ b/catalogs/sources/gtfs/schedule/ca-british-columbia-translink-vancouver-gtfs-1222.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1222,
+    "data_type": "gtfs",
+    "provider": "TransLink Vancouver",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "British Columbia",
+        "municipality": "Vancouver",
+        "bounding_box": {
+            "minimum_latitude": 49.004383,
+            "maximum_latitude": 49.474111,
+            "minimum_longitude": -123.423063,
+            "maximum_longitude": -122.30486,
+            "extracted_on": "2022-03-23T23:11:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/translink-vancouver/29/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-british-columbia-translink-vancouver-gtfs-1222.zip?alt=media",
+        "license": "https://developer.translink.ca/ServicesGtfs/GtfsData"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-new-brunswick-saint-john-transit-gtfs-1223.json
+++ b/catalogs/sources/gtfs/schedule/ca-new-brunswick-saint-john-transit-gtfs-1223.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1223,
+    "data_type": "gtfs",
+    "provider": "Saint John Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "New Brunswick",
+        "municipality": "Saint John",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-23T23:11:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/saint-john-transit/1224/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-new-brunswick-saint-john-transit-gtfs-1223.zip?alt=media",
+        "license": "https://catalogue-saintjohn.opendata.arcgis.com/datasets/d6f4783521364429a2e51a64c60ae234/about"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-montreal-gtfs-1221.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-societe-de-transport-de-montreal-gtfs-1221.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1221,
+    "data_type": "gtfs",
+    "provider": "Société de transport de Montréal",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Québec",
+        "municipality": "Montréal",
+        "bounding_box": {
+            "minimum_latitude": 45.402668,
+            "maximum_latitude": 45.701116,
+            "minimum_longitude": -73.956204,
+            "maximum_longitude": -73.480581,
+            "extracted_on": "2022-03-23T23:11:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/societe-de-transport-de-montreal/39/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-societe-de-transport-de-montreal-gtfs-1221.zip?alt=media",
+        "license": "https://www.stm.info/en/about/developers/terms-use"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-hamburg-hamburger-verkehrsverbund-gmbh-hvv-gtfs-1226.json
+++ b/catalogs/sources/gtfs/schedule/de-hamburg-hamburger-verkehrsverbund-gmbh-hvv-gtfs-1226.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1226,
+    "data_type": "gtfs",
+    "provider": "Hamburger Verkehrsverbund GmbH (HVV)",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Hamburg",
+        "bounding_box": {
+            "minimum_latitude": 51.536818622395,
+            "maximum_latitude": 56.650332937513,
+            "minimum_longitude": 8.310921044198,
+            "maximum_longitude": 12.131073730255,
+            "extracted_on": "2022-03-23T23:14:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/hamburger-verkehrsverbund-gmbh/1010/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-hamburg-hamburger-verkehrsverbund-gmbh-hvv-gtfs-1226.zip?alt=media",
+        "license": "https://www.govdata.de/dl-de/by-2-0"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-nordrhein-westfalen-rurtalbahn-gmbh-gtfs-1224.json
+++ b/catalogs/sources/gtfs/schedule/de-nordrhein-westfalen-rurtalbahn-gmbh-gtfs-1224.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1224,
+    "data_type": "gtfs",
+    "provider": "Rurtalbahn GmbH, ABELLIO Rail, VIAS GmbH, Aachener Straßenbahn und Energieversorgungs-AG, Rurtalbus GmbH, WestVerkehr GmbH, Staatsbahnen, National Express, ASEAG Netliner",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Nordrhein-Westfalen",
+        "municipality": "Aachen",
+        "bounding_box": {
+            "minimum_latitude": 50.510054,
+            "maximum_latitude": 51.678547,
+            "minimum_longitude": 5.859465,
+            "maximum_longitude": 8.016278,
+            "extracted_on": "2022-03-23T23:12:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/aachener-verkehrsverbund/836/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-nordrhein-westfalen-rurtalbahn-gmbh-gtfs-1224.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-unknown-karlsruher-verkehrsverbundes-gtfs-1225.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-karlsruher-verkehrsverbundes-gtfs-1225.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1225,
+    "data_type": "gtfs",
+    "provider": "Karlsruher Verkehrsverbundes",
+    "location": {
+        "country_code": "DE",
+        "municipality": "Karlsruhe",
+        "bounding_box": {
+            "minimum_latitude": 48.4444287068652,
+            "maximum_latitude": 49.3522641266005,
+            "minimum_longitude": 7.92748865301283,
+            "maximum_longitude": 9.52687613454039,
+            "extracted_on": "2022-03-23T23:13:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/karlsruher-verkehrsverbundes/896/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-karlsruher-verkehrsverbundes-gtfs-1225.zip?alt=media",
+        "license": "https://www.kvv.de/fahrplan/fahrplaene/open-data.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-navarra-transporte-urbano-comarcal-de-pamplona-gtfs-1219.json
+++ b/catalogs/sources/gtfs/schedule/es-navarra-transporte-urbano-comarcal-de-pamplona-gtfs-1219.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1219,
+    "data_type": "gtfs",
+    "provider": "Transporte Urbano Comarcal de Pamplona",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Navarra, Comunidad Foral de",
+        "municipality": "Pamplona",
+        "bounding_box": {
+            "minimum_latitude": 42.7338864109485,
+            "maximum_latitude": 42.8584154007876,
+            "minimum_longitude": -1.70393984355798,
+            "maximum_longitude": -1.57345744089785,
+            "extracted_on": "2022-03-23T23:05:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/transporte-urbano-comarcal-de-pamplona/499/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-navarra-transporte-urbano-comarcal-de-pamplona-gtfs-1219.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-linja-karjala-oy-gtfs-1227.json
+++ b/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-linja-karjala-oy-gtfs-1227.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1227,
+    "data_type": "gtfs",
+    "provider": "Linja-Karjala Oy, Savo-Karjalan Linja Oy",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Pohjois-Karjala",
+        "municipality": "Joensuu",
+        "bounding_box": {
+            "minimum_latitude": 62.092129,
+            "maximum_latitude": 63.325670884853885,
+            "minimum_longitude": 28.924184940398234,
+            "maximum_longitude": 30.936747,
+            "extracted_on": "2022-03-23T23:14:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://tvv.fra1.digitaloceanspaces.com/207.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-pohjois-karjala-linja-karjala-oy-gtfs-1227.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/gb-england-citymapper-gtfs-1249.json
+++ b/catalogs/sources/gtfs/schedule/gb-england-citymapper-gtfs-1249.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1249,
+    "data_type": "gtfs",
+    "provider": "Citymapper",
+    "name": "Smartbus",
+    "location": {
+        "country_code": "GB",
+        "subdivision_name": "England",
+        "municipality": "London",
+        "bounding_box": {
+            "minimum_latitude": 51.515629,
+            "maximum_latitude": 51.550418,
+            "minimum_longitude": -0.104632,
+            "maximum_longitude": -0.072139,
+            "extracted_on": "2022-03-23T23:19:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/citymapper/894/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gb-england-citymapper-gtfs-1249.zip?alt=media",
+        "license": "https://opendatacommons.org/licenses/pddl/1.0/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/gr-attiki-athens-urban-transport-organisation-organismos-astikon-sugkoinonion-oasa-gtfs-1228.json
+++ b/catalogs/sources/gtfs/schedule/gr-attiki-athens-urban-transport-organisation-organismos-astikon-sugkoinonion-oasa-gtfs-1228.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1228,
+    "data_type": "gtfs",
+    "provider": "Αthens Urban Transport Organisation (Οργανισμός Αστικών Συγκοινωνιών ΟΑΣΑ)",
+    "location": {
+        "country_code": "GR",
+        "subdivision_name": "Attiki",
+        "municipality": "Athens",
+        "bounding_box": {
+            "minimum_latitude": 37.7194145701699,
+            "maximum_latitude": 38.1550089904083,
+            "minimum_longitude": 23.417466558685,
+            "maximum_longitude": 24.0203030966813,
+            "extracted_on": "2022-03-23T23:15:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/athens-urban-transport-organisation/580/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gr-attiki-athens-urban-transport-organisation-organismos-astikon-sugkoinonion-oasa-gtfs-1228.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/id-jawa-barat-bogor-angkots-gtfs-1229.json
+++ b/catalogs/sources/gtfs/schedule/id-jawa-barat-bogor-angkots-gtfs-1229.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1229,
+    "data_type": "gtfs",
+    "provider": "Bogor Angkots ",
+    "location": {
+        "country_code": "ID",
+        "subdivision_name": "Jawa Barat",
+        "municipality": "Bogor",
+        "bounding_box": {
+            "minimum_latitude": -6.6616,
+            "maximum_latitude": -6.5205,
+            "minimum_longitude": 106.7285,
+            "maximum_longitude": 106.8651,
+            "extracted_on": "2022-03-23T23:15:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/bogor-angkots/725/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/id-jawa-barat-bogor-angkots-gtfs-1229.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/in-kerala-kochi-metro-gtfs-1209.json
+++ b/catalogs/sources/gtfs/schedule/in-kerala-kochi-metro-gtfs-1209.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1209,
+    "data_type": "gtfs",
+    "provider": "Kochi Metro",
+    "location": {
+        "country_code": "IN",
+        "subdivision_name": "Kerala",
+        "municipality": "Kochi",
+        "bounding_box": {
+            "minimum_latitude": 9.96,
+            "maximum_latitude": 10.1099,
+            "minimum_longitude": 76.2823,
+            "maximum_longitude": 76.3495,
+            "extracted_on": "2022-03-23T23:02:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/kochi-metro-rail-ltd/1118/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/in-kerala-kochi-metro-gtfs-1209.zip?alt=media",
+        "license": "https://kochimetro.org/opendata/TermsOfUse.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-liguria-amt-genova-gtfs-1230.json
+++ b/catalogs/sources/gtfs/schedule/it-liguria-amt-genova-gtfs-1230.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1230,
+    "data_type": "gtfs",
+    "provider": "AMT Genova",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Liguria",
+        "municipality": "Genoa",
+        "bounding_box": {
+            "minimum_latitude": 44.380802,
+            "maximum_latitude": 44.534306,
+            "minimum_longitude": 8.695372,
+            "maximum_longitude": 9.056105,
+            "extracted_on": "2022-03-23T23:15:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/amt-genova/1011/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-liguria-amt-genova-gtfs-1230.zip?alt=media",
+        "license": "https://www.amt.genova.it/amt/amministrazione-trasparente/open-data/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-lombardia-agenzia-mobilita-ambiente-territorio-gtfs-1231.json
+++ b/catalogs/sources/gtfs/schedule/it-lombardia-agenzia-mobilita-ambiente-territorio-gtfs-1231.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1231,
+    "data_type": "gtfs",
+    "provider": "Agenzia Mobilità Ambiente Territorio",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Lombardia",
+        "municipality": "Milan",
+        "bounding_box": {
+            "minimum_latitude": 45.3393649441656,
+            "maximum_latitude": 45.6311473404826,
+            "minimum_longitude": 8.99601914115518,
+            "maximum_longitude": 9.43662513013151,
+            "extracted_on": "2022-03-23T23:17:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/agenzia-mobilita-ambiente-territorio/341/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lombardia-agenzia-mobilita-ambiente-territorio-gtfs-1231.zip?alt=media",
+        "license": "http://www.amat-mi.it/it/mobilita/dati-strumenti-tecnologie/dati-gtfs/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-unknown-unobus-gtfs-1250.json
+++ b/catalogs/sources/gtfs/schedule/jp-unknown-unobus-gtfs-1250.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1250,
+    "data_type": "gtfs",
+    "provider": "Unobus",
+    "location": {
+        "country_code": "JP",
+        "bounding_box": {
+            "minimum_latitude": 34.660463,
+            "maximum_latitude": 35.012687,
+            "minimum_longitude": 133.918614140014,
+            "maximum_longitude": 134.184238,
+            "extracted_on": "2022-03-23T23:19:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www3.unobus.co.jp/opendata/GTFS-JP.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-unknown-unobus-gtfs-1250.zip?alt=media",
+        "license": "http://www3.unobus.co.jp/opendata/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/new-zealand-bay-of-plenty-baybus-gtfs-1232.json
+++ b/catalogs/sources/gtfs/schedule/new-zealand-bay-of-plenty-baybus-gtfs-1232.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1232,
+    "data_type": "gtfs",
+    "provider": "BayBus",
+    "location": {
+        "country_code": "New Zealand",
+        "subdivision_name": "Bay of Plenty",
+        "bounding_box": {
+            "minimum_latitude": -38.6393150613996,
+            "maximum_latitude": -37.3898234,
+            "minimum_longitude": 175.839138805048,
+            "maximum_longitude": 178.14268788955,
+            "extracted_on": "2022-03-23T23:17:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/bay-of-plenty-regional-council-bus-service/1222/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/new-zealand-bay-of-plenty-baybus-gtfs-1232.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/nz-waikato-bus-it-waikato-gtfs-1233.json
+++ b/catalogs/sources/gtfs/schedule/nz-waikato-bus-it-waikato-gtfs-1233.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1233,
+    "data_type": "gtfs",
+    "provider": "Bus It Waikato ",
+    "location": {
+        "country_code": "NZ",
+        "subdivision_name": "Waikato",
+        "bounding_box": {
+            "minimum_latitude": -38.9897987817514,
+            "maximum_latitude": -36.84853,
+            "minimum_longitude": 174.71168419116,
+            "maximum_longitude": 176.1052278,
+            "extracted_on": "2022-03-23T23:17:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/bus-it-waikato/1226/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nz-waikato-bus-it-waikato-gtfs-1233.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-green-bus-thailand-gtfs-1208.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-green-bus-thailand-gtfs-1208.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1208,
+    "data_type": "gtfs",
+    "provider": "Green Bus Thailand",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai ",
+        "bounding_box": {
+            "minimum_latitude": 7.91751,
+            "maximum_latitude": 20.404787,
+            "minimum_longitude": 98.298438,
+            "maximum_longitude": 103.638578,
+            "extracted_on": "2022-03-23T23:02:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/greenbus-thailand/784/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-green-bus-thailand-gtfs-1208.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alabama-birmingham-jefferson-county-transit-authority-gtfs-1248.json
+++ b/catalogs/sources/gtfs/schedule/us-alabama-birmingham-jefferson-county-transit-authority-gtfs-1248.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1248,
+    "data_type": "gtfs",
+    "provider": "Birmingham Jefferson County Transit Authority",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alabama",
+        "municipality": "Birmingham",
+        "bounding_box": {
+            "minimum_latitude": 33.33396,
+            "maximum_latitude": 33.66285,
+            "minimum_longitude": -87.00786,
+            "maximum_longitude": -86.67696,
+            "extracted_on": "2022-03-23T23:19:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/birmingham-jefferson-county-transit-authority/683/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alabama-birmingham-jefferson-county-transit-authority-gtfs-1248.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-alameda-contra-costa-transit-district-ac-transit-gtfs-1244.json
+++ b/catalogs/sources/gtfs/schedule/us-california-alameda-contra-costa-transit-district-ac-transit-gtfs-1244.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1244,
+    "data_type": "gtfs",
+    "provider": "Alameda-Contra Costa Transit District (AC Transit)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Oakland",
+        "bounding_box": {
+            "minimum_latitude": 37.409768,
+            "maximum_latitude": 38.017813,
+            "minimum_longitude": -122.421947,
+            "maximum_longitude": -121.886829,
+            "extracted_on": "2022-03-23T23:19:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ac-transit/1269/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-alameda-contra-costa-transit-district-ac-transit-gtfs-1244.zip?alt=media",
+        "license": "https://www.actransit.org/data-terms-and-conditions/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-glendale-gtfs-1245.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-glendale-gtfs-1245.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1245,
+    "data_type": "gtfs",
+    "provider": "City of Glendale",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Glendale",
+        "bounding_box": {
+            "minimum_latitude": 34.123164,
+            "maximum_latitude": 34.223555,
+            "minimum_longitude": -118.312149,
+            "maximum_longitude": -118.175199,
+            "extracted_on": "2022-03-23T23:19:16+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/city-of-glendale/628/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-of-glendale-gtfs-1245.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-county-connection-cccta-gtfs-1243.json
+++ b/catalogs/sources/gtfs/schedule/us-california-county-connection-cccta-gtfs-1243.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1243,
+    "data_type": "gtfs",
+    "provider": "County Connection (CCCTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Concord",
+        "bounding_box": {
+            "minimum_latitude": 37.659113,
+            "maximum_latitude": 38.019406,
+            "minimum_longitude": -122.191794,
+            "maximum_longitude": -121.778125,
+            "extracted_on": "2022-03-23T23:18:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/county-connection/222/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-county-connection-cccta-gtfs-1243.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-los-angeles-department-of-transportation-ladot-gtfs-1210.json
+++ b/catalogs/sources/gtfs/schedule/us-california-los-angeles-department-of-transportation-ladot-gtfs-1210.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1210,
+    "data_type": "gtfs",
+    "provider": "Los Angeles Department of Transportation (LADOT)",
+    "name": "Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Los Angeles",
+        "bounding_box": {
+            "minimum_latitude": 33.721646,
+            "maximum_latitude": 34.323144444,
+            "minimum_longitude": -118.882869444444,
+            "maximum_longitude": -118.131797222222,
+            "extracted_on": "2022-03-23T23:02:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ladot-transit-services/303/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-los-angeles-department-of-transportation-ladot-gtfs-1210.zip?alt=media",
+        "license": "https://www.ladottransit.com/dla.html"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-santa-barbara-metropolitan-transit-district-mtd-gtfs-1246.json
+++ b/catalogs/sources/gtfs/schedule/us-california-santa-barbara-metropolitan-transit-district-mtd-gtfs-1246.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1246,
+    "data_type": "gtfs",
+    "provider": "Santa Barbara Metropolitan Transit District (MTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Barbara",
+        "bounding_box": {
+            "minimum_latitude": 34.383217,
+            "maximum_latitude": 34.454905,
+            "minimum_longitude": -119.905809,
+            "maximum_longitude": -119.480564,
+            "extracted_on": "2022-03-23T23:19:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/santa-barbara-mtd/1156/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-santa-barbara-metropolitan-transit-district-mtd-gtfs-1246.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-santa-cruz-metro-scmtd-gtfs-1211.json
+++ b/catalogs/sources/gtfs/schedule/us-california-santa-cruz-metro-scmtd-gtfs-1211.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1211,
+    "data_type": "gtfs",
+    "provider": "Santa Cruz Metro (SCMTD)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Cruz",
+        "bounding_box": {
+            "minimum_latitude": 36.90448,
+            "maximum_latitude": 37.338436,
+            "minimum_longitude": -122.195023,
+            "maximum_longitude": -121.732437,
+            "extracted_on": "2022-03-23T23:02:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/santa-cruz-metro/343/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-santa-cruz-metro-scmtd-gtfs-1211.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-colorado-mountain-metropolitan-transit-gtfs-1241.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-mountain-metropolitan-transit-gtfs-1241.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1241,
+    "data_type": "gtfs",
+    "provider": "Mountain Metropolitan Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Colorado",
+        "municipality": "Colorado Springs",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-23T23:18:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mountain-metropolitan-transit/374/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-mountain-metropolitan-transit-gtfs-1241.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-delaware-delaware-transit-corporation-dart-first-state-gtfs-1235.json
+++ b/catalogs/sources/gtfs/schedule/us-delaware-delaware-transit-corporation-dart-first-state-gtfs-1235.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1235,
+    "data_type": "gtfs",
+    "provider": "Delaware Transit Corporation (DART First State)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Delaware",
+        "bounding_box": {
+            "minimum_latitude": 38.455356,
+            "maximum_latitude": 39.832812,
+            "minimum_longitude": -75.769633,
+            "maximum_longitude": -75.077004,
+            "extracted_on": "2022-03-23T23:17:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/dart-first-state/209/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-delaware-delaware-transit-corporation-dart-first-state-gtfs-1235.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-connect-transit-gtfs-1238.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-connect-transit-gtfs-1238.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1238,
+    "data_type": "gtfs",
+    "provider": "Connect Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Illinois",
+        "municipality": "Bloomington-Normal",
+        "bounding_box": {
+            "minimum_latitude": 40.44846874,
+            "maximum_latitude": 40.53679758,
+            "minimum_longitude": -89.039767,
+            "maximum_longitude": -88.91076565,
+            "extracted_on": "2022-03-23T23:18:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/connect-transit/668/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-connect-transit-gtfs-1238.zip?alt=media",
+        "license": "https://www.connect-transit.com/routes/general_transit_feed_specification.asp"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-indiana-indygo-gtfs-1237.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-indygo-gtfs-1237.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1237,
+    "data_type": "gtfs",
+    "provider": "IndyGo",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Indiana",
+        "municipality": "Indianapolis",
+        "bounding_box": {
+            "minimum_latitude": 39.628367,
+            "maximum_latitude": 39.920356,
+            "minimum_longitude": -86.32687,
+            "maximum_longitude": -85.962238,
+            "extracted_on": "2022-03-23T23:18:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/indygo/210/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-indygo-gtfs-1237.zip?alt=media",
+        "license": "http://www.indygo.net/about-indygo/indygo-developer-content-area/indygo-gtfs-terms-of-use/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-pioneer-valley-transit-authority-pvta-gtfs-1234.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-pioneer-valley-transit-authority-pvta-gtfs-1234.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1234,
+    "data_type": "gtfs",
+    "provider": "Pioneer Valley Transit Authority (PVTA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 42.018114,
+            "maximum_latitude": 42.477045,
+            "minimum_longitude": -72.796658,
+            "maximum_longitude": -72.400816,
+            "extracted_on": "2022-03-23T23:17:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/massdot/104/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-pioneer-valley-transit-authority-pvta-gtfs-1234.zip?alt=media",
+        "license": "https://www.mass.gov/doc/developers-license-agreement-11132009/download"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-new-mexico-atomic-city-transit-gtfs-1240.json
+++ b/catalogs/sources/gtfs/schedule/us-new-mexico-atomic-city-transit-gtfs-1240.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1240,
+    "data_type": "gtfs",
+    "provider": "Atomic City Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Mexico",
+        "municipality": "Los Alamos ",
+        "bounding_box": {
+            "minimum_latitude": 35.772873,
+            "maximum_latitude": 35.905342,
+            "minimum_longitude": -106.33245,
+            "maximum_longitude": -106.18932,
+            "extracted_on": "2022-03-23T23:18:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/atomic-city-transit/1130/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-mexico-atomic-city-transit-gtfs-1240.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-dakota-cities-area-transit-gtfs-1247.json
+++ b/catalogs/sources/gtfs/schedule/us-north-dakota-cities-area-transit-gtfs-1247.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1247,
+    "data_type": "gtfs",
+    "provider": "Cities Area Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Dakota",
+        "municipality": "Grand Forks",
+        "bounding_box": {
+            "minimum_latitude": 47.874921,
+            "maximum_latitude": 47.94908,
+            "minimum_longitude": -97.109559,
+            "maximum_longitude": -97.010581,
+            "extracted_on": "2022-03-23T23:19:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/cities-area-transit/834/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-dakota-cities-area-transit-gtfs-1247.zip?alt=media",
+        "license": "http://www.grandforksgov.com/government/city-departments/cities-area-transit/data"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-centre-county-transit-authority-cata-gtfs-1236.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-centre-county-transit-authority-cata-gtfs-1236.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1236,
+    "data_type": "gtfs",
+    "provider": "Centre County Transit Authority (CATA)",
+    "name": "CATABUS",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "State College",
+        "bounding_box": {
+            "minimum_latitude": 40.761013,
+            "maximum_latitude": 40.84053,
+            "minimum_longitude": -77.94164999999998,
+            "maximum_longitude": -77.75423999999998,
+            "extracted_on": "2022-03-23T23:18:01+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/catabus/536/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-centre-county-transit-authority-cata-gtfs-1236.zip?alt=media",
+        "license": "https://catabus.com/developer-tools/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-texas-via-metropolitan-transit-via-gtfs-1242.json
+++ b/catalogs/sources/gtfs/schedule/us-texas-via-metropolitan-transit-via-gtfs-1242.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1242,
+    "data_type": "gtfs",
+    "provider": "VIA Metropolitan Transit (VIA)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Texas",
+        "municipality": "San Antonio",
+        "bounding_box": {
+            "minimum_latitude": 29.294069,
+            "maximum_latitude": 29.650497,
+            "minimum_longitude": -98.711,
+            "maximum_longitude": -98.306921,
+            "extracted_on": "2022-03-23T23:18:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/via-metropolitan-transit/62/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-texas-via-metropolitan-transit-via-gtfs-1242.zip?alt=media",
+        "license": "https://www.viainfo.net/developers-resources/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-utah-elevated-transit-gtfs-1207.json
+++ b/catalogs/sources/gtfs/schedule/us-utah-elevated-transit-gtfs-1207.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1207,
+    "data_type": "gtfs",
+    "provider": "Elevated Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Utah",
+        "bounding_box": {
+            "minimum_latitude": 37.623984,
+            "maximum_latitude": 40.78426,
+            "minimum_longitude": -112.102336,
+            "maximum_longitude": -109.343134,
+            "extracted_on": "2022-03-23T23:02:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/elevated-transit/609/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-utah-elevated-transit-gtfs-1207.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-virginia-valley-metro-gtfs-1239.json
+++ b/catalogs/sources/gtfs/schedule/us-virginia-valley-metro-gtfs-1239.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1239,
+    "data_type": "gtfs",
+    "provider": "Valley Metro",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Virginia",
+        "municipality": "Roanoke",
+        "bounding_box": {
+            "minimum_latitude": 36.9201167889456,
+            "maximum_latitude": 37.818521406721,
+            "minimum_longitude": -80.420858,
+            "maximum_longitude": -79.1570869088173,
+            "extracted_on": "2022-03-23T23:18:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/roanoke-va-us/roanoke-va-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-virginia-valley-metro-gtfs-1239.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the eighteenth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 44 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~