### PR TITLE
fix: Missing constant causes `export_to_csv.yml` to fail

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -72,6 +72,7 @@ jobs:
             ENTITY_TYPE = "entity_type"
             UNKNOWN = "unknown"
             URLS_AUTHENTICATION_TYPE = "urls.authentication_type"
+            FEATURES = "features"
 
             # tools.constants.GTFS_SCHEDULE_CATALOG_PATH_FROM_ROOT
             GTFS_SCHEDULE_CATALOG_PATH_FROM_ROOT = "catalogs/sources/gtfs/schedule"


### PR DESCRIPTION
Fixes #180 by adding defining the constant `FEATURES` in `export_to_csv.yml`