### PR TITLE
fix: rename invalid license field

### DIFF
--- a/catalogs/sources/gtfs/schedule/be-wallonne-tec-gtfs-1868.json
+++ b/catalogs/sources/gtfs/schedule/be-wallonne-tec-gtfs-1868.json
@@ -17,6 +17,6 @@
     "urls": {
         "direct_download": "https://data.gtfs.be/tec/gtfs/be-tec-gtfs.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/be-wallonne-tec-gtfs-1868.zip?alt=media",
-        "license_url": "https://gtfs.be/"
+        "license": "https://gtfs.be/"
     }
 }

--- a/catalogs/sources/gtfs/schedule/ca-ontario-york-region-transit-gtfs-728.json
+++ b/catalogs/sources/gtfs/schedule/ca-ontario-york-region-transit-gtfs-728.json
@@ -17,6 +17,6 @@
     "urls": {
         "direct_download": "https://www.yrt.ca/google/google_transit.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-ontario-york-region-transit-gtfs-728.zip?alt=media",
-        "license_url": "https://www.yrt.ca/en/about-us/open-data-licence-agreement.aspx"
+        "license": "https://www.yrt.ca/en/about-us/open-data-licence-agreement.aspx"
     }
 }


### PR DESCRIPTION
# Description

As per [schema definition](https://github.com/MobilityData/mobility-database-catalogs/blob/36ed76887c00842937ba0acdfdf586765b0a3046/schemas/gtfs_schedule_source_schema.json#L145), the license URL field is named `license` instead of `license_url.` This PR fix the field name in two occurrences.