### PR TITLE
Poland mkuran.pl updates [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/pl-kujawsko-pomorskie-miejski-zaklad-komunikacji-w-toruniu-mzk-torun-gtfs-2089.json
+++ b/catalogs/sources/gtfs/schedule/pl-kujawsko-pomorskie-miejski-zaklad-komunikacji-w-toruniu-mzk-torun-gtfs-2089.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 2089,
+    "data_type": "gtfs",
+    "provider": "Urząd Miasta Torunia (MZK Toruń)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Kujawsko-pomorskie",
+        "municipality": "Toruń",
+        "bounding_box": {
+            "minimum_latitude": 52.9263168359386,
+            "maximum_latitude": 53.134097,
+            "minimum_longitude": 18.479291,
+            "maximum_longitude": 18.9227700233459,
+            "extracted_on": "2024-08-19T17:46:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/torun.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-kujawsko-pomorskie-miejski-zaklad-komunikacji-w-toruniu-mzk-torun-gtfs-2089.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-lomianki-gtfs-1123.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-lomianki-gtfs-1123.json
@@ -2,6 +2,7 @@
     "mdb_source_id": 1123,
     "data_type": "gtfs",
     "provider": "Komunikacja Miejska Łomianki",
+    "status": "inactive",
     "location": {
         "country_code": "PL",
         "subdivision_name": "Mazowieckie",
@@ -18,5 +19,6 @@
         "direct_download": "https://mkuran.pl/feed/kml/kml-latest.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-komunikacja-miejska-lomianki-gtfs-1123.zip?alt=media",
         "license": "https://mkuran.pl/gtfs/"
-    }
+    },
+    "redirect": []
 }

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-mzdik-radom-gtfs-1015.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-mzdik-radom-gtfs-1015.json
@@ -5,6 +5,7 @@
     "features": [
         "fares-v1"
     ],
+    "status": "deprecated",
     "location": {
         "country_code": "PL",
         "subdivision_name": "Mazowieckie",
@@ -20,5 +21,11 @@
     "urls": {
         "direct_download": "https://mkuran.pl/feed/radom/radom-latest.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-mzdik-radom-gtfs-1015.zip?alt=media"
-    }
+    },
+    "redirect": [
+        {
+            "id": 2090,
+            "comment": "Only the source URL changed, see feed 2090."
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-mzdik-radom-gtfs-2090.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-mzdik-radom-gtfs-2090.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 2090,
+    "data_type": "gtfs",
+    "provider": "MZDiK Radom",
+    "features": [
+        "fares-v1"
+    ],
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Mazowieckie",
+        "municipality": "Radom",
+        "bounding_box": {
+            "minimum_latitude": 51.31018,
+            "maximum_latitude": 51.468,
+            "minimum_longitude": 21.03423,
+            "maximum_longitude": 21.32751,
+            "extracted_on": "2024-08-28T21:25:29+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/radom.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-mzdik-radom-gtfs-2090.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-2091.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-2091.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 2091,
+    "data_type": "gtfs",
+    "provider": "Warszawska Kolej Dojazdowa (WKD)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Mazowieckie",
+        "municipality": "Warsaw",
+        "bounding_box": {
+            "minimum_latitude": 52.100645,
+            "maximum_latitude": 52.22768605033,
+            "minimum_longitude": 20.628435,
+            "maximum_longitude": 21.00040372159,
+            "extracted_on": "2024-08-28T21:26:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/wkd.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-2091.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-863.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-863.json
@@ -2,6 +2,7 @@
     "mdb_source_id": 863,
     "data_type": "gtfs",
     "provider": "Warszawska Kolej Dojazdowa (WKD)",
+    "status": "deprecated",
     "location": {
         "country_code": "PL",
         "subdivision_name": "Mazowieckie",
@@ -18,5 +19,11 @@
         "direct_download": "https://mkuran.pl/feed/wkd/wkd-latest.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-863.zip?alt=media",
         "license": "https://mkuran.pl/gtfs/"
-    }
+    },
+    "redirect": [
+        {
+            "id": 2091,
+            "comment": "Only the source URL changed, see feed 2091."
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawski-transport-publiczny-ztm-warszawa-gtfs-1008.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawski-transport-publiczny-ztm-warszawa-gtfs-1008.json
@@ -5,6 +5,7 @@
     "features": [
         "fares-v1"
     ],
+    "status": "deprecated",
     "location": {
         "country_code": "PL",
         "subdivision_name": "Mazowieckie",
@@ -21,5 +22,11 @@
         "direct_download": "https://mkuran.pl/feed/ztm/ztm-latest.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-warszawski-transport-publiczny-ztm-warszawa-gtfs-1008.zip?alt=media",
         "license": "https://www.ztm.waw.pl/pliki-do-pobrania/dane-rozkladowe/"
-    }
+    },
+    "redirect": [
+        {
+            "id": 2092,
+            "comment": "Only the source URL changed, see feed 2092."
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawski-transport-publiczny-ztm-warszawa-gtfs-2092.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-warszawski-transport-publiczny-ztm-warszawa-gtfs-2092.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 2092,
+    "data_type": "gtfs",
+    "provider": "Warszawski Transport Publiczny (ZTM Warszawa)",
+    "features": [
+        "fares-v1"
+    ],
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Mazowieckie",
+        "municipality": "Warsaw",
+        "bounding_box": {
+            "minimum_latitude": 51.921869,
+            "maximum_latitude": 52.493488,
+            "minimum_longitude": 20.462591,
+            "maximum_longitude": 21.463783,
+            "extracted_on": "2024-08-28T21:27:57+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/warsaw.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-warszawski-transport-publiczny-ztm-warszawa-gtfs-2092.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-pomorskie-miejski-zaklad-komunikacji-w-wejherowie-mzk-wejherowo-gtfs-2084.json
+++ b/catalogs/sources/gtfs/schedule/pl-pomorskie-miejski-zaklad-komunikacji-w-wejherowie-mzk-wejherowo-gtfs-2084.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 2084,
+    "data_type": "gtfs",
+    "provider": "Miejski Zakład Komunikacji w Wejherowie (MZK Wejherowo)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Pomorskie",
+        "municipality": "Wejherowo",
+        "bounding_box": {
+            "minimum_latitude": 54.567562,
+            "maximum_latitude": 54.640766,
+            "minimum_longitude": 18.097898,
+            "maximum_longitude": 18.387169,
+            "extracted_on": "2024-08-19T17:47:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/wejherowo.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-pomorskie-miejski-zaklad-komunikacji-w-wejherowie-mzk-wejherowo-gtfs-2084.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-pomorskie-zarzad-drog-i-zieleni-gdynia-zkm-gdynia-gtfs-2094.json
+++ b/catalogs/sources/gtfs/schedule/pl-pomorskie-zarzad-drog-i-zieleni-gdynia-zkm-gdynia-gtfs-2094.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 2094,
+    "data_type": "gtfs",
+    "provider": "Zarząd Dróg i Zieleni Gdynia (ZKM Gdynia)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Pomorskie",
+        "municipality": "Gdynia",
+        "bounding_box": {
+            "minimum_latitude": 54.3415636,
+            "maximum_latitude": 54.6323285,
+            "minimum_longitude": 18.21451,
+            "maximum_longitude": 18.5815284,
+            "extracted_on": "2024-08-29T17:32:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://api.zdiz.gdynia.pl/pt/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-pomorskie-zarzad-drog-i-zieleni-gdynia-zkm-gdynia-gtfs-2094.zip?alt=media",
+        "license": "http://www.opendefinition.org/licenses/cc-by"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-pomorskie-zarzad-transportu-miejskiego-gdansk-ztm-gdansk-gtfs-1014.json
+++ b/catalogs/sources/gtfs/schedule/pl-pomorskie-zarzad-transportu-miejskiego-gdansk-ztm-gdansk-gtfs-1014.json
@@ -2,6 +2,7 @@
     "mdb_source_id": 1014,
     "data_type": "gtfs",
     "provider": "Zarząd Transportu Miejskiego Gdańsk (ZTM Gdańsk), Zarząd Transportu Miejskiego Gdynia (ZKM Gdynia)",
+    "status": "deprecated",
     "location": {
         "country_code": "PL",
         "subdivision_name": "Pomorskie",
@@ -18,5 +19,15 @@
         "direct_download": "https://mkuran.pl/gtfs/tristar.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-pomorskie-zarzad-transportu-miejskiego-gdansk-ztm-gdansk-gtfs-1014.zip?alt=media",
         "license": "http://www.opendefinition.org/licenses/cc-by"
-    }
+    },
+    "redirect": [
+        {
+            "id": 2093,
+            "comment": "See 2093 for a replacement feed for Gdańsk."
+        },
+        {
+            "id": 2094,
+            "comment": "See 2094 for a replacement feed for Gdynia."
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/schedule/pl-pomorskie-zarzad-transportu-miejskiego-gdansk-ztm-gdansk-gtfs-2093.json
+++ b/catalogs/sources/gtfs/schedule/pl-pomorskie-zarzad-transportu-miejskiego-gdansk-ztm-gdansk-gtfs-2093.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 2093,
+    "data_type": "gtfs",
+    "provider": "Zarząd Transportu Miejskiego Gdańsk (ZTM Gdańsk)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Pomorskie",
+        "municipality": "Gdańsk",
+        "bounding_box": {
+            "minimum_latitude": 54.237928572047,
+            "maximum_latitude": 54.474834202056,
+            "minimum_longitude": 18.355140132614,
+            "maximum_longitude": 18.934177112697,
+            "extracted_on": "2024-08-28T21:15:08+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://ckan.multimediagdansk.pl/dataset/c24aa637-3619-4dc2-a171-a23eec8f2172/resource/30e783e4-2bec-4a7d-bb22-ee3e3b26ca96/download/gtfsgoogle.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-pomorskie-zarzad-transportu-miejskiego-gdansk-ztm-gdansk-gtfs-2093.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-unknown-polregio-gtfs-2087.json
+++ b/catalogs/sources/gtfs/schedule/pl-unknown-polregio-gtfs-2087.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 2087,
+    "data_type": "gtfs",
+    "provider": "Polregio",
+    "location": {
+        "country_code": "PL",
+        "bounding_box": {
+            "minimum_latitude": 49.24722949438,
+            "maximum_latitude": 54.79372147682,
+            "minimum_longitude": 10.66983101587,
+            "maximum_longitude": 23.65107129355,
+            "extracted_on": "2024-08-19T17:53:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/polregio.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-unknown-polregio-gtfs-2087.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-unknown-polskie-koleje-panstwowe-intercity-pkp-intercity-gtfs-2088.json
+++ b/catalogs/sources/gtfs/schedule/pl-unknown-polskie-koleje-panstwowe-intercity-pkp-intercity-gtfs-2088.json
@@ -1,0 +1,21 @@
+{
+    "mdb_source_id": 2088,
+    "data_type": "gtfs",
+    "provider": "Polskie Koleje Państwowe Intercity (PKP Intercity)",
+    "location": {
+        "country_code": "PL",
+        "bounding_box": {
+            "minimum_latitude": 49.24722949438,
+            "maximum_latitude": 54.79372147682,
+            "minimum_longitude": 14.26659541863,
+            "maximum_longitude": 23.90884100854,
+            "extracted_on": "2024-08-19T17:54:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/pkpic.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-unknown-polskie-koleje-panstwowe-intercity-pkp-intercity-gtfs-2088.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-warminsko-mazurskie-miejski-zaklad-komunikacji-w-elku-mzk-elk-gtfs-2086.json
+++ b/catalogs/sources/gtfs/schedule/pl-warminsko-mazurskie-miejski-zaklad-komunikacji-w-elku-mzk-elk-gtfs-2086.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 2086,
+    "data_type": "gtfs",
+    "provider": "Miejski Zakład Komunikacji w Ełku (MZK Ełk)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Warmińsko-mazurskie",
+        "municipality": "Ełk",
+        "bounding_box": {
+            "minimum_latitude": 53.74023088718,
+            "maximum_latitude": 53.9399037153,
+            "minimum_longitude": 22.16239379266,
+            "maximum_longitude": 22.48585944603,
+            "extracted_on": "2024-08-19T17:51:04+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/elk.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-warminsko-mazurskie-miejski-zaklad-komunikacji-w-elku-mzk-elk-gtfs-2086.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pl-zachodniopomorskie-komunikacja-autobusowa-swinoujscie-ka-swinoujscie-gtfs-2085.json
+++ b/catalogs/sources/gtfs/schedule/pl-zachodniopomorskie-komunikacja-autobusowa-swinoujscie-ka-swinoujscie-gtfs-2085.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 2085,
+    "data_type": "gtfs",
+    "provider": "Komunikacja Autobusowa Świnoujście (KA Świnoujście)",
+    "location": {
+        "country_code": "PL",
+        "subdivision_name": "Zachodniopomorskie",
+        "municipality": "Świnoujście",
+        "bounding_box": {
+            "minimum_latitude": 53.84902826912,
+            "maximum_latitude": 53.92857542178,
+            "minimum_longitude": 14.216049,
+            "maximum_longitude": 14.455431,
+            "extracted_on": "2024-08-19T17:49:14+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://mkuran.pl/gtfs/swinoujscie.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-zachodniopomorskie-komunikacja-autobusowa-swinoujscie-ka-swinoujscie-gtfs-2085.zip?alt=media",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "redirect": []
+}


### PR DESCRIPTION
As mostly stated in the commit messages:

feat: add more feeds from mkuran.pl [SOURCES] (the only available one which I haven't added is the Kielce one, as they have a funky license (see mkuran.pl/gtfs).)
- pl-kujawsko-pomorskie-miejski-zaklad-komunikacji-w-toruniu-mzk-torun-gtfs-2083.json
- pl-pomorskie-miejski-zaklad-komunikacji-w-wejherowie-mzk-wejherowo-gtfs-2084
- pl-zachodniopomorskie-komunikacja-autobusowa-swinoujscie-ka-swinoujscie-gtfs-2085.json
- pl-warminsko-mazurskie-miejski-zaklad-komunikacji-w-elku-mzk-elk-gtfs-2086
- pl-unknown-polregio-gtfs-2087
- pl-unknown-polskie-koleje-panstwowe-intercity-pkp-intercity-gtfs-2088

fix: update URLs for feeds from mkuran.pl [SOURCES] (`/feed/*` -> `/gtfs/*`)
- pl-mazowieckie-warszawska-kolej-dojazdowa-wkd-gtfs-863.json
- pl-mazowieckie-warszawski-transport-publiczny-ztm-warszawa-gtfs-1008.json
- pl-mazowieckie-mzdik-radom-gtfs-1015.json

fix: update feeds removed from mkuran.pl [SOURCES]
- pl-pomorskie-zarzad-transportu-miejskiego-gdansk-ztm-gdansk-gtfs-1014.json (this one had data on Gdynia and Gdańsk combined, but only Gdańsk publishes an up-to-date GTFS feed, so now this feed doesn't include Gdynia)
- pl-mazowieckie-komunikacja-miejska-lomianki-gtfs-1123.json (there is no replacement, so I marked it as `inactive`)