### PR TITLE
fix: store latest datasets cronjob size limit

### DIFF
--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -112,7 +112,6 @@ jobs:
           DATASETS=$(jq . ./urls_matrix.json -c)
           echo $DATASETS
           echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
-#          echo "::set-output name=matrix::$DATASETS"
       - name: Persist URLs matrix artifact
         if: always()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -71,7 +71,7 @@ jobs:
                   else:
                       urls[base] = {
                           DIRECT_DOWNLOAD: direct_download_url,
-                          LATEST: latest_url.replace("URL_STORAGE_PREFIX", ""),
+                          LATEST: latest_url.replace(URL_STORAGE_PREFIX, ""),
                           AUTHENTICATION_TYPE: authentication_type,
                           API_KEY_PARAMETER_NAME: api_key_parameter_name
                       }

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -13,9 +13,9 @@ jobs:
   get-urls:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -136,9 +136,9 @@ jobs:
 #    strategy:
 #      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #      - name: Set up Python 3.9
-#        uses: actions/setup-python@v2
+#        uses: actions/setup-python@v3
 #        with:
 #          python-version: 3.9
 #      - name: Install dependencies
@@ -235,7 +235,7 @@ jobs:
 #          parent: false
 #      - name: Persist Download Reports artifact
 #        if: always()
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: download_reports
 #          path: download_reports
@@ -245,9 +245,9 @@ jobs:
 #    strategy:
 #      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #      - name: Set up Python 3.9
-#        uses: actions/setup-python@v2
+#        uses: actions/setup-python@v3
 #        with:
 #          python-version: 3.9
 #      - name: Install dependencies
@@ -312,7 +312,7 @@ jobs:
 #                  fp.write(file_log)
 #      - name: Persist Latest Reports artifact
 #        if: always()
-#        uses: actions/upload-artifact@v2
+#        uses: actions/upload-artifact@v3
 #        with:
 #          name: latest_reports
 #          path: latest_reports

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -30,6 +30,7 @@ jobs:
           # OS constants
           ROOT = os.getcwd()
           GTFS_SCHEDULE_CATALOG_PATH_FROM_ROOT = "catalogs/sources/gtfs/schedule"
+          URL_STORAGE_PREFIX = "https://storage.googleapis.com/storage/v1/b/mdb-latest/o"
           MATRIX_FILE = "urls_matrix.json"
 
           # File constants
@@ -70,7 +71,7 @@ jobs:
                   else:
                       urls[base] = {
                           DIRECT_DOWNLOAD: direct_download_url,
-                          LATEST: latest_url,
+                          LATEST: latest_url.replace("URL_STORAGE_PREFIX", ""),
                           AUTHENTICATION_TYPE: authentication_type,
                           API_KEY_PARAMETER_NAME: api_key_parameter_name
                       }

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -1,10 +1,9 @@
 name: Store latest datasets cronjob
 
 on:
-  push:
-    branches: [ '**' ]
-#  schedule:
-#    - cron: "0 0 * * *"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   URL_STORAGE_PREFIX: "https://storage.googleapis.com/storage/v1/b/mdb-latest/o"
@@ -106,7 +105,6 @@ jobs:
                   DATA: urls_data_string.replace("}{", "} {")
               }
               urls_data.append(job_data)
-              break
           matrix_data = {INCLUDE: urls_data}
 
           with open(os.path.join(ROOT, MATRIX_FILE), "w") as fp:

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -1,8 +1,10 @@
 name: Store latest datasets cronjob
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  push:
+    branches: [ '**' ]
+#  schedule:
+#    - cron: "0 0 * * *"
 
 jobs:
   get-urls:
@@ -109,7 +111,8 @@ jobs:
         run: |
           DATASETS=$(jq . ./urls_matrix.json -c)
           echo $DATASETS
-          echo "::set-output name=matrix::$DATASETS"
+          echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
+#          echo "::set-output name=matrix::$DATASETS"
       - name: Persist URLs matrix artifact
         if: always()
         uses: actions/upload-artifact@v2
@@ -124,189 +127,189 @@ jobs:
           path: ./get_urls_report.txt
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-  store-datasets:
-    needs: [ get-urls ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel requests
-      - name: Validate and download the datasets
-        shell: python
-        env:
-          API_SOURCE_SECRETS: ${{ secrets.API_SOURCE_SECRETS }}
-        run: |
-          import os
-          import json
-          import requests
-          from zipfile import ZipFile
-
-          # OS constants
-          ROOT = os.getcwd()
-          DATASETS = "datasets"
-          FOLDER = """${{ matrix.hash }}"""
-          DOWNLOAD_REPORTS = "download_reports"
-
-          # Jobs constants
-          BASE = "base"
-          DIRECT_DOWNLOAD = "direct_download"
-          AUTHENTICATION_TYPE = "authentication_type"
-          API_KEY_PARAMETER_NAME = "api_key_parameter_name"
-
-          # Secrets constants
-          API_SOURCE_SECRETS = "API_SOURCE_SECRETS"
-
-          # Load API source secrets
-          api_source_secrets = json.loads(os.environ[API_SOURCE_SECRETS])
-
-          jobs = """${{ matrix.data }}""".split()
-          for job in jobs:
-              job_json = json.loads(job)
-              base = job_json[BASE]
-              url = job_json[DIRECT_DOWNLOAD]
-              authentication_type = job_json[AUTHENTICATION_TYPE]
-              api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
-              api_key_parameter_value = api_source_secrets.get(base)
-
-              # Download the dataset
-              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
-              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
-
-              params = {}
-              headers = {}
-              if authentication_type == 1:
-                  params[api_key_parameter_name] = api_key_parameter_value
-              elif authentication_type == 2:
-                  headers[api_key_parameter_name] = api_key_parameter_value
-
-              is_downloadable = True
-              try:
-                  zip_file_req = requests.get(url, params=params, headers=headers, allow_redirects=True)
-                  zip_file_req.raise_for_status()
-              except Exception as e:
-                  is_downloadable = False
-                  file_log = (
-                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
-                  )
-
-              if is_downloadable:
-                  zip_file = zip_file_req.content
-                  with open(zip_path, "wb") as f:
-                      f.write(zip_file)
-                  # Make sure that the download file is a zip file
-                  try:
-                      ZipFile(zip_path, "r")
-                      file_log = (
-                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
-                      )
-                  except Exception as e:
-                      os.remove(zip_path)
-                      file_log = (
-                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
-                      )
-              report_path = os.path.join(ROOT, DOWNLOAD_REPORTS, f"{base}.txt")
-              os.makedirs(os.path.dirname(report_path), exist_ok=True)
-              with open(report_path, "w") as fp:
-                  fp.write(file_log)
-      - name: Set up and authorize Cloud
-        uses: google-github-actions/auth@v0
-        with:
-          credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
-      - name: Upload datasets to Google Cloud Storage
-        id: upload-datasets
-        uses: google-github-actions/upload-cloud-storage@main
-        with:
-          path: datasets/${{ matrix.hash }}
-          destination: mdb-latest
-          parent: false
-      - name: Persist Download Reports artifact
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: download_reports
-          path: download_reports
-  validate-latest:
-    needs: [ get-urls, store-datasets ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install wheel requests
-      - name: Validate the latest datasets
-        shell: python
-        run: |
-          import os
-          import json
-          import requests
-          from zipfile import ZipFile
-
-          # OS constants
-          ROOT = os.getcwd()
-          DATASETS = "datasets"
-          FOLDER = """${{ matrix.hash }}"""
-          LATEST_REPORTS = "latest_reports"
-
-          # Jobs constants
-          BASE = "base"
-          LATEST = "latest"
-
-          jobs = """${{ matrix.data }}""".split()
-          for job in jobs:
-              job_json = json.loads(job)
-              base = job_json[BASE]
-              url = job_json[LATEST]
-
-              # Download the dataset
-              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
-              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
-              is_downloadable = True
-              try:
-                  zip_file_req = requests.get(url, allow_redirects=True)
-                  zip_file_req.raise_for_status()
-              except Exception as e:
-                  is_downloadable = False
-                  file_log = (
-                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
-                  )
-
-              if is_downloadable:
-                  zip_file = zip_file_req.content
-                  with open(zip_path, "wb") as f:
-                      f.write(zip_file)
-                  # Make sure that the download file is a zip file
-                  try:
-                      ZipFile(zip_path, "r")
-                      file_log = (
-                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
-                      )
-                  except Exception as e:
-                      os.remove(zip_path)
-                      file_log = (
-                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
-                      )
-              report_path = os.path.join(ROOT, LATEST_REPORTS, f"{base}.txt")
-              os.makedirs(os.path.dirname(report_path), exist_ok=True)
-              with open(report_path, "w") as fp:
-                  fp.write(file_log)
-      - name: Persist Latest Reports artifact
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: latest_reports
-          path: latest_reports
+#  store-datasets:
+#    needs: [ get-urls ]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Set up Python 3.9
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.9
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install wheel requests
+#      - name: Validate and download the datasets
+#        shell: python
+#        env:
+#          API_SOURCE_SECRETS: ${{ secrets.API_SOURCE_SECRETS }}
+#        run: |
+#          import os
+#          import json
+#          import requests
+#          from zipfile import ZipFile
+#
+#          # OS constants
+#          ROOT = os.getcwd()
+#          DATASETS = "datasets"
+#          FOLDER = """${{ matrix.hash }}"""
+#          DOWNLOAD_REPORTS = "download_reports"
+#
+#          # Jobs constants
+#          BASE = "base"
+#          DIRECT_DOWNLOAD = "direct_download"
+#          AUTHENTICATION_TYPE = "authentication_type"
+#          API_KEY_PARAMETER_NAME = "api_key_parameter_name"
+#
+#          # Secrets constants
+#          API_SOURCE_SECRETS = "API_SOURCE_SECRETS"
+#
+#          # Load API source secrets
+#          api_source_secrets = json.loads(os.environ[API_SOURCE_SECRETS])
+#
+#          jobs = """${{ matrix.data }}""".split()
+#          for job in jobs:
+#              job_json = json.loads(job)
+#              base = job_json[BASE]
+#              url = job_json[DIRECT_DOWNLOAD]
+#              authentication_type = job_json[AUTHENTICATION_TYPE]
+#              api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
+#              api_key_parameter_value = api_source_secrets.get(base)
+#
+#              # Download the dataset
+#              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
+#              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+#
+#              params = {}
+#              headers = {}
+#              if authentication_type == 1:
+#                  params[api_key_parameter_name] = api_key_parameter_value
+#              elif authentication_type == 2:
+#                  headers[api_key_parameter_name] = api_key_parameter_value
+#
+#              is_downloadable = True
+#              try:
+#                  zip_file_req = requests.get(url, params=params, headers=headers, allow_redirects=True)
+#                  zip_file_req.raise_for_status()
+#              except Exception as e:
+#                  is_downloadable = False
+#                  file_log = (
+#                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
+#                  )
+#
+#              if is_downloadable:
+#                  zip_file = zip_file_req.content
+#                  with open(zip_path, "wb") as f:
+#                      f.write(zip_file)
+#                  # Make sure that the download file is a zip file
+#                  try:
+#                      ZipFile(zip_path, "r")
+#                      file_log = (
+#                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
+#                      )
+#                  except Exception as e:
+#                      os.remove(zip_path)
+#                      file_log = (
+#                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
+#                      )
+#              report_path = os.path.join(ROOT, DOWNLOAD_REPORTS, f"{base}.txt")
+#              os.makedirs(os.path.dirname(report_path), exist_ok=True)
+#              with open(report_path, "w") as fp:
+#                  fp.write(file_log)
+#      - name: Set up and authorize Cloud
+#        uses: google-github-actions/auth@v0
+#        with:
+#          credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
+#      - name: Upload datasets to Google Cloud Storage
+#        id: upload-datasets
+#        uses: google-github-actions/upload-cloud-storage@main
+#        with:
+#          path: datasets/${{ matrix.hash }}
+#          destination: mdb-latest
+#          parent: false
+#      - name: Persist Download Reports artifact
+#        if: always()
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: download_reports
+#          path: download_reports
+#  validate-latest:
+#    needs: [ get-urls, store-datasets ]
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Set up Python 3.9
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.9
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install wheel requests
+#      - name: Validate the latest datasets
+#        shell: python
+#        run: |
+#          import os
+#          import json
+#          import requests
+#          from zipfile import ZipFile
+#
+#          # OS constants
+#          ROOT = os.getcwd()
+#          DATASETS = "datasets"
+#          FOLDER = """${{ matrix.hash }}"""
+#          LATEST_REPORTS = "latest_reports"
+#
+#          # Jobs constants
+#          BASE = "base"
+#          LATEST = "latest"
+#
+#          jobs = """${{ matrix.data }}""".split()
+#          for job in jobs:
+#              job_json = json.loads(job)
+#              base = job_json[BASE]
+#              url = job_json[LATEST]
+#
+#              # Download the dataset
+#              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
+#              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+#              is_downloadable = True
+#              try:
+#                  zip_file_req = requests.get(url, allow_redirects=True)
+#                  zip_file_req.raise_for_status()
+#              except Exception as e:
+#                  is_downloadable = False
+#                  file_log = (
+#                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
+#                  )
+#
+#              if is_downloadable:
+#                  zip_file = zip_file_req.content
+#                  with open(zip_path, "wb") as f:
+#                      f.write(zip_file)
+#                  # Make sure that the download file is a zip file
+#                  try:
+#                      ZipFile(zip_path, "r")
+#                      file_log = (
+#                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
+#                      )
+#                  except Exception as e:
+#                      os.remove(zip_path)
+#                      file_log = (
+#                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
+#                      )
+#              report_path = os.path.join(ROOT, LATEST_REPORTS, f"{base}.txt")
+#              os.makedirs(os.path.dirname(report_path), exist_ok=True)
+#              with open(report_path, "w") as fp:
+#                  fp.write(file_log)
+#      - name: Persist Latest Reports artifact
+#        if: always()
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: latest_reports
+#          path: latest_reports

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -106,6 +106,7 @@ jobs:
                   DATA: urls_data_string.replace("}{", "} {")
               }
               urls_data.append(job_data)
+              break
           matrix_data = {INCLUDE: urls_data}
 
           with open(os.path.join(ROOT, MATRIX_FILE), "w") as fp:
@@ -118,201 +119,201 @@ jobs:
           echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
       - name: Persist URLs matrix artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: urls_matrix
           path: ./urls_matrix.json
       - name: Persist Get URLS report artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: get_urls_report
           path: ./get_urls_report.txt
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-#  store-datasets:
-#    needs: [ get-urls ]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up Python 3.9
-#        uses: actions/setup-python@v3
-#        with:
-#          python-version: 3.9
-#      - name: Install dependencies
-#        run: |
-#          python -m pip install --upgrade pip
-#          pip install wheel requests
-#      - name: Validate and download the datasets
-#        shell: python
-#        env:
-#          API_SOURCE_SECRETS: ${{ secrets.API_SOURCE_SECRETS }}
-#        run: |
-#          import os
-#          import json
-#          import requests
-#          from zipfile import ZipFile
-#
-#          # OS constants
-#          ROOT = os.getcwd()
-#          DATASETS = "datasets"
-#          FOLDER = """${{ matrix.hash }}"""
-#          DOWNLOAD_REPORTS = "download_reports"
-#
-#          # Jobs constants
-#          BASE = "base"
-#          DIRECT_DOWNLOAD = "direct_download"
-#          AUTHENTICATION_TYPE = "authentication_type"
-#          API_KEY_PARAMETER_NAME = "api_key_parameter_name"
-#
-#          # Secrets constants
-#          API_SOURCE_SECRETS = "API_SOURCE_SECRETS"
-#
-#          # Load API source secrets
-#          api_source_secrets = json.loads(os.environ[API_SOURCE_SECRETS])
-#
-#          jobs = """${{ matrix.data }}""".split()
-#          for job in jobs:
-#              job_json = json.loads(job)
-#              base = job_json[BASE]
-#              url = job_json[DIRECT_DOWNLOAD]
-#              authentication_type = job_json[AUTHENTICATION_TYPE]
-#              api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
-#              api_key_parameter_value = api_source_secrets.get(base)
-#
-#              # Download the dataset
-#              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
-#              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
-#
-#              params = {}
-#              headers = {}
-#              if authentication_type == 1:
-#                  params[api_key_parameter_name] = api_key_parameter_value
-#              elif authentication_type == 2:
-#                  headers[api_key_parameter_name] = api_key_parameter_value
-#
-#              is_downloadable = True
-#              try:
-#                  zip_file_req = requests.get(url, params=params, headers=headers, allow_redirects=True)
-#                  zip_file_req.raise_for_status()
-#              except Exception as e:
-#                  is_downloadable = False
-#                  file_log = (
-#                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
-#                  )
-#
-#              if is_downloadable:
-#                  zip_file = zip_file_req.content
-#                  with open(zip_path, "wb") as f:
-#                      f.write(zip_file)
-#                  # Make sure that the download file is a zip file
-#                  try:
-#                      ZipFile(zip_path, "r")
-#                      file_log = (
-#                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
-#                      )
-#                  except Exception as e:
-#                      os.remove(zip_path)
-#                      file_log = (
-#                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
-#                      )
-#              report_path = os.path.join(ROOT, DOWNLOAD_REPORTS, f"{base}.txt")
-#              os.makedirs(os.path.dirname(report_path), exist_ok=True)
-#              with open(report_path, "w") as fp:
-#                  fp.write(file_log)
-#      - name: Set up and authorize Cloud
-#        uses: google-github-actions/auth@v0
-#        with:
-#          credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
-#      - name: Upload datasets to Google Cloud Storage
-#        id: upload-datasets
-#        uses: google-github-actions/upload-cloud-storage@main
-#        with:
-#          path: datasets/${{ matrix.hash }}
-#          destination: mdb-latest
-#          parent: false
-#      - name: Persist Download Reports artifact
-#        if: always()
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: download_reports
-#          path: download_reports
-#  validate-latest:
-#    needs: [ get-urls, store-datasets ]
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up Python 3.9
-#        uses: actions/setup-python@v3
-#        with:
-#          python-version: 3.9
-#      - name: Install dependencies
-#        run: |
-#          python -m pip install --upgrade pip
-#          pip install wheel requests
-#      - name: Validate the latest datasets
-#        shell: python
-#        run: |
-#          import os
-#          import json
-#          import requests
-#          from zipfile import ZipFile
-#
-#          # OS constants
-#          ROOT = os.getcwd()
-#          DATASETS = "datasets"
-#          FOLDER = """${{ matrix.hash }}"""
-#          LATEST_REPORTS = "latest_reports"
-#
-#          # Jobs constants
-#          BASE = "base"
-#          LATEST = "latest"
-#
-#          jobs = """${{ matrix.data }}""".split()
-#          for job in jobs:
-#              job_json = json.loads(job)
-#              base = job_json[BASE]
-#              url = job_json[LATEST]
-#
-#              # Download the dataset
-#              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
-#              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
-#              is_downloadable = True
-#              try:
-#                  zip_file_req = requests.get(url, allow_redirects=True)
-#                  zip_file_req.raise_for_status()
-#              except Exception as e:
-#                  is_downloadable = False
-#                  file_log = (
-#                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
-#                  )
-#
-#              if is_downloadable:
-#                  zip_file = zip_file_req.content
-#                  with open(zip_path, "wb") as f:
-#                      f.write(zip_file)
-#                  # Make sure that the download file is a zip file
-#                  try:
-#                      ZipFile(zip_path, "r")
-#                      file_log = (
-#                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
-#                      )
-#                  except Exception as e:
-#                      os.remove(zip_path)
-#                      file_log = (
-#                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
-#                      )
-#              report_path = os.path.join(ROOT, LATEST_REPORTS, f"{base}.txt")
-#              os.makedirs(os.path.dirname(report_path), exist_ok=True)
-#              with open(report_path, "w") as fp:
-#                  fp.write(file_log)
-#      - name: Persist Latest Reports artifact
-#        if: always()
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: latest_reports
-#          path: latest_reports
+  store-datasets:
+    needs: [ get-urls ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel requests
+      - name: Validate and download the datasets
+        shell: python
+        env:
+          API_SOURCE_SECRETS: ${{ secrets.API_SOURCE_SECRETS }}
+        run: |
+          import os
+          import json
+          import requests
+          from zipfile import ZipFile
+
+          # OS constants
+          ROOT = os.getcwd()
+          DATASETS = "datasets"
+          FOLDER = """${{ matrix.hash }}"""
+          DOWNLOAD_REPORTS = "download_reports"
+
+          # Jobs constants
+          BASE = "base"
+          DIRECT_DOWNLOAD = "direct_download"
+          AUTHENTICATION_TYPE = "authentication_type"
+          API_KEY_PARAMETER_NAME = "api_key_parameter_name"
+
+          # Secrets constants
+          API_SOURCE_SECRETS = "API_SOURCE_SECRETS"
+
+          # Load API source secrets
+          api_source_secrets = json.loads(os.environ[API_SOURCE_SECRETS])
+
+          jobs = """${{ matrix.data }}""".split()
+          for job in jobs:
+              job_json = json.loads(job)
+              base = job_json[BASE]
+              url = job_json[DIRECT_DOWNLOAD]
+              authentication_type = job_json[AUTHENTICATION_TYPE]
+              api_key_parameter_name = job_json[API_KEY_PARAMETER_NAME]
+              api_key_parameter_value = api_source_secrets.get(base)
+
+              # Download the dataset
+              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
+              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+
+              params = {}
+              headers = {}
+              if authentication_type == 1:
+                  params[api_key_parameter_name] = api_key_parameter_value
+              elif authentication_type == 2:
+                  headers[api_key_parameter_name] = api_key_parameter_value
+
+              is_downloadable = True
+              try:
+                  zip_file_req = requests.get(url, params=params, headers=headers, allow_redirects=True)
+                  zip_file_req.raise_for_status()
+              except Exception as e:
+                  is_downloadable = False
+                  file_log = (
+                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
+                  )
+
+              if is_downloadable:
+                  zip_file = zip_file_req.content
+                  with open(zip_path, "wb") as f:
+                      f.write(zip_file)
+                  # Make sure that the download file is a zip file
+                  try:
+                      ZipFile(zip_path, "r")
+                      file_log = (
+                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
+                      )
+                  except Exception as e:
+                      os.remove(zip_path)
+                      file_log = (
+                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
+                      )
+              report_path = os.path.join(ROOT, DOWNLOAD_REPORTS, f"{base}.txt")
+              os.makedirs(os.path.dirname(report_path), exist_ok=True)
+              with open(report_path, "w") as fp:
+                  fp.write(file_log)
+      - name: Set up and authorize Cloud
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
+      - name: Upload datasets to Google Cloud Storage
+        id: upload-datasets
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: datasets/${{ matrix.hash }}
+          destination: mdb-latest
+          parent: false
+      - name: Persist Download Reports artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: download_reports
+          path: download_reports
+  validate-latest:
+    needs: [ get-urls, store-datasets ]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.get-urls.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel requests
+      - name: Validate the latest datasets
+        shell: python
+        run: |
+          import os
+          import json
+          import requests
+          from zipfile import ZipFile
+
+          # OS constants
+          ROOT = os.getcwd()
+          DATASETS = "datasets"
+          FOLDER = """${{ matrix.hash }}"""
+          LATEST_REPORTS = "latest_reports"
+
+          # Jobs constants
+          BASE = "base"
+          LATEST = "latest"
+
+          jobs = """${{ matrix.data }}""".split()
+          for job in jobs:
+              job_json = json.loads(job)
+              base = job_json[BASE]
+              url = URL_STORAGE_PREFIX + job_json[LATEST]
+
+              # Download the dataset
+              zip_path = os.path.join(ROOT, DATASETS, FOLDER, f"{base}.zip")
+              os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+              is_downloadable = True
+              try:
+                  zip_file_req = requests.get(url, allow_redirects=True)
+                  zip_file_req.raise_for_status()
+              except Exception as e:
+                  is_downloadable = False
+                  file_log = (
+                      f"{base}: FAILURE! Exception {e} occurred when downloading URL {url}.\n"
+                  )
+
+              if is_downloadable:
+                  zip_file = zip_file_req.content
+                  with open(zip_path, "wb") as f:
+                      f.write(zip_file)
+                  # Make sure that the download file is a zip file
+                  try:
+                      ZipFile(zip_path, "r")
+                      file_log = (
+                          f"{base}: SUCCESS! A GTFS dataset zip file was downloaded.\n"
+                      )
+                  except Exception as e:
+                      os.remove(zip_path)
+                      file_log = (
+                          f"{base}: FAILURE! Exception {e} occurred when loading the zip file.\n"
+                      )
+              report_path = os.path.join(ROOT, LATEST_REPORTS, f"{base}.txt")
+              os.makedirs(os.path.dirname(report_path), exist_ok=True)
+              with open(report_path, "w") as fp:
+                  fp.write(file_log)
+      - name: Persist Latest Reports artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: latest_reports
+          path: latest_reports

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -6,6 +6,9 @@ on:
 #  schedule:
 #    - cron: "0 0 * * *"
 
+env:
+  URL_STORAGE_PREFIX: "https://storage.googleapis.com/storage/v1/b/mdb-latest/o"
+
 jobs:
   get-urls:
     runs-on: ubuntu-latest
@@ -30,7 +33,7 @@ jobs:
           # OS constants
           ROOT = os.getcwd()
           GTFS_SCHEDULE_CATALOG_PATH_FROM_ROOT = "catalogs/sources/gtfs/schedule"
-          URL_STORAGE_PREFIX = "https://storage.googleapis.com/storage/v1/b/mdb-latest/o"
+          URL_STORAGE_PREFIX = """${{ env.URL_STORAGE_PREFIX }}"""
           MATRIX_FILE = "urls_matrix.json"
 
           # File constants

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -268,6 +268,7 @@ jobs:
           DATASETS = "datasets"
           FOLDER = """${{ matrix.hash }}"""
           LATEST_REPORTS = "latest_reports"
+          URL_STORAGE_PREFIX = """${{ env.URL_STORAGE_PREFIX }}"""
 
           # Jobs constants
           BASE = "base"


### PR DESCRIPTION
# Description

The `store latest datasets` cronjob is failing, blocking the downloads and verification of all datasets. The failure is due to the GitHub step/job output size. In this PR, the step output is replaced with the "new" Github output pattern, and the latest URL prefix is removed from the output to reduce the number of characters of the job results.

# Expected behavior

The `store latest datasets` cronjob runs successfully.