### PR TITLE
Fix mislabeling of feeds from Turkey, Kocaeli, Izmit to Turkey, Izmir

### DIFF
--- a/catalogs/sources/gtfs/schedule/tr-kocaeli-eshot-gtfs-1823.json
+++ b/catalogs/sources/gtfs/schedule/tr-kocaeli-eshot-gtfs-1823.json
@@ -4,8 +4,7 @@
     "provider": "Eshot",
     "location": {
         "country_code": "TR",
-        "subdivision_name": "Kocaeli",
-        "municipality": "Izmit",
+        "subdivision_name": "Izmir",
         "bounding_box": {
             "minimum_latitude": 37.942080002386,
             "maximum_latitude": 39.344003,

--- a/catalogs/sources/gtfs/schedule/tr-kocaeli-izban-gtfs-1828.json
+++ b/catalogs/sources/gtfs/schedule/tr-kocaeli-izban-gtfs-1828.json
@@ -5,8 +5,7 @@
     "name": "Rail",
     "location": {
         "country_code": "TR",
-        "subdivision_name": "Kocaeli",
-        "municipality": "Izmit",
+        "subdivision_name": "Izmir",
         "bounding_box": {
             "minimum_latitude": 37.9508674904,
             "maximum_latitude": 38.788888888889,

--- a/catalogs/sources/gtfs/schedule/tr-kocaeli-metro-izmir-gtfs-1824.json
+++ b/catalogs/sources/gtfs/schedule/tr-kocaeli-metro-izmir-gtfs-1824.json
@@ -4,8 +4,7 @@
     "provider": "METRO İZMİR",
     "location": {
         "country_code": "TR",
-        "subdivision_name": "Kocaeli",
-        "municipality": "Izmir",
+        "subdivision_name": "Izmir",
         "bounding_box": {
             "minimum_latitude": 38.3916,
             "maximum_latitude": 38.4656,

--- a/catalogs/sources/gtfs/schedule/tr-kocaeli-tram-izmir-gtfs-1829.json
+++ b/catalogs/sources/gtfs/schedule/tr-kocaeli-tram-izmir-gtfs-1829.json
@@ -4,8 +4,7 @@
     "provider": "TRAM İZMİR",
     "location": {
         "country_code": "TR",
-        "subdivision_name": "Kocaeli",
-        "municipality": "Izmit",
+        "subdivision_name": "Izmir",
         "bounding_box": {
             "minimum_latitude": 38.397748,
             "maximum_latitude": 38.47965,


### PR DESCRIPTION
fix: Fixed incorrect locations of feeds that were previously mislabeled as Turkey, Kocaeli, Izmit. The feeds are actually for Turkey, Izmir.  (Also fixing [this](https://github.com/MobilityData/mobility-database-catalogs/pull/495) pr)
- tr-kocaeli-metro-izmir-gtfs-1824.json
- tr-kocaeli-eshot-gtfs-1823.json
- tr-kocaeli-izban-gtfs-1828.json
- tr-kocaeli-tram-izmir-gtfs-1829.json

I am not sure if the files need to be renamed as well.