### PR TITLE
docs: Improvements to README.md and CONTRIBUTING.md

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -12,16 +12,22 @@ newIssueWelcomeComment: >
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: >
   Thanks for opening this pull request! You're awesome.
+
   We use [semantic commit messages](https://github.com/electron/electron/blob/main/docs/development/pull-requests.md#commit-message-guidelines) to streamline the release process. Before your pull request can be merged, you should **update your pull request title** to start with a semantic prefix.
+
   Examples of titles with semantic prefixes:
-    - `fix: Fix wrong countries for some sources`
-    - `feat: Add Features and Status to MDB Schema [SOURCES]
-    - `docs: Improvements to README.md and CONTRIBUTING.md`
-  If your pull request includes adding or updating a source, make sure to **end your pull request title with "[SOURCES]"** so the GitHub workflow runs.
-  To get this PR to the finish line, please do the following:
-    - Read our [Contribution Guidelines](https://github.com/MobilityData/mobility-database-catalogs/blob/main/CONTRIBUTING.md)
-    - When contributing sources, [review the GTFS Schedule and GTFS Realtime Schemas](https://github.com/MobilityData/mobility-database-catalogs#the-core-parts)
-    - Include tests when adding/changing code behavior
+
+- `fix: Fix wrong countries for some sources`
+- `feat: Add Features and Status to MDB Schema [SOURCES]`
+- `docs: Improvements to README.md and CONTRIBUTING.md`
+
+ If your pull request includes adding or updating a source, make sure to **end your pull request title with "[SOURCES]"** so the GitHub workflow runs.
+
+ To get this PR to the finish line, please do the following:
+
+- Read our [Contribution Guidelines](https://github.com/MobilityData/mobility-database-catalogs/blob/main/CONTRIBUTING.md)
+- When contributing sources, [review the GTFS Schedule and GTFS Realtime Schemas](https://github.com/MobilityData/mobility-database-catalogs#the-architecture)
+- Include tests when adding/changing code behavior
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
 
 # Comment to be posted to on pull requests merged by a first time user

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,17 @@ To contribute data to the Mobility Database catalogs, please follow these steps:
 #### Add a GTFS Schedule source
 The easiest way to add a GTFS Schedule source is to use the operation `tools.operations.add_gtfs_schedule_source` through the Python interpreter or in your scripts. This operation makes sure the information provided is correct and will pass our tests. Provide the information about your source in the operation function to add your source.
 
-If your GTFS Schedule source requires API authentication, please use the [form](https://database.mobilitydata.org/update-a-data-source) instead of the PR process so we can generate our own API credentials for the source.
+**If your GTFS Schedule source requires API authentication, please use the [form](https://database.mobilitydata.org/update-a-data-source) **instead of the PR process so we can generate our own API credentials for the source. Sources with `authentication_type=1` or `authentication_type=2` can't be added from forks, but those with `authentication_type=0` can.
 
 ```python
 >>> add_gtfs_schedule_source(
         provider=$YOUR_SOURCE_PROVIDER_NAME,
         country_code=$YOUR_SOURCE_COUNTRY_CODE,
         direct_download_url=$YOUR_SOURCE_DIRECT_DOWNLOAD_URL,
+        authentication_type=$OPTIONAL_AUTHENTICATION_TYPE,
+        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
+        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
+        api_key_parameter_value=$NOT_STORED_API_KEY_PARAMETER_VALUE,
         subdivision_name=$OPTIONAL_SUBDIVISION_NAME,
         municipality=$OPTIONAL_MUNICIPALITY,
         license_url=$OPTIONAL_LICENSE_URL,
@@ -87,6 +91,10 @@ The default value for every parameter is `None`. Note that once a parameter valu
         subdivision_name=$OPTIONAL_SOURCE_SUBDIVISION_NAME,
         municipality=$OPTIONAL_SOURCE_MUNICIPALITY,
         direct_download_url=$OPTIONAL_SOURCE_DIRECT_DOWNLOAD_URL,
+        authentication_type=$OPTIONAL_AUTHENTICATION_TYPE,
+        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
+        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
+        api_key_parameter_value=$NOT_STORED_API_KEY_PARAMETER_VALUE,
         license_url=$OPTIONAL_LICENSE_URL,
         features=[$OPTIONAL_FEATURE_ARRAY],
         status=$OPTIONAL_STATUS
@@ -117,7 +125,10 @@ The default value for every parameter is `None`. Note that once a parameter valu
 ```
 
 ### Update a source file name
-You need to manually search for the JSON file you want in your fork, modify the file name, and modify the `latest.url` to match the new file name.
+You need to
+1. Manually search for the JSON file you want in your fork. For example, finding `ca-ontario-toronto-transit-commission-gtfs-732.json` in the `schedule` folder.
+2. Modify the file name. For example, updating the file name to `ca-ontario-ttc-gtfs-732.json`.
+3. Modify the `latest.url` to match the new file name. For example, changing `https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-toronto-transit-commission-gtfs-732.zip?alt=media` to `https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-toronto-ttc-gtfs-732.zip?alt=media`.
 
 ## Contributing operations
 To contribute operations to the mobility database catalogs, it is suggested that you follow the steps below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ To contribute data to the Mobility Database catalogs, please follow these steps:
 #### Add a GTFS Schedule source
 The easiest way to add a GTFS Schedule source is to use the operation `tools.operations.add_gtfs_schedule_source` through the Python interpreter or in your scripts. This operation makes sure the information provided is correct and will pass our tests. Provide the information about your source in the operation function to add your source.
 
-**If your GTFS Schedule source requires API authentication, please use the [form](https://database.mobilitydata.org/update-a-data-source) **instead of the PR process so we can generate our own API credentials for the source. Sources with `authentication_type=1` or `authentication_type=2` can't be added from forks, but those with `authentication_type=0` can.
+**If your GTFS Schedule source requires API authentication, please use the [form](https://database.mobilitydata.org/update-a-data-source)** instead of the PR process so we can generate our own API credentials for the source. Sources with `authentication_type=1` or `authentication_type=2` can't be added from forks, but those with `authentication_type=0` can.
 
 ```python
 >>> add_gtfs_schedule_source(
@@ -60,7 +60,7 @@ The easiest way to add a GTFS Schedule source is to use the operation `tools.ope
 #### Add a GTFS Realtime source
 The easiest way to add a GTFS Realtime source is to use the operation `tools.operations.add_gtfs_realtime_source` through the Python interpreter or in your scripts. Provide the information about your source in the operation function to add your source.
 
-```
+```python
 >>> add_gtfs_realtime_source(
         entity_type=[$YOUR_SOURCE_ARRAY_OF_ENTITY_TYPES],
         provider=$YOUR_SOURCE_PROVIDER_NAME,
@@ -81,6 +81,8 @@ The easiest way to update a GTFS Schedule source is to use the operation `tools.
 The default value for every parameter is `None`. Note that once a parameter value is added, it cannot be set to `None` again.
 
 `mdb_source_id` and `data_type` cannot be updated. All other parameters can.
+
+**If your GTFS Schedule source requires API authentication, please use the [form](https://database.mobilitydata.org/update-a-data-source)** instead of the PR process to update the source. Sources with `authentication_type=1` or `authentication_type=2` can't be updated from forks, but those with `authentication_type=0` can.
 
 ```python
 >>> update_gtfs_schedule_source(
@@ -108,7 +110,7 @@ The default value for every parameter is `None`. Note that once a parameter valu
 
 `mdb_source_id` and `data_type` cannot be updated. All other parameters can.
 
-```
+```python
 >>> update_gtfs_realtime_source(
         mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
         entity_type=[$YOUR_SOURCE_ARRAY_OF_ENTITY_TYPES],
@@ -150,10 +152,6 @@ To contribute operations to the mobility database catalogs, it is suggested that
 "Sticking to a single consistent and documented coding style for this project is important to ensure that code reviewers dedicate their attention to the functionality of the validation, as opposed to disagreements about the coding style (and avoid [bike-shedding](https://en.wikipedia.org/wiki/Law_of_triviality))."
 
 This project uses [the Black code formatter](https://github.com/psf/black), which is compliant with [PEP8](https://www.python.org/dev/peps/pep-0008/), the style guide for Python code. A [pre-commit](https://pre-commit.com/) hook file is provided with the repo so it is easy to apply Black before each commit. A CI workflow is testing the code pushed in a pull request to make sure it is PEP8 compliant.
-
-## Integration Tests
-
-In order to avoid invalid sources in the Mobility Database Catalogs, any modification made in the repository, addition or update, must pass the integration tests before being merged into the project. The integration tests are listed in the [Test Integration](/tests/test_integration.py) module.
 
 ## How to run tests locally
 This project includes unit and integration tests in order to:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,26 @@
 ## How to contribute to the catalogs
-All contributions to this project are welcome. To propose changes, we encourage contributors to:
+All contributions to this project are welcome. If you want to add or updates sources and don't want to use GitHub, [you can use the form here](https://database.mobilitydata.org/update-a-data-source) and the MobilityData team will add it.
+
+If you want to use GitHub:
+
+To propose changes, we encourage contributors to:
 1. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) this project on GitHub
 2. Create a new branch, and
-3. Propose their changes by opening a [new pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests).
-
-## Issue and PR templates
-We encourage contributors to format pull request titles following the Conventional Commit Specification.
+3. Propose their changes by opening a [new pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests). We encourage contributors to format pull request titles following the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/#examples).
 
 ## Having problems?
 Have you encountered an error? A critical step in troubleshooting is being able to reproduce the problem. You can [create a bug ticket](https://github.com/MobilityData/mobility-database-catalogs/issues/new?assignees=maximearmstrong&labels=&template=bug_report.md&title=%5BBUG%5D) with reproduction steps and we will review it.
 
 ## Contributing data
-To contribute data to the Mobility Database catalogs, it is suggested that you follow the steps below.
 
 Note that adding or updating sources manually is possible, although not recommended as it increases the risk of introducing incorrect or invalid information into your branch and pull request. [Using the operations makes sure your JSON files are valid](#contribute-data).
 
-Note that your contribution must pass all of our tests, as implemented in the CI workflows of this project repository, to be merged into the main branch. To pass our tests, make sure that your contribution conforms to the appropriate JSON schema and that the ID and direct download URL values contributed for a source are unique across the Mobility Database Catalogs.
+Note that your contribution must pass all of our tests, as implemented in the CI workflows of this project repository, to be merged into the main branch. To pass our tests, make sure that your contribution conforms to the appropriate JSON schema and that the ID and direct download URL values contributed for a source are not already in the Mobility Database Catalogs.  
 
-### Prepare to contribute data
-Check our sources to see if any of them match the one you want to add or update.
-
-If yes, please update the source.
-Otherwise, please add the source.
-
-### Contribution flow
+### Data contribution flow
 
 To contribute data to the Mobility Database catalogs, please follow these steps:
+1. [Check our sources](https://github.com/MobilityData/mobility-database-catalogs#browsing-and-consuming-the-spreadsheet) to see if any of them match the one you want to add or update.
 1. Clone our repository on your local machine using the HTTPS protocol `git clone https://github.com/MobilityData/mobility-database-catalogs.git`.
 2. Create a new branch for your contribution `git checkout -b $YOUR_NEW_BRANCH`. Note that you can list the existing branches with `git branch -a` to make sure your branch name is not already used.
 3. Set up the Python environment following the instructions in our README.md.
@@ -39,22 +34,16 @@ To contribute data to the Mobility Database catalogs, please follow these steps:
 11. When your contribution is ready, convert your pull request from draft to ready for review and request a review from a team member at Mobility Data. Not that if you need to modify your contribution after this step, you will be asked to convert your pull request back to draft.
 12. Once your pull request is converted to ready for review and that all the checks have passed, we will approve and merge it.
 
-### Contribute data
-
 #### Add a GTFS Schedule source
 The easiest way to add a GTFS Schedule source is to use the operation `tools.operations.add_gtfs_schedule_source` through the Python interpreter or in your scripts. This operation makes sure the information provided is correct and will pass our tests. Provide the information about your source in the operation function to add your source.
 
-Note that you must pass an `api_key_parameter_value` if your source has `authentication_type = 1` or `authentication_type = 2`. The `api_key_parameter_value` will not be stored and is used only for testing before the source is added to the database..
+If your GTFS Schedule source requires API authentication, please use the [form](https://database.mobilitydata.org/update-a-data-source) instead of the PR process so we can generate our own API credentials for the source.
 
 ```python
 >>> add_gtfs_schedule_source(
         provider=$YOUR_SOURCE_PROVIDER_NAME,
         country_code=$YOUR_SOURCE_COUNTRY_CODE,
         direct_download_url=$YOUR_SOURCE_DIRECT_DOWNLOAD_URL,
-        authentication_type=$OPTIONAL_AUTHENTICATION_TYPE,
-        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
-        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
-        api_key_parameter_value=$NOT_STORED_API_KEY_PARAMETER_VALUE,
         subdivision_name=$OPTIONAL_SUBDIVISION_NAME,
         municipality=$OPTIONAL_MUNICIPALITY,
         license_url=$OPTIONAL_LICENSE_URL,
@@ -89,8 +78,6 @@ The default value for every parameter is `None`. Note that once a parameter valu
 
 `mdb_source_id` and `data_type` cannot be updated. All other parameters can.
 
-Note that you must pass an `api_key_parameter_value` if your source has `authentication_type = 1` or `authentication_type = 2` and that you want to update the direct download URL or authentication-related fields. The `api_key_parameter_value` will not be stored and is used only for testing before the source is updated in the database.
-
 ```python
 >>> update_gtfs_schedule_source(
         mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
@@ -100,10 +87,6 @@ Note that you must pass an `api_key_parameter_value` if your source has `authent
         subdivision_name=$OPTIONAL_SOURCE_SUBDIVISION_NAME,
         municipality=$OPTIONAL_SOURCE_MUNICIPALITY,
         direct_download_url=$OPTIONAL_SOURCE_DIRECT_DOWNLOAD_URL,
-        authentication_type=$OPTIONAL_AUTHENTICATION_TYPE,
-        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
-        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
-        api_key_parameter_value=$NOT_STORED_API_KEY_PARAMETER_VALUE,
         license_url=$OPTIONAL_LICENSE_URL,
         features=[$OPTIONAL_FEATURE_ARRAY],
         status=$OPTIONAL_STATUS
@@ -133,6 +116,9 @@ The default value for every parameter is `None`. Note that once a parameter valu
     )
 ```
 
+### Update a source file name
+You need to manually search for the JSON file you want in your fork, modify the file name, and modify the `latest.url` to match the new file name.
+
 ## Contributing operations
 To contribute operations to the mobility database catalogs, it is suggested that you follow the steps below.
 
@@ -153,6 +139,10 @@ To contribute operations to the mobility database catalogs, it is suggested that
 "Sticking to a single consistent and documented coding style for this project is important to ensure that code reviewers dedicate their attention to the functionality of the validation, as opposed to disagreements about the coding style (and avoid [bike-shedding](https://en.wikipedia.org/wiki/Law_of_triviality))."
 
 This project uses [the Black code formatter](https://github.com/psf/black), which is compliant with [PEP8](https://www.python.org/dev/peps/pep-0008/), the style guide for Python code. A [pre-commit](https://pre-commit.com/) hook file is provided with the repo so it is easy to apply Black before each commit. A CI workflow is testing the code pushed in a pull request to make sure it is PEP8 compliant.
+
+## Integration Tests
+
+In order to avoid invalid sources in the Mobility Database Catalogs, any modification made in the repository, addition or update, must pass the integration tests before being merged into the project. The integration tests are listed in the [Test Integration](/tests/test_integration.py) module.
 
 ## How to run tests locally
 This project includes unit and integration tests in order to:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The Mobility Database Catalogs is a list of open mobility data sources from across the world. [You can learn more about the Mobility Database here](https://database.mobilitydata.org/).
 
-To search sources easily, you can download [the CSV spreadsheet](#the-spreadsheet). If you want to filter for specific types of sources, [you can learn how to here](#get-and-filter-sources).
+To search sources easily, you can download [the CSV spreadsheet](#browsing-and-consuming-the-spreadsheet). If you want to filter for specific types of sources, [you can learn how to here](#get-and-filter-sources).
 
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To search sources easily, you can download [the CSV spreadsheet](#browsing-and-c
 * [GTFS Realtime Schema](#gtfs-realtime-schema)
 * [Installation](#installation)
 * [Get and Filter Sources](#get-and-filter-sources)
+* [Integration Tests](#integration-tests)
 * [License](#license)
 * [Contributing](#contributing)
 
@@ -219,6 +220,9 @@ To get the sources by status, `$STATUS` is expressed as a string and one of:
         feature=$STATUS,
     )
 ```
+## Integration Tests
+
+In order to avoid invalid sources in the Mobility Database Catalogs, any modification made in the repository, addition or update, must pass the integration tests before being merged into the project. The integration tests are listed in the [Test Integration](/tests/test_integration.py) module.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,29 @@
 
 [![Integration tests](https://github.com/MobilityData/mobility-catalogs/actions/workflows/integration_tests.yml/badge.svg?branch=issue%2F343%2Fcatalogs-prototype)](https://github.com/MobilityData/mobility-catalogs/actions/workflows/integration_tests.yml) [![Unit tests](https://github.com/MobilityData/mobility-catalogs/actions/workflows/unit_tests.yml/badge.svg?branch=issue%2F343%2Fcatalogs-prototype)](https://github.com/MobilityData/mobility-catalogs/actions/workflows/unit_tests.yml) [![Export catalogs to CSV](https://github.com/MobilityData/mobility-catalogs/actions/workflows/export_to_csv.yml/badge.svg?branch=issue%2F343%2Fcatalogs-prototype)](https://github.com/MobilityData/mobility-catalogs/actions/workflows/export_to_csv.yml) [![Join the MobilityData chat](https://badgen.net/badge/slack/%20/green?icon=slack)](https://bit.ly/mobilitydata-slack)
 
-The Mobility Database Catalogs is a project that provides a list of open mobility data sources from across the world, and the code to filter and manipulate them. [You can learn more about the Mobility Database here](https://database.mobilitydata.org/).
+The Mobility Database Catalogs is a list of open mobility data sources from across the world. [You can learn more about the Mobility Database here](https://database.mobilitydata.org/).
 
-[You can view our release plan for V1 here](https://github.com/MobilityData/mobility-database-catalogs/issues/30).
+To search sources easily, you can download [the CSV spreadsheet](#the-spreadsheet). If you want to filter for specific types of sources, [you can learn how to here](#get-and-filter-sources).
+
 
 ## Table of Contents
 
-* [The Spreadsheet](#the-spreadsheet)
-* [The Core Parts](#the-core-parts)
-* [GTFS Schedule Data Structure](#gtfs-schedule-data-structure)
-* [GTFS Realtime Data Structure](#gtfs-realtime-data-structure)
+* [Browsing and Consuming The Spreadsheet](#browsing-and-consuming-the-spreadsheet)
+* [The Architecture](#the-architecture)
+* [GTFS Schedule Schema](#gtfs-schedule-schema)
+* [GTFS Realtime Schema](#gtfs-realtime-schema)
 * [Installation](#installation)
-* [Using the Mobility Database Catalogs](#using-the-mobility-database-catalogs)
-* [Integration Tests](#integration-tests)
+* [Get and Filter Sources](#get-and-filter-sources)
 * [License](#license)
 * [Contributing](#contributing)
 
-## The Spreadsheet
+## Browsing and Consuming The Spreadsheet
 
 If you're only interested in browsing the sources or pulling all the latest URLs, [download the CSV](https://bit.ly/catalogs-csv). You can cross reference IDs from the Mobility Database, TransitFeeds and Transitland with [this ID map spreadsheet](https://docs.google.com/spreadsheets/d/1Q96KDppKsn2khdrkraZCQ7T_qRSfwj7WsvqXvuMt4Bc/edit?resourcekey#gid=1787149399).
 
-## The Core Parts
+If you are consuming the spreadsheet, we recommend downloading a new version every time you use it, since the `latest.url` is occasionally updated to match any changes made to the provider and subdivision name within the source file.
+
+## The Architecture
 
 ### Catalogs
 
@@ -36,7 +38,7 @@ Contains the tools to search, add and update the sources. The `tools.operations`
 
 Contains the JSON schemas used to validate the sources in the integration tests.
 
-## GTFS Schedule Data Structure
+## GTFS Schedule Schema
 
 |Field Name|Type|Presence|Definition|  
 |-|-|-|-|
@@ -64,7 +66,7 @@ Contains the JSON schemas used to validate the sources in the integration tests.
 | - latest | URL | System generated | A stable URL for the latest dataset of a source.
 |- license |URL| Optional     | The license information for the direct download URL.  
 
-## GTFS Realtime Data Structure
+## GTFS Realtime Schema
 
 |Field Name|Type|Presence|Definition|  
 |-|-|-|-|
@@ -144,7 +146,7 @@ $ git clone https://github.com/MobilityData/mobility-database-catalogs.git
 $ cd mobility-database-catalogs
 ```
 
-## Using the Mobility Database Catalogs
+## Get and Filter Sources
 
 ### Setup
 
@@ -218,90 +220,6 @@ To get the sources by status, `$STATUS` is expressed as a string and one of:
     )
 ```
 
-To add a new GTFS Schedule source. Note that you must pass an `api_key_parameter_value` if your source has `authentication_type = 1` or `authentication_type = 2`. The `api_key_parameter_value` will not be stored and is used only for testing before the source is added to the database.
-
-```python
->>> add_gtfs_schedule_source(
-        provider=$YOUR_SOURCE_PROVIDER_NAME,
-        country_code=$YOUR_SOURCE_COUNTRY_CODE,
-        direct_download_url=$YOUR_SOURCE_DIRECT_DOWNLOAD_URL,
-        authentication_type=$OPTIONAL_AUTHENTICATION_TYPE,
-        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
-        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
-        api_key_parameter_value=$NOT_STORED_API_KEY_PARAMETER_VALUE,
-        subdivision_name=$OPTIONAL_SUBDIVISION_NAME,
-        municipality=$OPTIONAL_MUNICIPALITY,
-        license_url=$OPTIONAL_LICENSE_URL,
-        name=$OPTIONAL_SOURCE_NAME,
-        features=[$OPTIONAL_FEATURE_ARRAY],
-        status=$OPTIONAL_STATUS
-    )
-```
-
-To add a new GTFS Realtime source:
-
-```python
->>> add_gtfs_realtime_source(
-        entity_type=[$YOUR_SOURCE_ARRAY_OF_ENTITY_TYPES],
-        provider=$YOUR_SOURCE_PROVIDER_NAME,
-        direct_download_url=$YOUR_SOURCE_DIRECT_DOWNLOAD_URL,
-        authentication_type=$OPTIONAL_AUTHENTICATION_TYPE,
-        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
-        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
-        license_url=$OPTIONAL_LICENSE_URL,
-        name=$OPTIONAL_SOURCE_NAME,
-        static_reference=[$OPTIONAL_ARRAY_OF_STATIC_REFERENCE_NUMERICAL_IDS],
-        note=$OPTIONAL_SOURCE_NOTE,
-        features=[$OPTIONAL_FEATURE_ARRAY],
-        status=$OPTIONAL_STATUS
-    )
-```
-
-To update a GTFS Schedule source. Note that you must pass an `api_key_parameter_value` if your source has `authentication_type = 1` or `authentication_type = 2` and that you want to update the direct download URL or authentication-related fields. The `api_key_parameter_value` will not be stored and is used only for testing before the source is updated in the database.
-
-```python
->>> update_gtfs_schedule_source(
-        mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
-        provider=$OPTIONAL_SOURCE_PROVIDER_NAME,
-        name=$OPTIONAL_SOURCE_NAME,
-        country_code=$OPTIONAL_SOURCE_COUNTRY_CODE,
-        subdivision_name=$OPTIONAL_SOURCE_SUBDIVISION_NAME,
-        municipality=$OPTIONAL_SOURCE_MUNICIPALITY,
-        direct_download_url=$OPTIONAL_SOURCE_DIRECT_DOWNLOAD_URL,
-        authentication_type=$OPTIONAL_AUTHENTICATION_TYPE,
-        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
-        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
-        api_key_parameter_value=$NOT_STORED_API_KEY_PARAMETER_VALUE,
-        license_url=$OPTIONAL_LICENSE_URL,
-        features=[$OPTIONAL_FEATURE_ARRAY],
-        status=$OPTIONAL_STATUS
-    )
-```
-
-To update a GTFS Realtime source:
-
-```python
->>> update_gtfs_realtime_source(
-        mdb_source_id=$YOUR_SOURCE_NUMERICAL_ID,
-        entity_type=[$YOUR_SOURCE_ARRAY_OF_ENTITY_TYPES],
-        provider=$YOUR_SOURCE_PROVIDER_NAME,
-        direct_download_url=$YOUR_SOURCE_DIRECT_DOWNLOAD_URL,
-        authentication_type=$YOUR_SOURCE_AUTHENTICATION_TYPE,
-        authentication_info_url=$CONDITIONALLY_REQUIRED_AUTHENTICATION_INFO_URL,
-        api_key_parameter_name=$CONDITIONALLY_REQUIRED_API_KEY_PARAMETER_NAME,
-        license_url=$OPTIONAL_LICENSE_URL,
-        name=$OPTIONAL_SOURCE_NAME,
-        static_reference=[$OPTIONAL_ARRAY_OF_STATIC_REFERENCE_NUMERICAL_IDS],
-        note=$OPTIONAL_SOURCE_NOTE,
-        features=[$OPTIONAL_FEATURE_ARRAY],
-        status=$OPTIONAL_STATUS
-    )
-```
-
-## Integration Tests
-
-In order to avoid invalid sources in the Mobility Database Catalogs, any modification made in the repository, addition or update, must pass the integration tests before being merged into the project. The integration tests are listed in the [Test Integration](/tests/test_integration.py) module
-
 ## License
 
 Code licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
@@ -310,4 +228,4 @@ All of the Mobility Database catalog's metadata is made available under [Creativ
 
 ## Contributing
 
-We welcome contributions to the project! Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.
+We welcome contributions to the project! You can add and update sources or contribute code. Please check out our [Contribution guidelines](/CONTRIBUTING.md) for details.


### PR DESCRIPTION
This PR

- Simplifies README.MD to focus on the most common uses of the repo 
- Expands CONTRIBUTING.MD to include contribution use cases like updating file names, and more information on tests. 

@maximearmstrong It would be helpful to get your perspective on how to write CONTRIBUTING.md so it's easy for a contributor to find the tests and run them on their code changes. 