### PR TITLE
Update Metro Lisboa URL source [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/pt-lisboa-metro-de-lisboa-metro-gtfs-1036.json
+++ b/catalogs/sources/gtfs/schedule/pt-lisboa-metro-de-lisboa-metro-gtfs-1036.json
@@ -14,8 +14,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://www.transporlis.pt/Portals/0/OpenData/gtfs/zip/2/gtfs_2.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-lisboa-metro-de-lisboa-metro-gtfs-1036.zip?alt=media",
-        "license": "http://opendefinition.org/licenses/cc-zero/"
+        "direct_download": "https://www.metrolisboa.pt/google_transit/googleTransit.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-lisboa-metro-de-lisboa-metro-gtfs-1036.zip?alt=media"
     }
 }


### PR DESCRIPTION
Added new Metro Lisboa source URL as per [NAP Portugal](https://nap-portugal.imt-ip.pt/nap/multimodalsupplydetail/186).
Removed license since none is provided with the new source.

Also closes #674 