### PR TITLE
fix: SSL error part 1 - adding user agent to the test workflow

### DIFF
--- a/.github/workflows/direct_download_urls_test_for_sources.yml
+++ b/.github/workflows/direct_download_urls_test_for_sources.yml
@@ -147,6 +147,10 @@ jobs:
           # Secrets constants
           API_SOURCE_SECRETS = "API_SOURCE_SECRETS"
 
+          # Requests constants
+          USER_AGENT = "User-Agent"
+          DEFAULT_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+
           jobs = """${{ matrix.data }}""".split()
           for job in jobs:
               job_json = json.loads(job)
@@ -156,7 +160,7 @@ jobs:
               api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
 
               params = {}
-              headers = {}
+              headers = {USER_AGENT: DEFAULT_USER_AGENT}
 
               if authentication_type in [1, 2]:
                   # Load API source secrets only if authentication is required

--- a/.github/workflows/direct_download_urls_test_for_sources.yml
+++ b/.github/workflows/direct_download_urls_test_for_sources.yml
@@ -149,6 +149,8 @@ jobs:
 
           # Requests constants
           USER_AGENT = "User-Agent"
+          # Selecting a default user agent instead of using a library like fake-useragent.
+          # We want to make sure we always use the same user agent for reproducibility purposes. 
           DEFAULT_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
 
           jobs = """${{ matrix.data }}""".split()


### PR DESCRIPTION
**Summary:**

#216: bug: SSL errors when validating URL

This PR adds a user agent to the GET requests in `direct_download_urls_test_for_sources.yml` so that we fix the SSL and HTTP errors encountered, as suggested [here](https://stackoverflow.com/questions/38489386/python-requests-403-forbidden).

**Expected behavior:** 

Direct download URLs can be tested without encountering SSL errors related to a missing user agent.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~