### PR TITLE
fix: https url fixes for Puget Sound One Bus Away URLs

### DIFF
--- a/catalogs/sources/gtfs/realtime/unknown-unknown-city-of-seattle-streetcar-gtfs-rt-sa-1547.json
+++ b/catalogs/sources/gtfs/realtime/unknown-unknown-city-of-seattle-streetcar-gtfs-rt-sa-1547.json
@@ -6,7 +6,7 @@
     ],
     "provider": "City of Seattle - Streetcar",
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/23.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/23.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/unknown-unknown-city-of-seattle-streetcar-gtfs-rt-tu-1548.json
+++ b/catalogs/sources/gtfs/realtime/unknown-unknown-city-of-seattle-streetcar-gtfs-rt-tu-1548.json
@@ -6,7 +6,7 @@
     ],
     "provider": "City of Seattle - Streetcar",
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/23.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/23.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/unknown-unknown-city-of-seattle-streetcar-gtfs-rt-vp-1546.json
+++ b/catalogs/sources/gtfs/realtime/unknown-unknown-city-of-seattle-streetcar-gtfs-rt-vp-1546.json
@@ -6,7 +6,7 @@
     ],
     "provider": "City of Seattle - Streetcar",
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/23.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/23.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-everett-transit-gtfs-rt-sa-1550.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-everett-transit-gtfs-rt-sa-1550.json
@@ -9,7 +9,7 @@
         288
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/97.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/97.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-everett-transit-gtfs-rt-tu-1551.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-everett-transit-gtfs-rt-tu-1551.json
@@ -9,7 +9,7 @@
         288
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/97.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/97.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-everett-transit-gtfs-rt-vp-1549.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-everett-transit-gtfs-rt-vp-1549.json
@@ -9,7 +9,7 @@
         288
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/97.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/97.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-pierce-transit-gtfs-rt-sa-1544.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-pierce-transit-gtfs-rt-sa-1544.json
@@ -9,7 +9,7 @@
         265
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/3.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/3.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-pierce-transit-gtfs-rt-tu-1543.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-pierce-transit-gtfs-rt-tu-1543.json
@@ -9,7 +9,7 @@
         265
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/3.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/3.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-pierce-transit-gtfs-rt-vp-1545.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-pierce-transit-gtfs-rt-vp-1545.json
@@ -9,7 +9,7 @@
         265
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/3.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/3.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-sound-transit-gtfs-rt-sa-1553.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-sound-transit-gtfs-rt-sa-1553.json
@@ -9,7 +9,7 @@
         268
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/40.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/40.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-sound-transit-gtfs-rt-tu-1554.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-sound-transit-gtfs-rt-tu-1554.json
@@ -9,7 +9,7 @@
         268
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/40.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/40.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-sound-transit-gtfs-rt-vp-1552.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-sound-transit-gtfs-rt-vp-1552.json
@@ -9,7 +9,7 @@
         268
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/40.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/40.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-washington-state-ferries-gtfs-rt-sa-1556.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-washington-state-ferries-gtfs-rt-sa-1556.json
@@ -9,7 +9,7 @@
         1331
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/95.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/alerts-for-agency/95.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-washington-state-ferries-gtfs-rt-tu-1557.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-washington-state-ferries-gtfs-rt-tu-1557.json
@@ -9,7 +9,7 @@
         1331
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/95.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/trip-updates-for-agency/95.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",

--- a/catalogs/sources/gtfs/realtime/us-washington-washington-state-ferries-gtfs-rt-vp-1555.json
+++ b/catalogs/sources/gtfs/realtime/us-washington-washington-state-ferries-gtfs-rt-vp-1555.json
@@ -9,7 +9,7 @@
         1331
     ],
     "urls": {
-        "direct_download": "http://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/95.pb",
+        "direct_download": "https://api.pugetsound.onebusaway.org/api/gtfs_realtime/vehicle-positions-for-agency/95.pb",
         "authentication_type": 1,
         "authentication_info": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads",
         "api_key_parameter_name": "key",


### PR DESCRIPTION
Puget Sound One Bus Away realtime URLs weren't working correctly because they needed to be `https://`. Fixed in this PR.