### PR TITLE
fix: download-artifact action

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download the catalog of sources CSV artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: sources.csv
           path: sources.csv


### PR DESCRIPTION
# Description
Download artifact action has been deprecated. This PR upgrades the action to v4, its latest version.