### PR TITLE
Stripped spaces when creating sources.csv

### DIFF
--- a/scripts/export_to_csv.py
+++ b/scripts/export_to_csv.py
@@ -100,6 +100,11 @@ for source_id, source in catalog.items():
     source[REDIRECT_ID] = ids_str
     source[REDIRECT_COMMENT] = comments_str
 
+    # Some fields in the JSON files have extraneous spaces at the beginning or end. It's just looking for trouble.
+    for key in source.keys():
+        if isinstance(source[key], str):
+            source[key] = source[key].strip()
+
     catalog[source_id] = source
 # Sort the catalog and convert it to a list
 catalog = list(dict(sorted(catalog.items())).values())


### PR DESCRIPTION
This PR solves this issue in the mobility-feed-api repo: [#407](https://github.com/MobilityData/mobility-feed-api/issues/407)
There was already a PR #362 , but it did not solve all the problems.

This time some of the provider fields in the json files of the catalog had spaces at the end.
This was put in sources.csv.
But when filling the DB the spaces were removed.
This created a discrepancy between sources.csv and the DB that caused the integration tests to fail.

Corrected the problem by removing extraneous spaces on every string read from the json files, before writing to sources.csv.

Here is the list of entries that were modified:
405, 902, 1112, 1115, 1124, 1132, 1134, 1204, 1214, 1215, 1216, 1217, 1218, 1229, 1312, 1321, 1476, 1477, 1478, 1619, 1636, 2020

