### PR TITLE
fix: update Nantes feed

### DIFF
--- a/catalogs/sources/gtfs/schedule/fr-bretagne-societe-deconomie-mixte-des-transports-de-lagglomeration-nantaise-tan-gtfs-1025.json
+++ b/catalogs/sources/gtfs/schedule/fr-bretagne-societe-deconomie-mixte-des-transports-de-lagglomeration-nantaise-tan-gtfs-1025.json
@@ -1,13 +1,13 @@
 {
     "mdb_source_id": 1025,
     "data_type": "gtfs",
-    "provider": "Société d'Economie Mixte des Transports de l'Agglomération Nantaise (TAN)",
+    "provider": "Naolib",
     "features": [
         "fares-v1"
     ],
     "location": {
         "country_code": "FR",
-        "subdivision_name": "Bretagne",
+        "subdivision_name": "Pays-de-la-Loire",
         "municipality": "Nantes",
         "bounding_box": {
             "minimum_latitude": 47.12305797,

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-naolib-gtfs-1025.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-naolib-gtfs-1025.json
@@ -19,7 +19,7 @@
     },
     "urls": {
         "direct_download": "https://data.nantesmetropole.fr/explore/dataset/244400404_tan-arrets-horaires-circuits/files/16a1a0af5946619af621baa4ad9ee662/download/",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-bretagne-societe-deconomie-mixte-des-transports-de-lagglomeration-nantaise-tan-gtfs-1025.zip?alt=media",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-naolib-gtfs-1025.zip?alt=media",
         "license": "https://data.nantesmetropole.fr/explore/dataset/244400404_tan-arrets-horaires-circuits/information/"
     }
 }


### PR DESCRIPTION
This PR contains:
- Update provider name
- Fix subdivision name (Nantes is no longer in 'Bretagne' since half a century)

Should we also change json file name and lastest url ? However I guess that it might break data anteriority.