### PR TITLE
Update Fertagus feed URL and remove license [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/pt-lisboa-fertagus-gtfs-1034.json
+++ b/catalogs/sources/gtfs/schedule/pt-lisboa-fertagus-gtfs-1034.json
@@ -15,6 +15,6 @@
     },
     "urls": {
         "direct_download": "https://www.fertagus.pt/GTFSTMLzip/Fertagus_GTFS.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-lisboa-fertagus-gtfs-1034.zip?alt=media",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-lisboa-fertagus-gtfs-1034.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/pt-lisboa-fertagus-gtfs-1034.json
+++ b/catalogs/sources/gtfs/schedule/pt-lisboa-fertagus-gtfs-1034.json
@@ -14,8 +14,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/13/gtfs_13.zip",
+        "direct_download": "https://www.fertagus.pt/GTFSTMLzip/Fertagus_GTFS.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-lisboa-fertagus-gtfs-1034.zip?alt=media",
-        "license": "http://www.opendefinition.org/licenses/cc-zero"
     }
 }


### PR DESCRIPTION
Added new URL from [NAP Portugal](https://nap-portugal.imt-ip.pt/nap/multimodalsupplydetail/185) and removed license since Fertagus dis not specify one for this new source.