### PR TITLE
Removed channel IDs in payload for Slack notif

### DIFF
--- a/.github/workflows/add_new_or_updated_feeds.yml
+++ b/.github/workflows/add_new_or_updated_feeds.yml
@@ -139,7 +139,6 @@ jobs:
         with:
           payload: |
             {
-              "channel": "G01BLNPU0M8",
               "blocks": [
                 {
                   "type": "header",
@@ -203,7 +202,6 @@ jobs:
         with:
           payload: |
             {
-              "channel": "G01BLNPU0M8",
               "attachments": [
                 {
                   "color": "#f20000",


### PR DESCRIPTION
Removed the channel IDs as this was deemed irrelevant since the webhook only works with one specific channel.