### PR TITLE
fix: Fix feed of Verkehrsverbund Hegau-Bodensee [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ch-unknown-lk2-gtfs-914.json
+++ b/catalogs/sources/gtfs/schedule/ch-unknown-lk2-gtfs-914.json
@@ -1,9 +1,11 @@
 {
     "mdb_source_id": 914,
     "data_type": "gtfs",
-    "provider": "LK2",
+    "provider": "NVBW",
+    "name": "Verkehrsverbund Hegau-Bodensee",
     "location": {
-        "country_code": "CH",
+        "country_code": "DE",
+        "subdivision_name": "Baden-Württemberg",
         "bounding_box": {
             "minimum_latitude": 47.6262750305982,
             "maximum_latitude": 47.9837269187185,
@@ -14,6 +16,7 @@
     },
     "urls": {
         "direct_download": "https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/vhb.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ch-unknown-lk2-gtfs-914.zip?alt=media"
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ch-unknown-lk2-gtfs-914.zip?alt=media",
+        "license": "https://www.nvbw.de/open-data/lizenz"
     }
 }


### PR DESCRIPTION
The feed actually contains routes of "Verkehrsverbund Hegau-Bodensee" which is located in Baden-Württemberg, Germany.