### PR TITLE
Update Metro Saint Louis static feed [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-190.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-190.json
@@ -2,6 +2,12 @@
     "mdb_source_id": 190,
     "data_type": "gtfs",
     "provider": "Metro St. Louis",
+    "status": "deprecated",
+    "redirect": [
+        {
+            "id": 2096
+        }
+    ],
     "location": {
         "country_code": "US",
         "subdivision_name": "Missouri",

--- a/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-2096.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-2096.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 190,
+    "data_type": "gtfs",
+    "provider": "Metro St. Louis",
+    "status": "deprecated",
+    "redirect": [
+        {
+            "id": 2096
+        }
+    ],
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "Missouri",
+        "municipality": "St. Louis",
+        "bounding_box": {
+            "minimum_latitude": 38.469747,
+            "maximum_latitude": 38.825646,
+            "minimum_longitude": -90.662094,
+            "maximum_longitude": -89.874657,
+            "extracted_on": "2022-03-15T17:41:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://metrostlouis.org/Transit/google_transit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-missouri-metro-st-louis-gtfs-190.zip?alt=media"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-2098.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-2098.json
@@ -1,13 +1,7 @@
 {
-    "mdb_source_id": 190,
+    "mdb_source_id": 2098,
     "data_type": "gtfs",
     "provider": "Metro St. Louis",
-    "status": "deprecated",
-    "redirect": [
-        {
-            "id": 2096
-        }
-    ],
     "location": {
         "country_code": "US",
         "subdivision_name": "Missouri",
@@ -21,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://metrostlouis.org/Transit/google_transit.zip",
+        "direct_download": "https://www.metrostlouis.org/Transit/google_transit.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-missouri-metro-st-louis-gtfs-190.zip?alt=media"
     }
 }


### PR DESCRIPTION
Hello again!

I noticed an issue with the feed for Saint Louis - it looks like the old URL is returning old static data. I went to their website and [copied the URL](https://www.metrostlouis.org/developer-resources/), it looks like these two (nearly identical) links return different data.

From what I can tell from the realtime data, the feed that I added contains all the necessary details.

Please let me know if I can update any ids, or if I missed any steps.

Thanks~