### PR TITLE
chore: Update Nashville MTA URLs for schedule / realtime [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/realtime/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-rt-sa-1621.json
+++ b/catalogs/sources/gtfs/realtime/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-rt-sa-1621.json
@@ -11,6 +11,6 @@
     "urls": {
         "direct_download": "http://transitdata.nashvillemta.org/TMGTFSRealTimeWebService/alert/alerts.pb",
         "authentication_type": 0,
-        "license": "https://www.nashvillemta.org/Nashville-MTA-Developer-Data-Request.asp"
+        "license": "https://www.wegotransit.com/contact-us/data-request-submission/"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-rt-tu-1620.json
+++ b/catalogs/sources/gtfs/realtime/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-rt-tu-1620.json
@@ -11,6 +11,6 @@
     "urls": {
         "direct_download": "http://transitdata.nashvillemta.org/TMGTFSRealTimeWebService/tripupdate/tripupdates.pb",
         "authentication_type": 0,
-        "license": "https://www.nashvillemta.org/Nashville-MTA-Developer-Data-Request.asp"
+        "license": "https://www.wegotransit.com/contact-us/data-request-submission/"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-rt-vp-1622.json
+++ b/catalogs/sources/gtfs/realtime/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-rt-vp-1622.json
@@ -11,6 +11,6 @@
     "urls": {
         "direct_download": "http://transitdata.nashvillemta.org/TMGTFSRealTimeWebService/vehicle/vehiclepositions.pb",
         "authentication_type": 0,
-        "license": "https://www.nashvillemta.org/Nashville-MTA-Developer-Data-Request.asp"
+        "license": "https://www.wegotransit.com/contact-us/data-request-submission/"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-360.json
+++ b/catalogs/sources/gtfs/schedule/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-360.json
@@ -15,7 +15,8 @@
         }
     },
     "urls": {
-        "direct_download": "http://www.nashvillemta.org/GoogleExport/google_transit.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-360.zip?alt=media"
+        "direct_download": "https://www.wegotransit.com/googleexport/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-tennessee-nashville-metropolitan-transit-authority-nashville-mta-gtfs-360.zip?alt=media",
+        "license": "https://www.wegotransit.com/contact-us/data-request-submission/"
     }
 }


### PR DESCRIPTION
Nashville Metro Transit Authority (the legal entity) changed the name of its service to WeGo Public Transit in July of 2018. This meant that the website also changed. While the URLs currently in the database are redirecting with `HTTP 302`, at some point that is likely to stop working. Note that the realtime data feeds did not change.

I have also added the `license` field to the `urls` as it is allowed in the schema. Happy to make other adjustments as needed.