### PR TITLE
fix: upgrade upload artifact action to v4

### DIFF
--- a/.github/workflows/direct_download_urls_test_for_sources.yml
+++ b/.github/workflows/direct_download_urls_test_for_sources.yml
@@ -100,7 +100,7 @@ jobs:
           echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
       - name: Persist URLs matrix artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: urls_matrix
           path: ./urls_matrix.json
@@ -205,7 +205,7 @@ jobs:
                       f"The dataset for the source must be a valid GTFS Schedule zip file or URL.\n"
                   )
       - name: Persist datasets artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: datasets
           path: datasets

--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -37,7 +37,7 @@ jobs:
         run: python3 scripts/export_to_csv.py
 
       - name: Upload the catalog of sources CSV artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: sources.csv
           path: sources.csv

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           pytest -v ./tests/test_integration.py --html=mobility-catalogs-integration-tests-report.html --self-contained-html
       - name: Upload the HTML artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: mobility-catalogs-integration-tests-report-v${{ github.run_id }}.${{ github.run_number }}
           path: mobility-catalogs-integration-tests-report.html

--- a/.github/workflows/store_latest_datasets_cronjob.yml
+++ b/.github/workflows/store_latest_datasets_cronjob.yml
@@ -117,13 +117,13 @@ jobs:
           echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
       - name: Persist URLs matrix artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: urls_matrix
           path: ./urls_matrix.json
       - name: Persist Get URLS report artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: get_urls_report
           path: ./get_urls_report.txt
@@ -234,7 +234,7 @@ jobs:
           parent: false
       - name: Persist Download Reports artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: download_reports
           path: download_reports
@@ -312,7 +312,7 @@ jobs:
                   fp.write(file_log)
       - name: Persist Latest Reports artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: latest_reports
           path: latest_reports

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           pytest --ignore=./tests/test_integration.py --html=mobility-catalogs-unit-tests-report.html --self-contained-html
       - name: Upload the HTML artifact
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: mobility-catalogs-unit-tests-report-v${{ github.run_id }}.${{ github.run_number }}
           path: mobility-catalogs-unit-tests-report.html


### PR DESCRIPTION
## Description
Upgrade upload artifact action to the latest version as older versions are [deprecated](https://github.com/actions/upload-artifact)

Example of failing action, [link](https://github.com/MobilityData/mobility-database-catalogs/actions/runs/11241281397)