### PR TITLE
Wave Transit's updated feeds [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1110.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1110.json
@@ -3,6 +3,7 @@
     "data_type": "gtfs",
     "provider": "Wave Transit",
     "status": "active",
+    "name": "fixed route",
     "location": {
         "country_code": "US",
         "subdivision_name": "North Carolina",

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1110.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1110.json
@@ -2,7 +2,7 @@
     "mdb_source_id": 1110,
     "data_type": "gtfs",
     "provider": "Wave Transit",
-    "status": "inactive",
+    "status": "active",
     "location": {
         "country_code": "US",
         "subdivision_name": "North Carolina",
@@ -17,6 +17,8 @@
     },
     "urls": {
         "direct_download": "https://www.wavetransit.com/gtransit/google_transit.zip",
+        "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-1110.zip?alt=media"
-    }
+    },
+    "redirect": []
 }

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1861.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1861.json
@@ -24,5 +24,11 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-1861.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [
+        {
+            "id": 1110
+        }
+    ]
+    
+    
 }

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1861.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1861.json
@@ -6,6 +6,7 @@
     "features": [
         "fares-v1"
     ],
+    "status": "deprecated",
     "location": {
         "country_code": "US",
         "subdivision_name": "North Carolina",
@@ -20,6 +21,8 @@
     },
     "urls": {
         "direct_download": "https://drive.google.com/u/0/uc?id=18zwweT64NI5O_goGVc_h-OGTTShfiacG&export=download",
+        "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-1861.zip?alt=media"
-    }
+    },
+    "redirect": []
 }

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1862.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1862.json
@@ -6,6 +6,7 @@
     "features": [
         "fares-v1"
     ],
+    "status": "deprecated",
     "location": {
         "country_code": "US",
         "subdivision_name": "North Carolina",
@@ -20,6 +21,8 @@
     },
     "urls": {
         "direct_download": "https://drive.google.com/u/0/uc?id=1w_7Ma9B9-aA-iBTWz3gxwGlORXPjppQ-&export=download",
+        "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-1862.zip?alt=media"
-    }
+    },
+    "redirect": []
 }

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1862.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-1862.json
@@ -24,5 +24,9 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-1862.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [
+        {
+            "id": 2026
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-2026.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-2026.json
@@ -20,7 +20,6 @@
         "direct_download": "https://www.wavetransit.com/gtransit/google_transit_uncw.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-2026.zip?alt=media",
-        "license": "INVALID_OR_NO_URL_PROVIDED"
     },
     "redirect": []
 }

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-2026.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-2026.json
@@ -19,7 +19,7 @@
     "urls": {
         "direct_download": "https://www.wavetransit.com/gtransit/google_transit_uncw.zip",
         "authentication_type": 0,
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-2026.zip?alt=media",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-2026.zip?alt=media"
     },
     "redirect": []
 }

--- a/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-2026.json
+++ b/catalogs/sources/gtfs/schedule/us-north-carolina-wave-transit-gtfs-2026.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 2026,
+    "data_type": "gtfs",
+    "provider": "Wave Transit",
+    "name": "UNCW Seahawk Shuttle",
+    "feed_contact_email": "planning@wavetransit.com",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "North Carolina",
+        "municipality": "Wilmington",
+        "bounding_box": {
+            "minimum_latitude": 34.1427973,
+            "maximum_latitude": 34.25147305,
+            "minimum_longitude": -77.89130328,
+            "maximum_longitude": -77.8608014,
+            "extracted_on": "2024-05-22T13:23:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://www.wavetransit.com/gtransit/google_transit_uncw.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-north-carolina-wave-transit-gtfs-2026.zip?alt=media",
+        "license": "INVALID_OR_NO_URL_PROVIDED"
+    },
+    "redirect": []
+}


### PR DESCRIPTION
Includes the following contributions from Wave Transit: 

- A new feed for the UNCW Seahawk Shuttle
- Updating the pre-existing https://www.wavetransit.com/gtransit/google_transit.zip feed's status to "active"
- Updating the old URLs as deprecated