### PR TITLE
fix: Updates GTFS Realtime JSON schema to make authentication type optional

### DIFF
--- a/schemas/gtfs_realtime_source_schema.json
+++ b/schemas/gtfs_realtime_source_schema.json
@@ -85,55 +85,66 @@
           "pattern": "^(http|https|ftp):\/\/[a-zA-Z0-9.,~#{}():&/%='?_+/-]+$"
         }
       },
-      "allOf": [
+      "oneOf": [
         {
-          "if": {
-            "properties": {
-              "authentication_type": {
-                "enum": [
-                  1,
-                  2,
-                  3
-                ]
-              }
-            }
-          },
-          "then": {
+          "not": {
             "required": [
-              "authentication_info"
+              "authentication_type"
             ]
-          },
-          "else": {
-            "not": {
-              "required": [
-                "authentication_info"
-              ]
-            }
           }
         },
         {
-          "if": {
-            "properties": {
-              "authentication_type": {
-                "enum": [
-                  1,
-                  2
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "authentication_type": {
+                    "enum": [
+                      1,
+                      2,
+                      3
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "authentication_info"
                 ]
+              },
+              "else": {
+                "not": {
+                  "required": [
+                    "authentication_info"
+                  ]
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "authentication_type": {
+                    "enum": [
+                      1,
+                      2
+                    ]
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "api_key_parameter_name"
+                ]
+              },
+              "else": {
+                "not": {
+                  "required": [
+                    "api_key_parameter_name"
+                  ]
+                }
               }
             }
-          },
-          "then": {
-            "required": [
-              "api_key_parameter_name"
-            ]
-          },
-          "else": {
-            "not": {
-              "required": [
-                "api_key_parameter_name"
-              ]
-            }
-          }
+          ]
         }
       ],
       "required": [


### PR DESCRIPTION
**Summary:**

Part 2 to #185: Define realtime schema and operations

This PR updates the GTFS Realtime JSON schema so that the `authentication_type` is optional. The previous version made integration tests to fail when a source was missing the `authentication_type`.

Changes:
 - `gtfs_realtime_source_schema.json` is updated.

**Expected behavior:** 

- The user can now add GTFS Realtime sources without specifying the `authentication_type` field.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~