### PR TITLE
Added paths-ignore

### DIFF
--- a/.github/workflows/direct_download_urls_test_for_sources.yml
+++ b/.github/workflows/direct_download_urls_test_for_sources.yml
@@ -3,6 +3,10 @@ name: Direct download URLs test for sources
 on:
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'scripts/**'
+      - '.github/workflows/add_new_or_updated_feeds.yml'
+      - '.github/workflows/**'
 
 jobs:
   get-urls:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,6 +3,10 @@ name: Integration tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'scripts/**'
+      - '.github/workflows/add_new_or_updated_feeds.yml'
+      - '.github/workflows/**'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/python_style_checker.yml
+++ b/.github/workflows/python_style_checker.yml
@@ -3,6 +3,10 @@ name: Python style checker
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'scripts/**'
+      - '.github/workflows/add_new_or_updated_feeds.yml'
+      - '.github/workflows/**'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,6 +3,10 @@ name: Unit tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'scripts/**'
+      - '.github/workflows/add_new_or_updated_feeds.yml'
+      - '.github/workflows/**'
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
In order to prevent triggering these workflows every time a change is made to another workflow or a script inside the `scripts/` folder, added paths-ignore.