### PR TITLE
feat: Add 3 developer test feeds for flex-v2 [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-1-gtfs-1817.json
+++ b/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-1-gtfs-1817.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 1817,
     "data_type": "gtfs",
-    "provider": "Flex-v2 Developer Test Feed 1",
+    "provider": "GoMonrovia",
     "features": [
         "flex-v2"
     ],
@@ -9,7 +9,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
-        "municipality": "test1",
+        "municipality": "Monrovia",
         "bounding_box": {
             "minimum_latitude": null,
             "maximum_latitude": null,

--- a/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-1-gtfs-1817.json
+++ b/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-1-gtfs-1817.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 1817,
+    "data_type": "gtfs",
+    "provider": "Flex-v2 Developer Test Feed 1",
+    "features": [
+        "flex-v2"
+    ],
+    "status": "development",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "test1",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-08-12T18:00:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.calitp.org/test/TestFlex1.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-flex-v2-developer-test-feed-1-gtfs-1817.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-2-gtfs-1818.json
+++ b/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-2-gtfs-1818.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 1818,
+    "data_type": "gtfs",
+    "provider": "Flex-v2 Developer Test Feed 2",
+    "features": [
+        "flex-v2"
+    ],
+    "status": "development",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "test2",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-08-12T18:01:24+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.calitp.org/test/TestFlex2.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-flex-v2-developer-test-feed-2-gtfs-1818.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-2-gtfs-1818.json
+++ b/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-2-gtfs-1818.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 1818,
     "data_type": "gtfs",
-    "provider": "Flex-v2 Developer Test Feed 2",
+    "provider": "City of Dixon",
     "features": [
         "flex-v2"
     ],
@@ -9,7 +9,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
-        "municipality": "test2",
+        "municipality": "Dixon",
         "bounding_box": {
             "minimum_latitude": null,
             "maximum_latitude": null,

--- a/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-3-gtfs-1819.json
+++ b/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-3-gtfs-1819.json
@@ -1,7 +1,7 @@
 {
     "mdb_source_id": 1819,
     "data_type": "gtfs",
-    "provider": "Flex-v2 Developer Test Feed 3",
+    "provider": "Anaheim Regional Transportation",
     "features": [
         "flex-v2"
     ],
@@ -9,7 +9,7 @@
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
-        "municipality": "test3",
+        "municipality": "Anaheim",
         "bounding_box": {
             "minimum_latitude": null,
             "maximum_latitude": null,

--- a/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-3-gtfs-1819.json
+++ b/catalogs/sources/gtfs/schedule/us-california-flex-v2-developer-test-feed-3-gtfs-1819.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 1819,
+    "data_type": "gtfs",
+    "provider": "Flex-v2 Developer Test Feed 3",
+    "features": [
+        "flex-v2"
+    ],
+    "status": "development",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "test3",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-08-12T18:01:51+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://gtfs.calitp.org/test/TestFlex3.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-flex-v2-developer-test-feed-3-gtfs-1819.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-fresno-county-rural-transit-agency-fcrta-gtfs-85.json
+++ b/catalogs/sources/gtfs/schedule/us-california-fresno-county-rural-transit-agency-fcrta-gtfs-85.json
@@ -5,7 +5,7 @@
     "features": [
         "fares-v1"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -19,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/fresnocounty-ca-us/fresnocounty-ca-us.zip",
+        "direct_download": "https://rapid.nationalrtap.org/GTFSFileManagement/UserUploadFiles/7869/google_transit.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-fresno-county-rural-transit-agency-fcrta-gtfs-85.zip?alt=media"
     }
 }


### PR DESCRIPTION
Add 3 feeds with 'development' status for testing flex-v2 features, representing a variety of service types
- Flex-v2 Developer test feed 1: uses location_groups.txt and locations.geojson includes a "donut" - one service area fully enclosed in another.
- Flex-v2 Developer test feed 2: single service area, with split service times and different booking rules dependent on day
- Flex-v2 Developer test feed 3: On-demand, flexible stop-based service