### PR TITLE
feat: Nineteenth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/au-tasmania-merseylink-gtfs-1251.json
+++ b/catalogs/sources/gtfs/schedule/au-tasmania-merseylink-gtfs-1251.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1251,
+    "data_type": "gtfs",
+    "provider": "MerseyLink",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Tasmania",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-24T00:15:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/merseylink/1221/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-tasmania-merseylink-gtfs-1251.zip?alt=media",
+        "license": "https://www.merseylink.com.au/gtfs-feed/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-mornington-railway-gtfs-1281.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-mornington-railway-gtfs-1281.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1281,
+    "data_type": "gtfs",
+    "provider": "Mornington Railway",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "bounding_box": {
+            "minimum_latitude": -38.22984964539984,
+            "maximum_latitude": -38.21404566869699,
+            "minimum_longitude": 145.0502921640873,
+            "maximum_longitude": 145.10695785284042,
+            "extracted_on": "2022-03-24T00:18:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mornington-railway/806/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-mornington-railway-gtfs-1281.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-alberta-strathcona-county-transit-gtfs-1297.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-strathcona-county-transit-gtfs-1297.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1297,
+    "data_type": "gtfs",
+    "provider": "Strathcona County Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Alberta",
+        "municipality": "Edmonton",
+        "bounding_box": {
+            "minimum_latitude": 53.5095,
+            "maximum_latitude": 53.568069,
+            "minimum_longitude": -113.525439,
+            "maximum_longitude": -113.250891,
+            "extracted_on": "2022-03-24T00:26:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/strathcona-county-transit/364/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-alberta-strathcona-county-transit-gtfs-1297.zip?alt=media",
+        "license": "https://data.strathcona.ca/Transportation/Strathcona-County-Transit-Bus-Schedule-GTFS-Data-F/2ek5-rxs5"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/de-bayern-hofbus-gtfs-1252.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-hofbus-gtfs-1252.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1252,
+    "data_type": "gtfs",
+    "provider": "HofBus",
+    "location": {
+        "country_code": "DE",
+        "subdivision_name": "Bayern",
+        "bounding_box": {
+            "minimum_latitude": 50.285254,
+            "maximum_latitude": 50.34338,
+            "minimum_longitude": 11.850416,
+            "maximum_longitude": 11.964562,
+            "extracted_on": "2022-03-24T00:15:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/hofbus/1197/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-hofbus-gtfs-1252.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/dk-unknown-rejseplanen-gtfs-1292.json
+++ b/catalogs/sources/gtfs/schedule/dk-unknown-rejseplanen-gtfs-1292.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1292,
+    "data_type": "gtfs",
+    "provider": "Rejseplanen",
+    "location": {
+        "country_code": "DK",
+        "bounding_box": {
+            "minimum_latitude": 53.552502176324,
+            "maximum_latitude": 57.739058058049,
+            "minimum_longitude": 8.116742858755,
+            "maximum_longitude": 16.359651748769,
+            "extracted_on": "2022-03-24T00:25:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://www.rejseplanen.info/labs/GTFS.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/dk-unknown-rejseplanen-gtfs-1292.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-bizkaia-bilbobus-gtfs-1253.json
+++ b/catalogs/sources/gtfs/schedule/es-bizkaia-bilbobus-gtfs-1253.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1253,
+    "data_type": "gtfs",
+    "provider": "Bilbobus",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Bizkaia",
+        "municipality": "Bilbao",
+        "bounding_box": {
+            "minimum_latitude": 43.226376863641,
+            "maximum_latitude": 43.28958706061865,
+            "minimum_longitude": -2.9749143846026342,
+            "maximum_longitude": -2.883005884056148,
+            "extracted_on": "2022-03-24T00:15:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/bilbobus/654/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-bizkaia-bilbobus-gtfs-1253.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/es-navarra-navarra-regional-gtfs-1254.json
+++ b/catalogs/sources/gtfs/schedule/es-navarra-navarra-regional-gtfs-1254.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1254,
+    "data_type": "gtfs",
+    "provider": "Navarra Regional",
+    "location": {
+        "country_code": "ES",
+        "subdivision_name": "Navarra, Comunidad Foral de",
+        "bounding_box": {
+            "minimum_latitude": 41.6424981847183,
+            "maximum_latitude": 43.3425474660011,
+            "minimum_longitude": -2.68474298385968,
+            "maximum_longitude": -0.88834736718245,
+            "extracted_on": "2022-03-24T00:15:59+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/government-of-navarra/1257/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-navarra-navarra-regional-gtfs-1254.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-etela-pohjanmaa-komia-liikenne-gtfs-1255.json
+++ b/catalogs/sources/gtfs/schedule/fi-etela-pohjanmaa-komia-liikenne-gtfs-1255.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1255,
+    "data_type": "gtfs",
+    "provider": "Komia Liikenne",
+    "name": "Regular scheduled traffic",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Etelä-Pohjanmaa",
+        "municipality": "Seinäjoki",
+        "bounding_box": {
+            "minimum_latitude": 62.731469,
+            "maximum_latitude": 62.838396,
+            "minimum_longitude": 22.766964,
+            "maximum_longitude": 22.929869,
+            "extracted_on": "2022-03-24T00:16:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/komia-liikenne/1225/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-etela-pohjanmaa-komia-liikenne-gtfs-1255.zip?alt=media",
+        "license": "https://www.komialiikenne.fi"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-grand-est-metz-gtfs-1298.json
+++ b/catalogs/sources/gtfs/schedule/fr-grand-est-metz-gtfs-1298.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1298,
+    "data_type": "gtfs",
+    "provider": "Metz",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Grand-Est",
+        "municipality": "Metz",
+        "bounding_box": {
+            "minimum_latitude": 48.998825,
+            "maximum_latitude": 49.189344,
+            "minimum_longitude": 6.003117,
+            "maximum_longitude": 6.324477,
+            "extracted_on": "2022-03-24T00:26:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/metz-metropole/850/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-grand-est-metz-gtfs-1298.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-ile-de-france-regie-autonome-des-transports-parisiens-gtfs-1291.json
+++ b/catalogs/sources/gtfs/schedule/fr-ile-de-france-regie-autonome-des-transports-parisiens-gtfs-1291.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1291,
+    "data_type": "gtfs",
+    "provider": "Régie Autonome des Transports Parisiens",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Île-de-France",
+        "municipality": "Paris",
+        "bounding_box": {
+            "minimum_latitude": 48.669856074950665,
+            "maximum_latitude": 49.058649071321184,
+            "minimum_longitude": 2.0122584189440045,
+            "maximum_longitude": 2.782492052599299,
+            "extracted_on": "2022-03-24T00:24:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/regie-autonome-des-transports-parisiens/413/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-ile-de-france-regie-autonome-des-transports-parisiens-gtfs-1291.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-ile-de-france-stif-gtfs-1283.json
+++ b/catalogs/sources/gtfs/schedule/fr-ile-de-france-stif-gtfs-1283.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1283,
+    "data_type": "gtfs",
+    "provider": "STIF",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Île-de-France",
+        "municipality": "Paris",
+        "bounding_box": {
+            "minimum_latitude": 47.960853,
+            "maximum_latitude": 49.426429,
+            "minimum_longitude": 1.149888,
+            "maximum_longitude": 3.560673,
+            "extracted_on": "2022-03-24T00:20:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/stif/822/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-ile-de-france-stif-gtfs-1283.zip?alt=media",
+        "license": "http://stif.info/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-meurthe-et-moselle-reseau-urbain-stan-gtfs-1256.json
+++ b/catalogs/sources/gtfs/schedule/fr-meurthe-et-moselle-reseau-urbain-stan-gtfs-1256.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1256,
+    "data_type": "gtfs",
+    "provider": "Réseau urbain Stan",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Meurthe-et-Moselle",
+        "municipality": "Nancy",
+        "bounding_box": {
+            "minimum_latitude": 48.610313,
+            "maximum_latitude": 48.731663,
+            "minimum_longitude": 6.107901,
+            "maximum_longitude": 6.27393,
+            "extracted_on": "2022-03-24T00:16:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/communaute-urbaine-du-grand-nancy/596/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-meurthe-et-moselle-reseau-urbain-stan-gtfs-1256.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-occitanie-offre-de-transport-du-reseau-libellus-gtfs-1286.json
+++ b/catalogs/sources/gtfs/schedule/fr-occitanie-offre-de-transport-du-reseau-libellus-gtfs-1286.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1286,
+    "data_type": "gtfs",
+    "provider": "Offre de transport du réseau Libellus",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Occitanie",
+        "municipality": "Mazamet",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 43.632646,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 2.405232,
+            "extracted_on": "2022-03-24T00:22:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mazamet/1218/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-occitanie-offre-de-transport-du-reseau-libellus-gtfs-1286.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-ile-dyeu-gtfs-1257.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-ile-dyeu-gtfs-1257.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1257,
+    "data_type": "gtfs",
+    "provider": "Ile d'Yeu",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Pays-de-la-Loire",
+        "municipality": "Nantes",
+        "bounding_box": {
+            "minimum_latitude": 46.7242998885,
+            "maximum_latitude": 46.8922038887,
+            "minimum_longitude": -2.3477262276,
+            "maximum_longitude": -2.1390199277,
+            "extracted_on": "2022-03-24T00:16:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/1070/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-ile-dyeu-gtfs-1257.zip?alt=media",
+        "license": "http://opendatacommons.org/licenses/odbl/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-lila-gtfs-1261.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-lila-gtfs-1261.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1261,
+    "data_type": "gtfs",
+    "provider": "LILA",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Pays-de-la-Loire",
+        "bounding_box": {
+            "minimum_latitude": 46.64782091,
+            "maximum_latitude": 48.10382256,
+            "minimum_longitude": -2.21905534,
+            "maximum_longitude": -0.74188328,
+            "extracted_on": "2022-03-24T00:16:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/969/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-lila-gtfs-1261.zip?alt=media",
+        "license": "https://data.nantesmetropole.fr/explore/dataset/234400034_032-012_gtfs_lila/information/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-pays-de-la-loire-gtfs-1258.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-pays-de-la-loire-gtfs-1258.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1258,
+    "data_type": "gtfs",
+    "provider": "Pays de la Loire",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Pays de la Loire",
+        "bounding_box": {
+            "minimum_latitude": 42.4199654845,
+            "maximum_latitude": 51.0304118157,
+            "minimum_longitude": -4.4803060144,
+            "maximum_longitude": 16.3790037675,
+            "extracted_on": "2022-03-24T00:16:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/1071/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-pays-de-la-loire-gtfs-1258.zip?alt=media",
+        "license": "http://opendatacommons.org/licenses/odbl/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-ter-pays-de-la-loire-gtfs-1259.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-ter-pays-de-la-loire-gtfs-1259.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1259,
+    "data_type": "gtfs",
+    "provider": "TER Pays de la Loire",
+    "name": "Cars SNCF transports à la demande",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Pays de la Loire",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-24T00:16:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/1073/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-ter-pays-de-la-loire-gtfs-1259.zip?alt=media",
+        "license": "https://opendatacommons.org/licenses/odbl/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-tram-train-gtfs-1260.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-tram-train-gtfs-1260.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1260,
+    "data_type": "gtfs",
+    "provider": "Tram Train",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Pays-de-la-Loire",
+        "municipality": "Nantes",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-03-24T00:16:31+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/1074/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-tram-train-gtfs-1260.zip?alt=media",
+        "license": "https://opendatacommons.org/licenses/odbl/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/hu-miskolc-mvk-zrt-gtfs-1287.json
+++ b/catalogs/sources/gtfs/schedule/hu-miskolc-mvk-zrt-gtfs-1287.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1287,
+    "data_type": "gtfs",
+    "provider": "MVK Zrt",
+    "location": {
+        "country_code": "HU",
+        "subdivision_name": "Miskolc",
+        "bounding_box": {
+            "minimum_latitude": 48.051575,
+            "maximum_latitude": 48.147408,
+            "minimum_longitude": 20.532918,
+            "maximum_longitude": 20.870524,
+            "extracted_on": "2022-03-24T00:22:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mvk-zrt/839/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-miskolc-mvk-zrt-gtfs-1287.zip?alt=media",
+        "license": "http://www.mvkzrt.hu/menetrend"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/in-delhi-delhi-transport-corporation-gtfs-1262.json
+++ b/catalogs/sources/gtfs/schedule/in-delhi-delhi-transport-corporation-gtfs-1262.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1262,
+    "data_type": "gtfs",
+    "provider": "Delhi Transport Corporation",
+    "location": {
+        "country_code": "IN",
+        "subdivision_name": "Delhi",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 28.87865,
+            "minimum_longitude": 0.0,
+            "maximum_longitude": 77.49000549,
+            "extracted_on": "2022-03-24T00:16:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/delhi-transport-corporation/1047/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/in-delhi-delhi-transport-corporation-gtfs-1262.zip?alt=media",
+        "license": "https://otd.delhi.gov.in/static/assets/terms-and-conditions.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-lazio-roma-servizi-per-la-mobilita-gtfs-1294.json
+++ b/catalogs/sources/gtfs/schedule/it-lazio-roma-servizi-per-la-mobilita-gtfs-1294.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1294,
+    "data_type": "gtfs",
+    "provider": "Roma Servizi per la Mobilità",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Lazio",
+        "municipality": "Rome",
+        "bounding_box": {
+            "minimum_latitude": 41.648593,
+            "maximum_latitude": 42.4415,
+            "minimum_longitude": 12.107767,
+            "maximum_longitude": 12.789177,
+            "extracted_on": "2022-03-24T00:25:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://romamobilita.it/sites/default/files/rome_static_gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lazio-roma-servizi-per-la-mobilita-gtfs-1294.zip?alt=media",
+        "license": "https://romamobilita.it/it/tecnologie/open-data/dataset"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-lombardia-azienda-varesina-trasporti-avt-gtfs-1264.json
+++ b/catalogs/sources/gtfs/schedule/it-lombardia-azienda-varesina-trasporti-avt-gtfs-1264.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1264,
+    "data_type": "gtfs",
+    "provider": "Azienda Varesina Trasporti (AVT)",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Lombardia",
+        "municipality": "Varese",
+        "bounding_box": {
+            "minimum_latitude": 45.858448,
+            "maximum_latitude": 45.860677,
+            "minimum_longitude": 8.787817,
+            "maximum_longitude": 8.790801,
+            "extracted_on": "2022-03-24T00:17:15+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/azienda-varesina-trasporti/525/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lombardia-azienda-varesina-trasporti-avt-gtfs-1264.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-lombardia-movibus-srl-gtfs-1267.json
+++ b/catalogs/sources/gtfs/schedule/it-lombardia-movibus-srl-gtfs-1267.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1267,
+    "data_type": "gtfs",
+    "provider": "Movibus S.r.l.",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Lombardia",
+        "municipality": "Milano",
+        "bounding_box": {
+            "minimum_latitude": 45.45574,
+            "maximum_latitude": 45.634625,
+            "minimum_longitude": 8.7251913,
+            "maximum_longitude": 9.176118,
+            "extracted_on": "2022-03-24T00:17:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/movibus-s-r-l/1232/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lombardia-movibus-srl-gtfs-1267.zip?alt=media",
+        "license": "http://dati.mit.gov.it/catalog/dataset/orari-autobus-lombardia"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-piemonte-trenitalia-gtfs-1266.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-trenitalia-gtfs-1266.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1266,
+    "data_type": "gtfs",
+    "provider": "TRENITALIA, Gruppo Torinese Trasporti (GTT)",
+    "name": "SFM (Railway)",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Piemonte",
+        "municipality": "Turin",
+        "bounding_box": {
+            "minimum_latitude": 44.5503552277837,
+            "maximum_latitude": 45.4201003714791,
+            "minimum_longitude": 6.6586595428636,
+            "maximum_longitude": 8.207680132992,
+            "extracted_on": "2022-03-24T00:17:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/gruppo-torinese-trasporti/664/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-trenitalia-gtfs-1266.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-quadri-orari-traghetti-gtfs-1268.json
+++ b/catalogs/sources/gtfs/schedule/it-regione-autonoma-della-sardegna-quadri-orari-traghetti-gtfs-1268.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1268,
+    "data_type": "gtfs",
+    "provider": "Quadri orari traghetti",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Regione Autonoma della Sardegna",
+        "bounding_box": {
+            "minimum_latitude": 39.1114042,
+            "maximum_latitude": 41.2119799,
+            "minimum_longitude": 8.2940375,
+            "maximum_longitude": 9.4067082,
+            "extracted_on": "2022-03-24T00:17:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/quadri-orari-traghetti/1169/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-regione-autonoma-della-sardegna-quadri-orari-traghetti-gtfs-1268.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-sardegna-collegamenti-marittimi-grandi-navi-veloci-gtfs-1265.json
+++ b/catalogs/sources/gtfs/schedule/it-sardegna-collegamenti-marittimi-grandi-navi-veloci-gtfs-1265.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1265,
+    "data_type": "gtfs",
+    "provider": "Collegamenti marittimi Grandi Navi Veloci",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Sardegna",
+        "bounding_box": {
+            "minimum_latitude": 35.78928874574407,
+            "maximum_latitude": 44.411405000188,
+            "minimum_longitude": -5.803751351906152,
+            "maximum_longitude": 15.0918573,
+            "extracted_on": "2022-03-24T00:17:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/collegamenti-marittimi-grandi-navi-veloci/1164/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-sardegna-collegamenti-marittimi-grandi-navi-veloci-gtfs-1265.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-toscana-azienda-trasporti-area-fiorentina-ataf-gtfs-1263.json
+++ b/catalogs/sources/gtfs/schedule/it-toscana-azienda-trasporti-area-fiorentina-ataf-gtfs-1263.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1263,
+    "data_type": "gtfs",
+    "provider": "Azienda Trasporti Area Fiorentina (ATAF)",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Toscana",
+        "municipality": "Firenze",
+        "bounding_box": {
+            "minimum_latitude": 43.6708429005161,
+            "maximum_latitude": 43.9140659813961,
+            "minimum_longitude": 11.0112905791906,
+            "maximum_longitude": 11.3885660460831,
+            "extracted_on": "2022-03-24T00:17:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/azienda-trasporti-dellarea-fiorentina/739/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-toscana-azienda-trasporti-area-fiorentina-ataf-gtfs-1263.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ph-unknown-philippines-gtfs-1269.json
+++ b/catalogs/sources/gtfs/schedule/ph-unknown-philippines-gtfs-1269.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1269,
+    "data_type": "gtfs",
+    "provider": "Philippines",
+    "location": {
+        "country_code": "PH",
+        "bounding_box": {
+            "minimum_latitude": 14.2502,
+            "maximum_latitude": 14.884,
+            "minimum_longitude": 120.9,
+            "maximum_longitude": 121.229,
+            "extracted_on": "2022-03-24T00:17:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/philippines/71/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ph-unknown-philippines-gtfs-1269.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-boleslawiec-gtfs-1271.json
+++ b/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-boleslawiec-gtfs-1271.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1271,
+    "data_type": "gtfs",
+    "provider": "Komunikacja Miejska - Bolesławiec",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Dolnośląskie",
+        "municipality": "Bolesławiec",
+        "bounding_box": {
+            "minimum_latitude": 51.23244,
+            "maximum_latitude": 51.52693,
+            "minimum_longitude": 15.46822,
+            "maximum_longitude": 15.6345,
+            "extracted_on": "2022-03-24T00:17:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/przyjazdy-pl-boles-awiec/1209/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-dolnoslaskie-komunikacja-miejska-boleslawiec-gtfs-1271.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-malopolskie-mpk-sa-w-krakowie-gtfs-1270.json
+++ b/catalogs/sources/gtfs/schedule/pl-malopolskie-mpk-sa-w-krakowie-gtfs-1270.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 1270,
+    "data_type": "gtfs",
+    "provider": "MPK SA w Krakowie",
+    "name": "Tram",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Małopolskie",
+        "municipality": "Kraków",
+        "bounding_box": {
+            "minimum_latitude": 50.012338,
+            "maximum_latitude": 50.101977,
+            "minimum_longitude": 19.88192,
+            "maximum_longitude": 20.116968,
+            "extracted_on": "2022-03-24T00:17:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mpk-sa-w-krakowie/1105/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-malopolskie-mpk-sa-w-krakowie-gtfs-1270.zip?alt=media",
+        "license": "https://www.mpk.krakow.pl/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pl-pomorskie-pkp-szybka-kolej-miejska-w-trojmiescie-gtfs-1290.json
+++ b/catalogs/sources/gtfs/schedule/pl-pomorskie-pkp-szybka-kolej-miejska-w-trojmiescie-gtfs-1290.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1290,
+    "data_type": "gtfs",
+    "provider": "PKP Szybka Kolej Miejska w Trójmieście",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Pomorskie",
+        "municipality": "Trójmieście",
+        "bounding_box": {
+            "minimum_latitude": 54.1210638,
+            "maximum_latitude": 54.6058525,
+            "minimum_longitude": 17.7504301,
+            "maximum_longitude": 18.6446624,
+            "extracted_on": "2022-03-24T00:23:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/pkp-szybka-kolej-miejska-w-trojmie-cie/1116/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-pomorskie-pkp-szybka-kolej-miejska-w-trojmiescie-gtfs-1290.zip?alt=media",
+        "license": "http://przyjazdy.pl/gtfs"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/pt-lisboa-mobi-cascais-gtfs-1272.json
+++ b/catalogs/sources/gtfs/schedule/pt-lisboa-mobi-cascais-gtfs-1272.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1272,
+    "data_type": "gtfs",
+    "provider": "Mobi Cascais",
+    "location": {
+        "country_code": "PT",
+        "subdivision_name": "Lisboa",
+        "municipality": "Cascais",
+        "bounding_box": {
+            "minimum_latitude": 38.679561,
+            "maximum_latitude": 38.763594,
+            "minimum_longitude": -9.484887,
+            "maximum_longitude": -9.313059,
+            "extracted_on": "2022-03-24T00:17:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/mobi-cascais/1075/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-lisboa-mobi-cascais-gtfs-1272.zip?alt=media",
+        "license": "https://dadosabertos.cascais.pt/dataset/gtfs-mobicascais"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/rs-sumadijski-okrug-kragujevac-gtfs-1273.json
+++ b/catalogs/sources/gtfs/schedule/rs-sumadijski-okrug-kragujevac-gtfs-1273.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1273,
+    "data_type": "gtfs",
+    "provider": "Kragujevac",
+    "location": {
+        "country_code": "RS",
+        "subdivision_name": "Šumadijski okrug",
+        "municipality": "Kragujevac",
+        "bounding_box": {
+            "minimum_latitude": 43.934379,
+            "maximum_latitude": 44.08938,
+            "minimum_longitude": 20.79543,
+            "maximum_longitude": 21.01479,
+            "extracted_on": "2022-03-24T00:17:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/gas-kragujevac/1230/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/rs-sumadijski-okrug-kragujevac-gtfs-1273.zip?alt=media",
+        "license": "https://www.kgbus.rs/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-northern-chiang-mai-gtfs-1282.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-northern-chiang-mai-gtfs-1282.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1282,
+    "data_type": "gtfs",
+    "provider": "Northern Chiang Mai",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai",
+        "bounding_box": {
+            "minimum_latitude": 18.791541,
+            "maximum_latitude": 20.061907,
+            "minimum_longitude": 98.847561,
+            "maximum_longitude": 99.362492,
+            "extracted_on": "2022-03-24T00:18:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/northern-chiang-mai/797/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-northern-chiang-mai-gtfs-1282.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-western-chiang-mai-gtfs-1275.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-western-chiang-mai-gtfs-1275.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1275,
+    "data_type": "gtfs",
+    "provider": "Western Chiang Mai",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai",
+        "bounding_box": {
+            "minimum_latitude": 18.791196,
+            "maximum_latitude": 19.073048,
+            "minimum_longitude": 98.30328,
+            "maximum_longitude": 98.999285,
+            "extracted_on": "2022-03-24T00:17:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/coopthai-nct/798/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-western-chiang-mai-gtfs-1275.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-unknown-coopthai-gtfs-1274.json
+++ b/catalogs/sources/gtfs/schedule/th-unknown-coopthai-gtfs-1274.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1274,
+    "data_type": "gtfs",
+    "provider": "Coopthai",
+    "location": {
+        "country_code": "TH",
+        "bounding_box": {
+            "minimum_latitude": 18.41717,
+            "maximum_latitude": 18.800474,
+            "minimum_longitude": 98.67703,
+            "maximum_longitude": 99.006584,
+            "extracted_on": "2022-03-24T00:17:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/coopthai-nct/787/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-unknown-coopthai-gtfs-1274.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-miaoli-miaoli-gtfs-1276.json
+++ b/catalogs/sources/gtfs/schedule/tw-miaoli-miaoli-gtfs-1276.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1276,
+    "data_type": "gtfs",
+    "provider": "Miaoli",
+    "location": {
+        "country_code": "TW",
+        "subdivision_name": "Miaoli",
+        "bounding_box": {
+            "minimum_latitude": 24.136164,
+            "maximum_latitude": 25.12029,
+            "minimum_longitude": 120.62628,
+            "maximum_longitude": 121.517615,
+            "extracted_on": "2022-03-24T00:17:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/taiwan/954/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-miaoli-miaoli-gtfs-1276.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-unknown-taichung-gtfs-1277.json
+++ b/catalogs/sources/gtfs/schedule/tw-unknown-taichung-gtfs-1277.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1277,
+    "data_type": "gtfs",
+    "provider": "Taichung",
+    "location": {
+        "country_code": "TW",
+        "bounding_box": {
+            "minimum_latitude": 22.627563,
+            "maximum_latitude": 25.132208,
+            "minimum_longitude": 120.1524,
+            "maximum_longitude": 121.77578,
+            "extracted_on": "2022-03-24T00:18:18+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/taiwan/955/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-unknown-taichung-gtfs-1277.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alaska-ride-sitka-gtfs-1293.json
+++ b/catalogs/sources/gtfs/schedule/us-alaska-ride-sitka-gtfs-1293.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1293,
+    "data_type": "gtfs",
+    "provider": "RIDE Sitka",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alaska",
+        "municipality": "Sitka",
+        "bounding_box": {
+            "minimum_latitude": 57.033684,
+            "maximum_latitude": 57.127718,
+            "minimum_longitude": -135.399641,
+            "maximum_longitude": -135.232633,
+            "extracted_on": "2022-03-24T00:25:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/ride-sitka/713/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alaska-ride-sitka-gtfs-1293.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alberta-grande-prairie-transit-gtfs-1278.json
+++ b/catalogs/sources/gtfs/schedule/us-alberta-grande-prairie-transit-gtfs-1278.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1278,
+    "data_type": "gtfs",
+    "provider": "Grande Prairie Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alberta",
+        "municipality": "Grande Prairie",
+        "bounding_box": {
+            "minimum_latitude": 55.1364482604836,
+            "maximum_latitude": 55.1998543176981,
+            "minimum_longitude": -118.858995480986,
+            "maximum_longitude": -118.758170437994,
+            "extracted_on": "2022-03-24T00:18:20+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/grande-prairie-transit/1255/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alberta-grande-prairie-transit-gtfs-1278.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-glendale-beeline-gtfs-1280.json
+++ b/catalogs/sources/gtfs/schedule/us-california-glendale-beeline-gtfs-1280.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1280,
+    "data_type": "gtfs",
+    "provider": "Glendale Beeline",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Glendale",
+        "bounding_box": {
+            "minimum_latitude": 34.123164,
+            "maximum_latitude": 34.223555,
+            "minimum_longitude": -118.312149,
+            "maximum_longitude": -118.175199,
+            "extracted_on": "2022-03-24T00:18:28+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/glendale-beeline/917/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-glendale-beeline-gtfs-1280.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sacramento-regional-transit-gtfs-1296.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sacramento-regional-transit-gtfs-1296.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1296,
+    "data_type": "gtfs",
+    "provider": "Sacramento Regional Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Sacramento",
+        "bounding_box": {
+            "minimum_latitude": 38.453234,
+            "maximum_latitude": 38.722658,
+            "minimum_longitude": -121.764449,
+            "maximum_longitude": -121.092322,
+            "extracted_on": "2022-03-24T00:26:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/sacramento-regional-transit/67/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sacramento-regional-transit-gtfs-1296.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-vine-transit-gtfs-1288.json
+++ b/catalogs/sources/gtfs/schedule/us-california-vine-transit-gtfs-1288.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1288,
+    "data_type": "gtfs",
+    "provider": "VINE Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Napa",
+        "bounding_box": {
+            "minimum_latitude": 37.925323,
+            "maximum_latitude": 38.583539,
+            "minimum_longitude": -122.579754889011,
+            "maximum_longitude": -122.041518688202,
+            "extracted_on": "2022-03-24T00:22:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/napa-vine/1268/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-vine-transit-gtfs-1288.zip?alt=media",
+        "license": "https://vinetransit.com/open-data-portal/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-yolo-county-transportation-district-gtfs-1295.json
+++ b/catalogs/sources/gtfs/schedule/us-california-yolo-county-transportation-district-gtfs-1295.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1295,
+    "data_type": "gtfs",
+    "provider": "Yolo County Transportation District",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Woodland",
+        "bounding_box": {
+            "minimum_latitude": 38.534455659059,
+            "maximum_latitude": 38.7361269435958,
+            "minimum_longitude": -122.142116853125,
+            "maximum_longitude": -121.452880290322,
+            "extracted_on": "2022-03-24T00:25:55+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/sacramento-regional-transit/161/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-yolo-county-transportation-district-gtfs-1295.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-minnesota-rochester-city-lines-gtfs-1279.json
+++ b/catalogs/sources/gtfs/schedule/us-minnesota-rochester-city-lines-gtfs-1279.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1279,
+    "data_type": "gtfs",
+    "provider": "Rochester City Lines",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Minnesota",
+        "municipality": "Rochester",
+        "bounding_box": {
+            "minimum_latitude": 43.509117,
+            "maximum_latitude": 44.9758836493634,
+            "minimum_longitude": -93.2730178534985,
+            "maximum_longitude": -91.690971,
+            "extracted_on": "2022-03-24T00:18:25+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/rochester-city-lines/774/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-minnesota-rochester-city-lines-gtfs-1279.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-north-carolina-state-university-ncsu-gtfs-1284.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-north-carolina-state-university-ncsu-gtfs-1284.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1284,
+    "data_type": "gtfs",
+    "provider": "North Carolina State University (NCSU)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Raleigh",
+        "bounding_box": {
+            "minimum_latitude": 35.7659454167,
+            "maximum_latitude": 35.8023515275,
+            "minimum_longitude": -78.7167181595,
+            "maximum_longitude": -78.6637517487,
+            "extracted_on": "2022-03-24T00:20:58+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/north-carolina-state-university/387/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-north-carolina-state-university-ncsu-gtfs-1284.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-north-carolina-state-university-ncsu-gtfs-1289.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-north-carolina-state-university-ncsu-gtfs-1289.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1289,
+    "data_type": "gtfs",
+    "provider": "North Carolina State University (NCSU)",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Raleigh",
+        "bounding_box": {
+            "minimum_latitude": 35.7659454167,
+            "maximum_latitude": 35.8023515275,
+            "minimum_longitude": -78.7167181595,
+            "maximum_longitude": -78.6637517487,
+            "extracted_on": "2022-03-24T00:22:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://data.trilliumtransit.com/gtfs/ncsu-wolfline-nc-us/ncsu-wolfline-nc-us.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-north-carolina-state-university-ncsu-gtfs-1289.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-north-dakota-matbus-gtfs-1285.json
+++ b/catalogs/sources/gtfs/schedule/us-north-dakota-matbus-gtfs-1285.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1285,
+    "data_type": "gtfs",
+    "provider": "MATBUS",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Dakota",
+        "municipality": "Fargo",
+        "bounding_box": {
+            "minimum_latitude": 46.802662,
+            "maximum_latitude": 46.91984,
+            "minimum_longitude": -96.914784,
+            "maximum_longitude": -96.68326,
+            "extracted_on": "2022-03-24T00:22:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/matbus/833/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-dakota-matbus-gtfs-1285.zip?alt=media",
+        "license": "http://www.matbus.com/GTFSFeed.htm"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the nineteenth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 48 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~