### PR TITLE
Update URLs for LA Regional GTFS [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-california-bell-gardens-trolley-gtfs-228.json
+++ b/catalogs/sources/gtfs/schedule/us-california-bell-gardens-trolley-gtfs-228.json
@@ -3,9 +3,9 @@
     "data_type": "gtfs",
     "provider": "Bell Gardens Trolley",
     "features": [
-        "fares-v1"
+        "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -15,11 +15,11 @@
             "maximum_latitude": 33.975241,
             "minimum_longitude": -118.167153856536,
             "maximum_longitude": -118.13744,
-            "extracted_on": "2022-03-15T17:43:06+00:00"
+            "extracted_on": "2022-12-19T18:33:15+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/bellgardens-ca-us/bellgardens-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/bellgardens-ca-us/bellgardens-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-bell-gardens-trolley-gtfs-228.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-bellflower-bus-gtfs-227.json
+++ b/catalogs/sources/gtfs/schedule/us-california-bellflower-bus-gtfs-227.json
@@ -3,9 +3,9 @@
     "data_type": "gtfs",
     "provider": "Bellflower Bus",
     "features": [
-        "fares-v1"
+        "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -15,11 +15,11 @@
             "maximum_latitude": 33.909496,
             "minimum_longitude": -118.142691,
             "maximum_longitude": -118.108606,
-            "extracted_on": "2022-03-15T17:43:05+00:00"
+            "extracted_on": "2022-12-19T18:31:06+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/bellflower-ca-us/bellflower-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/bellflower-ca-us/bellflower-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-bellflower-bus-gtfs-227.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-compton-renaissance-gtfs-314.json
+++ b/catalogs/sources/gtfs/schedule/us-california-compton-renaissance-gtfs-314.json
@@ -3,10 +3,9 @@
     "data_type": "gtfs",
     "provider": "Compton Renaissance",
     "features": [
-        "fares-v1",
         "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -16,11 +15,11 @@
             "maximum_latitude": 33.9232688805322,
             "minimum_longitude": -118.255090151507,
             "maximum_longitude": -118.181491014396,
-            "extracted_on": "2022-03-15T21:14:34+00:00"
+            "extracted_on": "2022-12-19T18:35:27+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/compton-ca-us/compton-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/compton-ca-us/compton-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-compton-renaissance-gtfs-314.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
+++ b/catalogs/sources/gtfs/schedule/us-california-downeylink-gtfs-383.json
@@ -3,10 +3,9 @@
     "data_type": "gtfs",
     "provider": "DowneyLINK",
     "features": [
-        "fares-v1",
         "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -15,11 +14,11 @@
             "maximum_latitude": 33.9667896649685,
             "minimum_longitude": -118.15607158901,
             "maximum_longitude": -118.102802806934,
-            "extracted_on": "2022-03-16T15:27:18+00:00"
+            "extracted_on": "2022-12-19T18:36:26+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/downey-ca-us/downey-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/downey-ca-us/downey-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-downeylink-gtfs-383.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-get-around-town-express-gtfs-606.json
+++ b/catalogs/sources/gtfs/schedule/us-california-get-around-town-express-gtfs-606.json
@@ -3,9 +3,9 @@
     "data_type": "gtfs",
     "provider": "Get Around Town Express",
     "features": [
-        "fares-v1"
+        "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -15,11 +15,11 @@
             "maximum_latitude": 33.9592318964122,
             "minimum_longitude": -118.225215727351,
             "maximum_longitude": -118.163997470108,
-            "extracted_on": "2022-03-16T20:10:40+00:00"
+            "extracted_on": "2022-12-19T18:37:17+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/getaroundtownexpress-ca-us/getaroundtownexpress-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/getaroundtownexpress-ca-us/getaroundtownexpress-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-get-around-town-express-gtfs-606.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-glendora-transportation-division-gtfs-609.json
+++ b/catalogs/sources/gtfs/schedule/us-california-glendora-transportation-division-gtfs-609.json
@@ -3,10 +3,9 @@
     "data_type": "gtfs",
     "provider": "Glendora Transportation Division",
     "features": [
-        "fares-v1",
         "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -15,11 +14,11 @@
             "maximum_latitude": 34.1468809776457,
             "minimum_longitude": -117.89009,
             "maximum_longitude": -117.838194,
-            "extracted_on": "2022-03-16T20:10:45+00:00"
+            "extracted_on": "2022-12-19T18:38:06+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/glendora-ca-us/glendora-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/glendora-ca-us/glendora-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-glendora-transportation-division-gtfs-609.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-huntington-park-express-gtfs-558.json
+++ b/catalogs/sources/gtfs/schedule/us-california-huntington-park-express-gtfs-558.json
@@ -3,10 +3,9 @@
     "data_type": "gtfs",
     "provider": "Huntington Park Express",
     "features": [
-        "fares-v1",
         "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -16,11 +15,11 @@
             "maximum_latitude": 33.9891364484214,
             "minimum_longitude": -118.238692091684,
             "maximum_longitude": -118.192457392484,
-            "extracted_on": "2022-03-16T20:09:28+00:00"
+            "extracted_on": "2022-12-19T18:38:56+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/huntingtonpark-ca-us/huntingtonpark-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/huntingtonpark-ca-us/huntingtonpark-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-huntington-park-express-gtfs-558.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-lynwood-trolley-breeze-gtfs-570.json
+++ b/catalogs/sources/gtfs/schedule/us-california-lynwood-trolley-breeze-gtfs-570.json
@@ -3,9 +3,9 @@
     "data_type": "gtfs",
     "provider": "Lynwood Trolley / Breeze",
     "features": [
-        "fares-v1"
+        "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -15,11 +15,11 @@
             "maximum_latitude": 33.9452214237674,
             "minimum_longitude": -118.239279931577,
             "maximum_longitude": -118.180320930699,
-            "extracted_on": "2022-03-16T20:09:45+00:00"
+            "extracted_on": "2022-12-19T18:39:40+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/lynwood-ca-us/lynwood-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/lynwood-ca-us/lynwood-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-lynwood-trolley-breeze-gtfs-570.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-california-rosemead-explorer-gtfs-806.json
+++ b/catalogs/sources/gtfs/schedule/us-california-rosemead-explorer-gtfs-806.json
@@ -3,9 +3,9 @@
     "data_type": "gtfs",
     "provider": "Rosemead Explorer",
     "features": [
-        "fares-v1"
+        "fares-v2"
     ],
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -15,11 +15,11 @@
             "maximum_latitude": 34.083874,
             "minimum_longitude": -118.103673,
             "maximum_longitude": -118.065028,
-            "extracted_on": "2022-03-17T15:21:58+00:00"
+            "extracted_on": "2022-12-19T18:40:18+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/rosemead-ca-us/rosemead-ca-us.zip",
+        "direct_download": "https://raw.githubusercontent.com/LACMTA/los-angeles-regional-gtfs/main/rosemead-ca-us/rosemead-ca-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-rosemead-explorer-gtfs-806.zip?alt=media"
     }
 }


### PR DESCRIPTION
Update URLs, features (fares-v2), and status (active) for the following LA Regional Feeds:
    bellgardens-ca-us
    bellflower-ca-us
    compton-ca-us
    downey-ca-us
    getaroundtownexpress-ca-us
    glendora-ca-us
    huntingtonpark-ca-us
    lynwood-ca-us
    rosemead-ca-us
