### PR TITLE
feat: Twentieth import [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/au-new-south-wales-train-replacement-bus-operators-gtfs-1322.json
+++ b/catalogs/sources/gtfs/schedule/au-new-south-wales-train-replacement-bus-operators-gtfs-1322.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1322,
+    "data_type": "gtfs",
+    "provider": "train replacement bus operators, Sydney Trains, NSW Trains, Busways Western Sydney, Interline Bus Services, Transit Systems, Hillsbus, Punchbowl Bus Company, State Transit, Transdev NSW, Dions Bus Service, Forest Coach Lines, Cronulla Ferries, Brooklyn Ferry Service, Central Coast Ferries, Manly Fast Ferry, Church Point Ferry Service, Captain Cook Cruises, Palm Beach Ferry Service, Busabout, Rover Coaches, Hunter Valley Buses, Port Stephens Coaches, Northern Rivers Buslines, Tamworth Buslines, Surfside Buslines, Premier Motor Service, Quinns Coaches, Dunoon Bus Service, Waller's Bus Company, Murwillumbah Bus Company, Parsons Bus Service, Gosel's Bus Service, Bhangla Singh's Bus Service, Blanch's Bus Company, Ballina Buslines, Watson's Bus Service, Casino Bus Service, Forest Coach Lines, Lawrence Bus Service, Forest Coach Lines, Michael Jillett, Reynolds & Fogarty, Forest Coach Lines, Inverell Bus Service, Symes Coaches, Edwards Coaches, Hannafords Bus Service, Hopes Bus Service, Millerds Bus Service, Cavanaghs Bus Company, Busways Port Macquarie, Tinonee Bus Company, Eggins Comfort Coaches, Busways Great Lakes, Forster Buslines, Osborn Bus Service, Ogden's Coaches, Wingham Buslines, Brunswick Valley Coaches, Clarence River Ferries, Busways Central Coast, Red Bus Service, Blue Mountains Transit, Premier Charters, Premier Illawarra, Hunter Valley Buses, Busways Coffs Harbour, Busways Grafton, Newcastle Transport, Port Stephens Coaches, NSW TrainLink Train, Intercity Train, NSW TrainLink Coach, Sydney Light Rail, Berrima Buslines, Bathurst Buslines, Lithgow Buslines, Kennedys Bus Service, Kiama Coachlines, Nowra Coaches, Shoal Bus, Stuarts Coaches, Dubbo Buslines, Orange Buslines, Newman's Bus Service, Western Road Liners, Forbes Buslines, Buslink Broken Hill, Cowra Bus Service, Griffith Buslines, PBC Goulburn, PBC Crookwell, Picton Buslines, Premier Motor Service, Buslink Sunraysia, Busabout Wagga, Junee Buses, Allen's Coaches, Qcity Transit, Transborder Express, Murrays Coaches, Purtills, Newtons Bus Service, Ulladulla Buslines, Priors Bus Service, Symons Bus & Coach Service, Cooma Coaches, Martins Albury, Dysons, Cann's Buslines, Sapphire Coast Buslines, Bega Valley Coaches, Sapphire Coast Buslines, Sydney Ferries, Station Link, Forest Coach Lines, Hillsbus, Punchbowl Bus Company, Transdev NSW",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "New South Wales",
+        "bounding_box": {
+            "minimum_latitude": -37.8176444720042,
+            "maximum_latitude": -27.4655498069599,
+            "minimum_longitude": 141.435090952048,
+            "maximum_longitude": 153.619511714123,
+            "extracted_on": "2022-04-04T18:49:47+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/transport-for-nsw/237/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-new-south-wales-train-replacement-bus-operators-gtfs-1322.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/ca-ontario-guelph-transit-gtfs-1300.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-guelph-transit-gtfs-1300.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1300,
+    "data_type": "gtfs",
+    "provider": "Guelph Transit",
+    "location": {
+        "country_code": "CA",
+        "subdivision_name": "Ontario",
+        "municipality": "Guelph",
+        "bounding_box": {
+            "minimum_latitude": 43.49932,
+            "maximum_latitude": 43.580844,
+            "minimum_longitude": -80.322631,
+            "maximum_longitude": -80.175244,
+            "extracted_on": "2022-04-04T18:44:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/guelph-transit/53/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-guelph-transit-gtfs-1300.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-posely-gtfs-1317.json
+++ b/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-posely-gtfs-1317.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1317,
+    "data_type": "gtfs",
+    "provider": "POSELY",
+    "location": {
+        "country_code": "FI",
+        "subdivision_name": "Pohjois-Karjala",
+        "bounding_box": {
+            "minimum_latitude": 61.8669,
+            "maximum_latitude": 63.560062,
+            "minimum_longitude": 27.190477,
+            "maximum_longitude": 30.936747,
+            "extracted_on": "2022-04-04T18:45:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/liikennevirasto/733/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-pohjois-karjala-posely-gtfs-1317.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-ile-de-france-blablacar-bus-gtfs-1314.json
+++ b/catalogs/sources/gtfs/schedule/fr-ile-de-france-blablacar-bus-gtfs-1314.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1314,
+    "data_type": "gtfs",
+    "provider": "BlaBlaCar Bus",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Île-de-France",
+        "municipality": "Paris",
+        "bounding_box": {
+            "minimum_latitude": 41.394968,
+            "maximum_latitude": 53.552107,
+            "minimum_longitude": -4.48214,
+            "maximum_longitude": 13.730119,
+            "extracted_on": "2022-04-04T18:45:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/idbus/519/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-ile-de-france-blablacar-bus-gtfs-1314.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/fr-ile-de-france-transilien-sncf-gtfs-1299.json
+++ b/catalogs/sources/gtfs/schedule/fr-ile-de-france-transilien-sncf-gtfs-1299.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1299,
+    "data_type": "gtfs",
+    "provider": "Transilien SNCF",
+    "location": {
+        "country_code": "FR",
+        "subdivision_name": "Île-de-France",
+        "municipality": "Paris",
+        "bounding_box": {
+            "minimum_latitude": 48.00718,
+            "maximum_latitude": 49.285257,
+            "minimum_longitude": 1.370633,
+            "maximum_longitude": 3.409411,
+            "extracted_on": "2022-04-04T18:44:07+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/transilien-sncf/207/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-ile-de-france-transilien-sncf-gtfs-1299.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/gb-unknown-chiltern-railways-gtfs-1311.json
+++ b/catalogs/sources/gtfs/schedule/gb-unknown-chiltern-railways-gtfs-1311.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 1311,
+    "data_type": "gtfs",
+    "provider": "Chiltern Railways",
+    "location": {
+        "country_code": "GB",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 58.59018,
+            "minimum_longitude": -5.83908,
+            "maximum_longitude": 1.74971,
+            "extracted_on": "2022-04-04T18:44:54+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/association-of-train-operating-companies/284/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gb-unknown-chiltern-railways-gtfs-1311.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/it-marche-trenitalia-gtfs-1319.json
+++ b/catalogs/sources/gtfs/schedule/it-marche-trenitalia-gtfs-1319.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1319,
+    "data_type": "gtfs",
+    "provider": "Trenitalia, Contram Mobilita s.c.p.a., Trasfer Soc. Cons. a.r.l., Adriabus spa, Soc. Consortile A.T.M.A., Start Spa",
+    "location": {
+        "country_code": "IT",
+        "subdivision_name": "Marche",
+        "bounding_box": {
+            "minimum_latitude": 40.634364,
+            "maximum_latitude": 45.417772,
+            "minimum_longitude": 11.880772,
+            "maximum_longitude": 17.939272,
+            "extracted_on": "2022-04-04T18:45:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/region-marche/740/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-marche-trenitalia-gtfs-1319.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-sizuoka-kakegawa-local-voluntary-operation-bus-gtfs-1303.json
+++ b/catalogs/sources/gtfs/schedule/jp-sizuoka-kakegawa-local-voluntary-operation-bus-gtfs-1303.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1303,
+    "data_type": "gtfs",
+    "provider": "Kakegawa Local Voluntary Operation Bus",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Sizuoka",
+        "municipality": "Kakegawa",
+        "bounding_box": {
+            "minimum_latitude": 34.753825,
+            "maximum_latitude": 34.771492,
+            "minimum_longitude": 137.9915045,
+            "maximum_longitude": 138.031032,
+            "extracted_on": "2022-04-04T18:44:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/opentransit/352/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-sizuoka-kakegawa-local-voluntary-operation-bus-gtfs-1303.zip?alt=media",
+        "license": "http://opentrans.it/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-sizuoka-omaezaki-local-voluntary-operation-bus-gtfs-1301.json
+++ b/catalogs/sources/gtfs/schedule/jp-sizuoka-omaezaki-local-voluntary-operation-bus-gtfs-1301.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1301,
+    "data_type": "gtfs",
+    "provider": "Omaezaki Local Voluntary Operation Bus",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Sizuoka",
+        "municipality": "Omaezaki",
+        "bounding_box": {
+            "minimum_latitude": 34.6001182,
+            "maximum_latitude": 34.65078466,
+            "minimum_longitude": 138.1188726,
+            "maximum_longitude": 138.2219913,
+            "extracted_on": "2022-04-04T18:44:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/opentransit/353/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-sizuoka-omaezaki-local-voluntary-operation-bus-gtfs-1301.zip?alt=media",
+        "license": "http://opentrans.it/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/jp-sizuoka-susonohru-gtfs-1302.json
+++ b/catalogs/sources/gtfs/schedule/jp-sizuoka-susonohru-gtfs-1302.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1302,
+    "data_type": "gtfs",
+    "provider": "Susonohru",
+    "location": {
+        "country_code": "JP",
+        "subdivision_name": "Sizuoka",
+        "municipality": "Susono",
+        "bounding_box": {
+            "minimum_latitude": 35.15395111,
+            "maximum_latitude": 35.20147694,
+            "minimum_longitude": 138.8992461,
+            "maximum_longitude": 138.9346917,
+            "extracted_on": "2022-04-04T18:44:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/opentransit/354/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/jp-sizuoka-susonohru-gtfs-1302.zip?alt=media",
+        "license": "http://opentrans.it/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/nz-christchurch-christchurch-metro-gtfs-1313.json
+++ b/catalogs/sources/gtfs/schedule/nz-christchurch-christchurch-metro-gtfs-1313.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1313,
+    "data_type": "gtfs",
+    "provider": "Christchurch Metro",
+    "location": {
+        "country_code": "NZ",
+        "subdivision_name": "Christchurch",
+        "bounding_box": {
+            "minimum_latitude": -43.811456,
+            "maximum_latitude": -43.28702,
+            "minimum_longitude": 172.106654,
+            "maximum_longitude": 172.766792,
+            "extracted_on": "2022-04-04T18:45:02+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/christchurch-metro/41/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nz-christchurch-christchurch-metro-gtfs-1313.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/se-unknown-samtrafiken-gtfs-1321.json
+++ b/catalogs/sources/gtfs/schedule/se-unknown-samtrafiken-gtfs-1321.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1321,
+    "data_type": "gtfs",
+    "provider": "Samtrafiken, SJ, NSB, NSB/SJ, Visingsöleden, UL, Sörmlandstrafiken, ÖstgötaTrafiken, JLT, Länstrafiken Kronoberg, KLT, Region Gotland, Blekingetrafiken, Gällivare Stadstrafik, Hallandstrafiken, Värmlandstrafik, VL, Dalatrafik, X-trafik, Din Tur, Destination Gotland, Länstrafiken Jämtland, Länstrafiken Västerbotten, Länstrafiken Norrbotten, SL, Skånetrafiken, Flygbussarna, Västtrafik, Ventrafiken, Arlanda Express, Länstrafiken Örebro, Öresundståg, BT Buss, Mälartåg, Vy Tåg, Värmlandstrafik, Waxholmsbolaget, FlixTrain, Bus4You, Nettbuss Express, Skelleftebuss, Y-buss, MasExpressen, Silverlinjen, Härjedalingen, Merresor Express, ForSea, Snälltåget, Nikkaluoktaexpressen, Trafikverket Färjerederiet, Bergkvarabuss, Vy Nattåg, Vy Norrtåg, Krösatågen, Tågab, Karlstadsbuss, Luleå Lokaltrafik, Trosabussen, Ressels Rederi, Haparanda lokaltrafik, Roslagens Sjötrafik, Piteå Lokaltrafik, Strömma, Boden Stadstrafik, Snötåget, Kiruna Stadstrafik, Stadsbussarna Östersund, Krösatågen, SJ NORGE, Skärgårdsbåtarna i Uddevalla, MTRX, Stavsnäs Båttaxi, Söne Buss, Kalix stadstrafik, Flixbus, Stockholms stad",
+    "name": "TrafikLab ",
+    "location": {
+        "country_code": "SE",
+        "bounding_box": {
+            "minimum_latitude": 51.04013,
+            "maximum_latitude": 68.441703,
+            "minimum_longitude": 8.227388,
+            "maximum_longitude": 24.183867,
+            "extracted_on": "2022-04-04T18:47:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/trafiklab/50/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-unknown-samtrafiken-gtfs-1321.zip?alt=media",
+        "license": "http://www.trafiklab.se/api"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/se-unknown-trafiklab-gtfs-1320.json
+++ b/catalogs/sources/gtfs/schedule/se-unknown-trafiklab-gtfs-1320.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1320,
+    "data_type": "gtfs",
+    "provider": "Trafiklab",
+    "name": "All public transport in Sweden",
+    "location": {
+        "country_code": "SE",
+        "bounding_box": {
+            "minimum_latitude": 58.744573,
+            "maximum_latitude": 60.679478,
+            "minimum_longitude": 17.15189,
+            "maximum_longitude": 19.404908,
+            "extracted_on": "2022-04-04T18:46:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/storstockholms-lokaltrafik/1086/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-unknown-trafiklab-gtfs-1320.zip?alt=media",
+        "license": "https://www.trafiklab.se/node/17865/license"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-chiang-mai-university-cmu-gtfs-1310.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-chiang-mai-university-cmu-gtfs-1310.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1310,
+    "data_type": "gtfs",
+    "provider": "Chiang Mai University (CMU)",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai",
+        "municipality": "Chiang Mai",
+        "bounding_box": {
+            "minimum_latitude": 18.758568,
+            "maximum_latitude": 18.807697,
+            "minimum_longitude": 98.935385,
+            "maximum_longitude": 98.972451,
+            "extracted_on": "2022-04-04T18:44:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/chiang-mai-university/788/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-chiang-mai-university-cmu-gtfs-1310.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-kwanwiang-transport-gtfs-1315.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-kwanwiang-transport-gtfs-1315.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1315,
+    "data_type": "gtfs",
+    "provider": "Kwanwiang Transport, LTD.",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai ",
+        "bounding_box": {
+            "minimum_latitude": 18.720218,
+            "maximum_latitude": 18.795956,
+            "minimum_longitude": 98.946055,
+            "maximum_longitude": 99.004577,
+            "extracted_on": "2022-04-04T18:45:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/kwanwiang-transport/785/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-kwanwiang-transport-gtfs-1315.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/th-chiang-mai-whitebus-gtfs-1325.json
+++ b/catalogs/sources/gtfs/schedule/th-chiang-mai-whitebus-gtfs-1325.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1325,
+    "data_type": "gtfs",
+    "provider": "WhiteBus",
+    "location": {
+        "country_code": "TH",
+        "subdivision_name": "Chiang Mai",
+        "bounding_box": {
+            "minimum_latitude": 18.76967,
+            "maximum_latitude": 18.81262,
+            "minimum_longitude": 98.94592,
+            "maximum_longitude": 99.01788,
+            "extracted_on": "2022-04-04T18:49:53+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/whitebus/786/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/th-chiang-mai-whitebus-gtfs-1325.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-changhua-chyuanlin-passenger-transport-general-manager-gtfs-1305.json
+++ b/catalogs/sources/gtfs/schedule/tw-changhua-chyuanlin-passenger-transport-general-manager-gtfs-1305.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1305,
+    "data_type": "gtfs",
+    "provider": "CH_Yuanlin Passenger Transport (General Manager), CH_中鹿客運(公總), CH_彰化客運(公總)",
+    "location": {
+        "country_code": "TW",
+        "subdivision_name": "Changhua",
+        "bounding_box": {
+            "minimum_latitude": 23.385829,
+            "maximum_latitude": 25.297518,
+            "minimum_longitude": 120.171053,
+            "maximum_longitude": 121.94879,
+            "extracted_on": "2022-04-04T18:44:19+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/taiwan/956/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-changhua-chyuanlin-passenger-transport-general-manager-gtfs-1305.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-nantou-nttotal-passenger-common-total-gtfs-1306.json
+++ b/catalogs/sources/gtfs/schedule/tw-nantou-nttotal-passenger-common-total-gtfs-1306.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1306,
+    "data_type": "gtfs",
+    "provider": "NT_Total passenger (common total), NT_南投客運(公總), NT_全航客運(公總)",
+    "location": {
+        "country_code": "TW",
+        "subdivision_name": "Nantou",
+        "bounding_box": {
+            "minimum_latitude": 23.67303,
+            "maximum_latitude": 25.290079,
+            "minimum_longitude": 120.598713,
+            "maximum_longitude": 121.9837549,
+            "extracted_on": "2022-04-04T18:44:22+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/taiwan/958/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-nantou-nttotal-passenger-common-total-gtfs-1306.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/tw-yunlin-ylyuanlin-passenger-transport-general-manager-gtfs-1307.json
+++ b/catalogs/sources/gtfs/schedule/tw-yunlin-ylyuanlin-passenger-transport-general-manager-gtfs-1307.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1307,
+    "data_type": "gtfs",
+    "provider": "YL_Yuanlin Passenger Transport (General Manager), YL_臺西客運(公總)",
+    "location": {
+        "country_code": "TW",
+        "subdivision_name": "Yunlin",
+        "bounding_box": {
+            "minimum_latitude": 23.385829,
+            "maximum_latitude": 25.284729,
+            "minimum_longitude": 120.15701,
+            "maximum_longitude": 121.926085,
+            "extracted_on": "2022-04-04T18:44:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/taiwan/957/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tw-yunlin-ylyuanlin-passenger-transport-general-manager-gtfs-1307.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-alabama-capital-trailways-gtfs-1308.json
+++ b/catalogs/sources/gtfs/schedule/us-alabama-capital-trailways-gtfs-1308.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1308,
+    "data_type": "gtfs",
+    "provider": "Capital Trailways",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Alabama",
+        "bounding_box": {
+            "minimum_latitude": 30.6705,
+            "maximum_latitude": 33.208349,
+            "minimum_longitude": -88.1012,
+            "maximum_longitude": -87.0221,
+            "extracted_on": "2022-04-04T18:44:26+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/capital-trailways/819/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alabama-capital-trailways-gtfs-1308.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-biscay-la-burundesa-sa-gtfs-1316.json
+++ b/catalogs/sources/gtfs/schedule/us-biscay-la-burundesa-sa-gtfs-1316.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1316,
+    "data_type": "gtfs",
+    "provider": "La Burundesa S.A.",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Biscay",
+        "municipality": "Bilbao",
+        "bounding_box": {
+            "minimum_latitude": 0.0,
+            "maximum_latitude": 43.343606,
+            "minimum_longitude": -2.683427,
+            "maximum_longitude": 0.0,
+            "extracted_on": "2022-04-04T18:45:13+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/la-burundesa/658/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-biscay-la-burundesa-sa-gtfs-1316.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-tri-delta-transit-gtfs-1323.json
+++ b/catalogs/sources/gtfs/schedule/us-california-tri-delta-transit-gtfs-1323.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1323,
+    "data_type": "gtfs",
+    "provider": "Tri Delta Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Concord",
+        "bounding_box": {
+            "minimum_latitude": 37.918801,
+            "maximum_latitude": 38.039856,
+            "minimum_longitude": -122.139478,
+            "maximum_longitude": -121.6914,
+            "extracted_on": "2022-04-04T18:49:50+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/tri-delta-transit/1148/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-tri-delta-transit-gtfs-1323.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-turlock-transit-gtfs-1324.json
+++ b/catalogs/sources/gtfs/schedule/us-california-turlock-transit-gtfs-1324.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1324,
+    "data_type": "gtfs",
+    "provider": "Turlock Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "bounding_box": {
+            "minimum_latitude": 37.47806,
+            "maximum_latitude": 37.52925,
+            "minimum_longitude": -120.88435,
+            "maximum_longitude": -120.83076,
+            "extracted_on": "2022-04-04T18:49:52+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/turlock-transit/1288/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-turlock-transit-gtfs-1324.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-ferry-service-gtfs-1309.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-ferry-service-gtfs-1309.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 1309,
+    "data_type": "gtfs",
+    "provider": "Massachusetts Ferry Service",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Massachusetts",
+        "bounding_box": {
+            "minimum_latitude": 40.409099,
+            "maximum_latitude": 42.52193,
+            "minimum_longitude": -74.006617,
+            "maximum_longitude": -70.05891,
+            "extracted_on": "2022-04-04T18:44:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/massdot/109/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-massachusetts-ferry-service-gtfs-1309.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-pennsylvania-beaver-county-transit-authority-gtfs-1312.json
+++ b/catalogs/sources/gtfs/schedule/us-pennsylvania-beaver-county-transit-authority-gtfs-1312.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1312,
+    "data_type": "gtfs",
+    "provider": "Beaver County Transit Authority ",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Pennsylvania",
+        "municipality": "Rochester",
+        "bounding_box": {
+            "minimum_latitude": 40.4382300638098,
+            "maximum_latitude": 40.799899148935,
+            "minimum_longitude": -80.3831790616023,
+            "maximum_longitude": -79.9912694091361,
+            "extracted_on": "2022-04-04T18:44:56+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/beaver-county-transit-authority/1154/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-pennsylvania-beaver-county-transit-authority-gtfs-1312.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-washington-kitsap-transit-gtfs-1304.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-kitsap-transit-gtfs-1304.json
@@ -1,0 +1,22 @@
+{
+    "mdb_source_id": 1304,
+    "data_type": "gtfs",
+    "provider": "Kitsap Transit",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Washington",
+        "municipality": "Bremerton",
+        "bounding_box": {
+            "minimum_latitude": 47.3891906204372,
+            "maximum_latitude": 47.8123792166667,
+            "minimum_longitude": -122.7108108,
+            "maximum_longitude": -122.337807,
+            "extracted_on": "2022-04-04T18:44:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/kitsap-transit/296/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-kitsap-transit-gtfs-1304.zip?alt=media",
+        "license": "http://www.kitsaptransit.com/privacy-policy#developer"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-wisconsin-milwaukee-county-transit-system-gtfs-1318.json
+++ b/catalogs/sources/gtfs/schedule/us-wisconsin-milwaukee-county-transit-system-gtfs-1318.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 1318,
+    "data_type": "gtfs",
+    "provider": "Milwaukee County Transit System",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Wisconsin",
+        "municipality": "Milwaukee",
+        "bounding_box": {
+            "minimum_latitude": 42.8707516,
+            "maximum_latitude": 43.3841549,
+            "minimum_longitude": -88.1150233,
+            "maximum_longitude": -87.84947,
+            "extracted_on": "2022-04-04T18:45:27+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://transitfeeds.com/p/milwaukee-county-transit-system/182/latest/download",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-wisconsin-milwaukee-county-transit-system-gtfs-1318.zip?alt=media"
+    }
+}


### PR DESCRIPTION
**Summary:**

Fixes #71: First data import

This PR adds the twentieth part of first data import for the GTFS Schedule sources in the catalogs.

Changes:

- The GTFS Schedule Sources catalog is extended with 27 new sources.

**Expected behavior:** 

Same as before but with more sources.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~