### PR TITLE
fix: Shut up warnings about upload to cloud action

### DIFF
--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -227,7 +227,7 @@ jobs:
           credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
       - name: Upload datasets to Google Cloud Storage
         id: upload-datasets
-        uses: google-github-actions/upload-cloud-storage@main
+        uses: google-github-actions/upload-cloud-storage@v1.0.3
         with:
           path: datasets/${{ matrix.hash }}
           destination: mdb-latest


### PR DESCRIPTION
There is a ton of warnings to specify the version and not master. This should fix it.

Ref: https://github.com/MobilityData/mobility-database-catalogs/actions/runs/6175492851

```
google-github-actions/upload-cloud-storage is pinned at "main". We strongly advise against pinning to "@main" as it may be unstable. Please update your GitHub Action YAML from:

    uses: 'google-github-actions/upload-cloud-storage@main'

to:

    uses: 'google-github-actions/upload-cloud-storage@v0'

Alternatively, you can pin to any git tag or git SHA in the repository.
```