### PR TITLE
fix: Fix API secrets issue blocking fork PRs

### DIFF
--- a/.github/workflows/direct_download_urls_test_for_sources.yml
+++ b/.github/workflows/direct_download_urls_test_for_sources.yml
@@ -147,9 +147,6 @@ jobs:
           # Secrets constants
           API_SOURCE_SECRETS = "API_SOURCE_SECRETS"
 
-          # Load API source secrets
-          api_source_secrets = json.loads(os.environ[API_SOURCE_SECRETS])
-
           jobs = """${{ matrix.data }}""".split()
           for job in jobs:
               job_json = json.loads(job)
@@ -157,6 +154,11 @@ jobs:
               url = job_json[DIRECT_DOWNLOAD]
               authentication_type = job_json[AUTHENTICATION_TYPE]
               api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
+              if authentication_type in [1, 2]:
+                  # Load API source secrets only if authentication is required
+                  # This will allow users to add or update
+                  # sources that do not require authentication via forks.
+                  api_source_secrets = json.loads(os.environ[API_SOURCE_SECRETS])
               api_key_parameter_value = api_source_secrets.get(base)
 
               # Download the dataset


### PR DESCRIPTION
**Summary:**

Closes #204: Fix API secrets issue blocking fork PRs

This PR fixes `direct_download_urls_test_for_sources.yml` so that the API secret is loaded only if a source requiring authentication is added or updated. This change will allow user to contribute data that do not require authentication via forks. Fork PRs with data requiring authentication will still fail. Data requiring authentication must be updated by us via our repo to access the secret.

**Expected behavior:** 

Users can contribute data that do not require authentication via forks.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~