### PR TITLE
Allow csv upload when triggered by hand

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     # The user can opt out of uploading the csv if triggered by hand.
     # If triggered by a push, always upload.
-    if: ${{ github.event.upload_to_gcs == 'true' }}
+    if: ${{ github.event.inputs.upload_to_gcs == 'true' }}
     steps:
       - uses: actions/checkout@v2
       - name: Download the catalog of sources CSV artifact

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           export-env: true # Export loaded secrets as environment variables
         env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           CREDENTIALS: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ifkeehu5gzi7wy5ub5qvwkaire/credential"
 
       - name: Send a notification to mobility-feed-api

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -7,6 +7,11 @@ on:
       - 'catalogs/**'
 
   workflow_dispatch:
+    inputs:
+      upload_to_gcs:
+        description: 'true to upload the resulting csv to google so it becomes the official catalog csv'
+        required: false
+        default: 'true'
 
 jobs:
   export-to-csv:
@@ -40,9 +45,9 @@ jobs:
   store-csv:
     needs: [ export-to-csv ]
     runs-on: ubuntu-latest
-    # Don't upload to Google Cloud if it was triggered by hand.
-    # In that case the resulting sources.csv can be found in the build artifacts.
-    if: ${{ github.event_name != 'workflow_dispatch' }}
+    # The user can opt out of uploading the csv if triggered by hand.
+    # If triggered by a push, always upload.
+    if: ${{ github.event.upload_to_gcs == 'true' }}
     steps:
       - uses: actions/checkout@v2
       - name: Download the catalog of sources CSV artifact

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -56,7 +56,7 @@ jobs:
           name: sources.csv
           path: sources.csv
       - name: Set up and authorize Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
       - name: Upload csv to Google Cloud Storage

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -61,7 +61,7 @@ jobs:
           credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
       - name: Upload csv to Google Cloud Storage
         id: upload-csv
-        uses: google-github-actions/upload-cloud-storage@v0
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: sources.csv
           destination: mdb-csv

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -222,7 +222,7 @@ jobs:
               with open(report_path, "w") as fp:
                   fp.write(file_log)
       - name: Set up and authorize Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.ARCHIVE_DATASET_SA_KEY }}
       - name: Upload datasets to Google Cloud Storage


### PR DESCRIPTION
As I was testing https://github.com/MobilityData/mobility-database-catalogs/pull/365 I realized that there was no way to trigger the upload of sources.csv to GCP apart from changing the json files in the catalog.

This PR optionally allows upload when the trigger is manual.

It also corrects some problem with using old versions of GH actions.