### PR TITLE
Update Puget Sound Consolidated GTFS and mark as active [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-washington-metro-transit-gtfs-1080.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-metro-transit-gtfs-1080.json
@@ -3,7 +3,6 @@
     "data_type": "gtfs",
     "provider": "Metro Transit, Intercity Transit, City of Seattle, Community Transit, Pierce Transit, Sound Transit, Washington State Ferries, SeattleCenterMonorail, Everett Transit, Seattle Children's Hospital",
     "name": "Puget Sound Consolidated GTFS",
-    "status": "deprecated",
     "location": {
         "country_code": "US",
         "subdivision_name": "Washington",
@@ -16,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://developer.onebusaway.org/tmp/sound/gtfs/modified/gtfs_puget_sound_consolidated.zip",
+        "direct_download": "https://gtfs.sound.obaweb.org/prod/gtfs_puget_sound_consolidated.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-metro-transit-gtfs-1080.zip?alt=media"
     }
 }


### PR DESCRIPTION
Hi - this is my first time contributing, so let me know if I'm doing something weird.

This feed was marked as deprecated in 6daa4bea, but it seems like the feed should still be active - it just moved.

Requesting the old url redirects to a text file that says:

> These files have moved! Please visit https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/otd-downloads for the new location.

At that URL, there is a link to:

> The [Puget Sound Consolidated GTFS Schedule](https://gtfs.sound.obaweb.org/prod/gtfs_puget_sound_consolidated.zip) provides a single, merged GTFS Schedule file set for the region.

The linked zip is an up to date GTFS archive. The modified record now points to this GTFS file and I've removed the "deprecated" status from the record, since it seems up to date and I see no indication of it being dropped.