### PR TITLE
fix: Fix wrong countries for some sources

### DIFF
--- a/catalogs/sources/gtfs/schedule/ca-alberta-grande-prairie-transit-gtfs-1278.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-grande-prairie-transit-gtfs-1278.json
@@ -16,6 +16,6 @@
     },
     "urls": {
         "direct_download": "https://transitfeeds.com/p/grande-prairie-transit/1255/latest/download",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-alberta-grande-prairie-transit-gtfs-1278.zip?alt=media"
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-alberta-grande-prairie-transit-gtfs-1278.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/ca-alberta-grande-prairie-transit-gtfs-1278.json
+++ b/catalogs/sources/gtfs/schedule/ca-alberta-grande-prairie-transit-gtfs-1278.json
@@ -3,7 +3,7 @@
     "data_type": "gtfs",
     "provider": "Grande Prairie Transit",
     "location": {
-        "country_code": "US",
+        "country_code": "CA",
         "subdivision_name": "Alberta",
         "municipality": "Grande Prairie",
         "bounding_box": {

--- a/catalogs/sources/gtfs/schedule/es-alicante-tram-alicante-gtfs-1039.json
+++ b/catalogs/sources/gtfs/schedule/es-alicante-tram-alicante-gtfs-1039.json
@@ -3,7 +3,7 @@
     "data_type": "gtfs",
     "provider": "TRAM Alicante",
     "location": {
-        "country_code": "IE",
+        "country_code": "ES",
         "subdivision_name": "Alicante",
         "bounding_box": {
             "minimum_latitude": 38.345085144,

--- a/catalogs/sources/gtfs/schedule/es-alicante-tram-alicante-gtfs-1039.json
+++ b/catalogs/sources/gtfs/schedule/es-alicante-tram-alicante-gtfs-1039.json
@@ -15,6 +15,6 @@
     },
     "urls": {
         "direct_download": "http://www.tramalicante.es/google_transit_feed/google_transit.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ie-alicante-tram-alicante-gtfs-1039.zip?alt=media"
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/es-alicante-tram-alicante-gtfs-1039.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-indiana-muncie-indiana-transit-system-mits-gtfs-719.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-muncie-indiana-transit-system-mits-gtfs-719.json
@@ -3,7 +3,7 @@
     "data_type": "gtfs",
     "provider": "Muncie Indiana Transit System (MITS)",
     "location": {
-        "country_code": "CA",
+        "country_code": "US",
         "subdivision_name": "Indiana",
         "municipality": "Muncie",
         "bounding_box": {

--- a/catalogs/sources/gtfs/schedule/us-indiana-muncie-indiana-transit-system-mits-gtfs-719.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-muncie-indiana-transit-system-mits-gtfs-719.json
@@ -16,6 +16,6 @@
     },
     "urls": {
         "direct_download": "http://www.mitsbus.org/wp-content/uploads/2016/11/GTFS.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-indiana-muncie-indiana-transit-system-mits-gtfs-719.zip?alt=media"
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-muncie-indiana-transit-system-mits-gtfs-719.zip?alt=media"
     }
 }


### PR DESCRIPTION
I noticed that these sources have the wrong country code.

The `urls.latest` entries also seem wrong, but I'm not sure if/how they should be fixed.