### PR TITLE
fix: attempt to fix the single quote issue

### DIFF
--- a/.github/workflows/add_new_or_updated_feeds.yml
+++ b/.github/workflows/add_new_or_updated_feeds.yml
@@ -92,7 +92,7 @@ jobs:
             pip install gtfs_kit --quiet
             pip install unidecode --quiet
 
-            sections=$(echo "${{ steps.process-csv.outputs.PYTHON_SCRIPT_ARGS }}" | sed 's/""/"/g' | awk -F'§' '{for (i=1; i<=NF; i++) print $i}')
+            sections=$(echo '${{ steps.process-csv.outputs.PYTHON_SCRIPT_ARGS }}' | sed 's/""/"/g' | awk -F'§' '{for (i=1; i<=NF; i++) print $i}')
             for section in "${sections[@]}"; do
                 eval "python -c 'from tools.operations import *; ${section}'"
             done

--- a/scripts/process_csv_in_github_action.swift
+++ b/scripts/process_csv_in_github_action.swift
@@ -203,6 +203,9 @@ if CommandLine.argc == 5 {
 
     } // END FOR LOOP
 
+    // Replace single quotes (like in McGill's) with an apostrophe so there is no interference with the bash script in the next step.
+    PYTHON_SCRIPT_OUTPUT = PYTHON_SCRIPT_OUTPUT.replacingOccurrences(of: "'", with: "ʼ")
+
     // return final output so the action can grab it and pass it on to the Python script.
     print(PYTHON_SCRIPT_OUTPUT.dropFirst())
 


### PR DESCRIPTION
Single quotes are used in some submissions from providers (example: McGill's) and this causes an interference in the bash script that uses single quotes to delimit the python script arguments by closing the `echo` command too soon in the next step. This should fix it.