### PR TITLE
Changed when the catalog-sources-updated trigger is sent

### DIFF
--- a/.github/workflows/add_new_or_updated_feeds.yml
+++ b/.github/workflows/add_new_or_updated_feeds.yml
@@ -3,7 +3,7 @@ name: Add new or updated feeds from Google Sheets/Form
 on:
     workflow_dispatch:
     schedule:
-      - cron: '55 3 * * *' # At 00:00 ETC every day
+      - cron: '55 3 * * *' # Run every night
 
 env:
     DATE_FORMAT: "[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}|[0-9]{4}-[0-9]{2}-[0-9]{2}" # this is the format we need to compare dates between the CSV and the local system.
@@ -11,17 +11,10 @@ env:
     
     USERNAME: "github-actions[bot]" # GitHub username that will create the PR
     USERNAME_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
-    
-    ORGANIZATION: MobilityData # organization name
-    REPO_NAME: mobility-database-catalogs # repository name
+
     BASE: "main"
-    API_REPO_NAME: mobility-feed-api
-    API_TRIGGER_EVENT: catalog-sources-updated
 
     REVIEWERS_JSON: "[\"emmambd\"]" # List of GitHub usernames of the reviewers, in a JSON array : ["username1", "username2"]
-
-    GTFS_SCHEDULE_CATALOG_PATH_FROM_ROOT: "catalogs/sources/gtfs/schedule/"
-    GTFS_REALTIME_CATALOG_PATH_FROM_ROOT: "catalogs/sources/gtfs/realtime/"
 
 jobs:
   add-new-updated-feeds:
@@ -49,6 +42,7 @@ jobs:
         env:
             OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
             CREDENTIALS: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ifkeehu5gzi7wy5ub5qvwkaire/credential"
+            # The URL to obtain the csv file with the data of the google form. Taken from the "GiHub Actions — URLs" entry in 1password
             CSV_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/qkn5esttmtojawglm4l6t2bqaa/al2gjfhiuddabkp7o26hszuvia"
             SLACK_WEBHOOK_URL: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Slack webhook URLs/internal-public-transit-support channel"
 
@@ -125,14 +119,6 @@ jobs:
             committer_email: ${{ env.USERNAME_EMAIL }}
             message: "Automated commit — New/Updated feed"
 
-      - name: Trigger Update in API
-        if: steps.process-csv.outputs.PYTHON_SCRIPT_ARGS != ''
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ env.CREDENTIALS }}
-          repository: ${{ env.ORGANIZATION }}/${{ env.API_REPO_NAME }}
-          event-type: ${{ env.API_TRIGGER_EVENT }}
-  
       - name: Post notification in Slack channel of update
         if: steps.process-csv.outputs.PYTHON_SCRIPT_ARGS != ''
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -3,6 +3,9 @@ name: Export catalogs to CSV
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'catalogs/**'
+
   workflow_dispatch:
 
 jobs:
@@ -58,3 +61,18 @@ jobs:
           path: sources.csv
           destination: mdb-csv
           parent: false
+
+      - name: Load secrets from 1Password to be used for sending notification
+        id: onepw_secrets
+        uses: 1password/load-secrets-action@v1.3.1
+        with:
+          export-env: true # Export loaded secrets as environment variables
+        env:
+          CREDENTIALS: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ifkeehu5gzi7wy5ub5qvwkaire/credential"
+
+      - name: Send a notification to mobility-feed-api
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ env.CREDENTIALS }}
+          repository: MobilityData/mobility-feed-api
+          event-type: catalog-sources-updated


### PR DESCRIPTION
This PR solves this issue in the mobility-feed-api repo: [#407](https://github.com/MobilityData/mobility-feed-api/issues/407)
There was a desynchronization of the catalog csv file used in the integration tests and the contents of the DB in the QA repo.
Now modified so the catalog-sources-updated trigger is sent to the mobility-feed-api repo each time the source.csv file is generated, ie after a PR changing the catalog is merged.

### Testing:
Testing for this is tricky. I want to test mostly the notification mechanism. But I don't want to trigger all the GH actions that have catalog-sources-updated as a trigger. Because this will update the DBs in DEV, QA and PROD.
I could create a dummy GH action in mobility-feed-api that would just receive a test trigger and print something. But this action needs to be in main. 
I could send the trigger to one of my private repos, but then I would need to set a secret in mobility-database-catalogs with a Personal access token, and I don't have permission to do that.
I could put the token directly in the GH action that sends the notification, but that would be in cleartext and not recommended.

All this to say I don't know how to test apart from running the real thing. 