### PR TITLE
README: Fix example for get_sources_by_status, takes status as arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ To get the feeds by status, `$STATUS` is expressed as a string and one of:
 
 ```python
 >>> get_sources_by_status(
-        feature=$STATUS,
+        status=$STATUS,
     )
 ```
 ## Integration Tests


### PR DESCRIPTION
Currently broken / outdated - get_sources_by_status takes status as param not feature.