### PR TITLE
feat: added redirects and feed contact email to operations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,12 @@ The easiest way to add a GTFS Schedule source is to use the operation `tools.ope
         license_url=$OPTIONAL_LICENSE_URL,
         name=$OPTIONAL_SOURCE_NAME,
         features=[$OPTIONAL_FEATURE_ARRAY],
-        status=$OPTIONAL_STATUS
+        status=$OPTIONAL_STATUS,
+        feed_contact_email=$OPTIONAL_FEED_CONTACT_EMAIL,
+        redirects=[{
+            "id": $OPTIONAL_REDIRECT_ID,
+            "comment": $OPTIONAL_REDIRECT_COMMENT
+        }],
     )
 ```
 
@@ -99,7 +104,12 @@ The default value for every parameter is `None`. Note that once a parameter valu
         api_key_parameter_value=$NOT_STORED_API_KEY_PARAMETER_VALUE,
         license_url=$OPTIONAL_LICENSE_URL,
         features=[$OPTIONAL_FEATURE_ARRAY],
-        status=$OPTIONAL_STATUS
+        status=$OPTIONAL_STATUS,
+        feed_contact_email=$OPTIONAL_FEED_CONTACT_EMAIL,
+        redirects=[{
+            "id": $OPTIONAL_REDIRECT_ID,
+            "comment": $OPTIONAL_REDIRECT_COMMENT
+        }],
     )
 ```
 

--- a/schemas/gtfs_schedule_source_schema.json
+++ b/schemas/gtfs_schedule_source_schema.json
@@ -192,7 +192,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
+            "type": "number",
             "description": "The target feed id of that redirect."
           },
           "comment": {

--- a/tools/constants.py
+++ b/tools/constants.py
@@ -86,6 +86,10 @@ API_KEY_PARAMETER_NAME = "api_key_parameter_name"
 API_KEY_PARAMETER_VALUE = "api_key_parameter_value"
 NOTE = "note"
 ENTITY_TYPE = "entity_type"
+FEED_CONTACT_EMAIL = "feed_contact_email"
+REDIRECTS = "redirect"
+REDIRECT_ID = "id"
+REDIRECT_COMMENT = "comment"
 
 # TIME CONSTANTS
 SIX_MONTHS_IN_WEEKS = 26

--- a/tools/operations.py
+++ b/tools/operations.py
@@ -1,7 +1,5 @@
 import os
 from tools.constants import (
-    GTFS,
-    GTFS_RT,
     NAME,
     PROVIDER,
     COUNTRY_CODE,
@@ -21,6 +19,8 @@ from tools.constants import (
     CATALOGS,
     ALL,
     MDB_SOURCE_ID,
+    FEED_CONTACT_EMAIL,
+    REDIRECTS,
 )
 from tools.representations import GtfsScheduleSourcesCatalog, GtfsRealtimeSourcesCatalog
 
@@ -117,6 +117,8 @@ def add_gtfs_schedule_source(
     name=None,
     status=None,
     features=None,
+    feed_contact_email=None,
+    redirects=None,
 ):
     """Add a new GTFS Schedule source to the Mobility Catalogs."""
     catalog = GtfsScheduleSourcesCatalog()
@@ -134,6 +136,8 @@ def add_gtfs_schedule_source(
         NAME: name,
         STATUS: status,
         FEATURES: features,
+        FEED_CONTACT_EMAIL: feed_contact_email,
+        REDIRECTS: redirects,
     }
     catalog.add(**data)
     return catalog
@@ -154,6 +158,8 @@ def update_gtfs_schedule_source(
     license_url=None,
     status=None,
     features=None,
+    feed_contact_email=None,
+    redirects=None,
 ):
     """Update a GTFS Schedule source in the Mobility Catalogs."""
     catalog = GtfsScheduleSourcesCatalog()
@@ -172,6 +178,8 @@ def update_gtfs_schedule_source(
         NAME: name,
         STATUS: status,
         FEATURES: features,
+        FEED_CONTACT_EMAIL: feed_contact_email,
+        REDIRECTS: redirects,
     }
     catalog.update(**data)
     return catalog

--- a/tools/representations.py
+++ b/tools/representations.py
@@ -167,10 +167,12 @@ class SourcesCatalog(Catalog):
         redirects = kwargs.pop(REDIRECTS, [])
         if len(redirects) > 0:
             kwargs[REDIRECTS] = [
-                {REDIRECT_ID: elem.get(REDIRECT_ID), REDIRECT_COMMENT: elem.get(REDIRECT_COMMENT)}
+                {
+                    REDIRECT_ID: elem.get(REDIRECT_ID), REDIRECT_COMMENT: elem.get(REDIRECT_COMMENT)
+                }
                 for elem in redirects
             ]
-            kwargs[REDIRECTS] = list(filter(lambda x: x.get(REDIRECT_ID) is not None, kwargs[REDIRECTS]))
+            kwargs[REDIRECTS] = list(filter(lambda x: x.get(REDIRECT_ID) != 'None', kwargs[REDIRECTS]))
 
         entity = self.entity_cls.build(mdb_source_id=mdb_source_id, **kwargs)
         if isinstance(entity, self.entity_cls):
@@ -316,7 +318,7 @@ class GtfsScheduleSource(Source):
         urls = kwargs.pop(URLS, {})
         self.latest_url = urls.pop(LATEST)
         self.feed_contact_email = kwargs.pop(FEED_CONTACT_EMAIL, None)
-        self.redirects = kwargs.pop(REDIRECTS, {})
+        self.redirects = kwargs.pop(REDIRECTS, [])
 
     def __str__(self):
         attributes = {
@@ -559,6 +561,10 @@ class GtfsScheduleSource(Source):
             del schema[FEATURES]
         if schema[STATUS] is None:
             del schema[STATUS]
+        if schema[FEED_CONTACT_EMAIL] is None:
+            del schema[FEED_CONTACT_EMAIL]
+        if schema[REDIRECTS] is None:
+            del schema[REDIRECTS]
         return schema
 
 

--- a/tools/tests/test_operations.py
+++ b/tools/tests/test_operations.py
@@ -99,6 +99,12 @@ class TestOperations(TestCase):
         test_license_url = "test_license_url"
         test_status = "active"
         test_features = ["flex"]
+        feed_contact_email = "test contact email"
+        redirects = [
+            {"id": "test_id", "comment": "test_url"},
+            {"id": "test_id", "comment": "test_url"},
+            {"wrong_key": "test_value"}
+        ]
         under_test = add_gtfs_schedule_source(
             provider=test_provider,
             name=test_name,
@@ -113,6 +119,8 @@ class TestOperations(TestCase):
             license_url=test_license_url,
             status=test_status,
             features=test_features,
+            feed_contact_email=feed_contact_email,
+            redirects=redirects,
         )
         self.assertEqual(under_test, mock_catalog())
         self.assertEqual(mock_catalog.call_count, 2)
@@ -122,7 +130,7 @@ class TestOperations(TestCase):
     def test_update_gtfs_schedule_source(self, mock_catalog):
         test_mdb_source_id = "test_mdb_source_id"
         test_provider = "test_provider"
-        test_name = "test_name"
+        test_name = "test_name changed"
         test_country_code = "test_country_code"
         test_subdivision_name = "test_subdivision_name"
         test_municipality = "test_municipality"
@@ -134,6 +142,12 @@ class TestOperations(TestCase):
         test_license_url = "test_license_url"
         test_status = "active"
         test_features = ["flex"]
+        feed_contact_email = "test contact email changed"
+        redirects = [
+            {"id": "test_id", "comment": "test_url"},
+            {"id": "test_id changed", "comment": "test_url changed"},
+            {"wrong_key": "test_value"}
+        ]
         under_test = update_gtfs_schedule_source(
             mdb_source_id=test_mdb_source_id,
             provider=test_provider,
@@ -149,6 +163,8 @@ class TestOperations(TestCase):
             license_url=test_license_url,
             status=test_status,
             features=test_features,
+            feed_contact_email=feed_contact_email,
+            redirects=redirects,
         )
         self.assertEqual(under_test, mock_catalog())
         self.assertEqual(mock_catalog.call_count, 2)


### PR DESCRIPTION
Closes #319 
Closes #318 

✅ Added `redirects` to python `add` operation for schedule feeds
✅ Added `redirects` to python `update` operation for schedule feeds
✅ Added `feed_contact_email` to python `add` operation for schedule feeds
✅ Added `feed_contact_email` to python `update` operation for schedule feeds
✅ Updated unit tests
✅ Updated code snippet in documentation