### PR TITLE
fix: Daily cron job fails because of a KeyError Exception

### DIFF
--- a/.github/workflows/direct_download_urls_test_for_sources.yml
+++ b/.github/workflows/direct_download_urls_test_for_sources.yml
@@ -126,6 +126,8 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Validate and download the datasets
         shell: python
+        env:
+          API_SOURCE_SECRETS: ${{ secrets.API_SOURCE_SECRETS }}
         run: |
           import os
           import json
@@ -155,7 +157,7 @@ jobs:
               url = job_json[DIRECT_DOWNLOAD]
               authentication_type = job_json[AUTHENTICATION_TYPE]
               api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
-              api_key_parameter_value = api_source_secrets[base]
+              api_key_parameter_value = api_source_secrets.get(base)
 
               # Download the dataset
               zip_path = os.path.join(ROOT, DATASETS, f"{base}.zip")

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -3,6 +3,8 @@ name: Store latest datasets cronjob
 on:
   schedule:
     - cron: "0 0 * * *"
+  pull_request:
+    branches: [ main ]
 
 jobs:
   get-urls:

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -141,6 +141,8 @@ jobs:
           pip install wheel requests
       - name: Validate and download the datasets
         shell: python
+        env:
+          API_SOURCE_SECRETS: ${{ secrets.API_SOURCE_SECRETS }}
         run: |
           import os
           import json
@@ -172,7 +174,7 @@ jobs:
               url = job_json[DIRECT_DOWNLOAD]
               authentication_type = job_json[AUTHENTICATION_TYPE]
               api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
-              api_key_parameter_value = api_source_secrets[base]
+              api_key_parameter_value = api_source_secrets.get(base)
 
               # Download the dataset
               zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -3,8 +3,6 @@ name: Store latest datasets cronjob
 on:
   schedule:
     - cron: "0 0 * * *"
-  pull_request:
-    branches: [ main ]
 
 jobs:
   get-urls:


### PR DESCRIPTION
**Summary:**

Closes #197: Daily cron job fails because of a KeyError Exception

This PR fixes `store_latest_dataset_cronjob.yml` and `direct_download_urls_test_for_sources.yml`

**Expected behavior:** 

The daily cron job and previous PR source check should succeed without a `KeyError` Exception.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~