### PR TITLE
feat: Update Volanbusz GTFS feed URL and contact info [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/hu-unknown-volanbusz-gtfs-1836.json
+++ b/catalogs/sources/gtfs/schedule/hu-unknown-volanbusz-gtfs-1836.json
@@ -2,18 +2,21 @@
     "mdb_source_id": 1836,
     "data_type": "gtfs",
     "provider": "Volánbusz",
+    "feed_contact_email": "gtfs_volanbusz@mav-szk.hu",
     "location": {
         "country_code": "HU",
         "bounding_box": {
-            "minimum_latitude": 45.770676,
+            "minimum_latitude": 45.770688,
             "maximum_latitude": 48.580548,
-            "minimum_longitude": 16.159192,
-            "maximum_longitude": 22.869044,
-            "extracted_on": "2022-11-22T17:46:49+00:00"
+            "minimum_longitude": 16.159185,
+            "maximum_longitude": 25.810919,
+            "extracted_on": "2024-12-22T15:19:55+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://opendata.menetrendek.hu/public_gtfs/volanbusz_gtfs.zip",
+        "direct_download": "https://gtfs.kti.hu/public-gtfs/volanbusz_gtfs.zip",
+        "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/hu-unknown-volanbusz-gtfs-1836.zip?alt=media"
-    }
+    },
+    "redirect": []
 }


### PR DESCRIPTION
Update Volanbusz GTFS feed to the one published daily by Volanbusz.
More information at: https://www.volanbusz.hu/hu/menetrendek/gtfs

This resolves my form submission tracked as issue  #644