### PR TITLE
Https updates from Trillium feeds

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.json
@@ -19,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "https://oregon-gtfs.com/gtfs_data/albanytransit-or-us/albanytransit-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/albanytransit-or-us/albanytransit-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.json
+++ b/catalogs/sources/gtfs/schedule/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.json
@@ -19,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/albanytransit-or-us/albanytransit-or-us.zip",
+        "direct_download": "https://oregon-gtfs.com/gtfs_data/albanytransit-or-us/albanytransit-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-york-linx-transit-linnbenton-loop-albany-transit-system-gtfs-135.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-basin-transit-service-bts-gtfs-125.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-basin-transit-service-bts-gtfs-125.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/basin-or-us/basin-or-us.zip",
+        "direct_download": "https://oregon-gtfs.com/gtfs_data/basin-or-us/basin-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-basin-transit-service-bts-gtfs-125.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-basin-transit-service-bts-gtfs-125.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-basin-transit-service-bts-gtfs-125.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "https://oregon-gtfs.com/gtfs_data/basin-or-us/basin-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/basin-or-us/basin-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-basin-transit-service-bts-gtfs-125.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-benton-area-transportation-gtfs-126.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-benton-area-transportation-gtfs-126.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/benton-or-us/benton-or-us.zip",
+        "direct_download": "https://oregon-gtfs.com/gtfs_data/benton-or-us/benton-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-benton-area-transportation-gtfs-126.zip?alt=media",
         "license": "https://oregon-gtfs.trilliumtransit.com"

--- a/catalogs/sources/gtfs/schedule/us-oregon-benton-area-transportation-gtfs-126.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-benton-area-transportation-gtfs-126.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "https://oregon-gtfs.com/gtfs_data/benton-or-us/benton-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/benton-or-us/benton-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-benton-area-transportation-gtfs-126.zip?alt=media",
         "license": "https://oregon-gtfs.trilliumtransit.com"

--- a/catalogs/sources/gtfs/schedule/us-oregon-buena-vista-ferry-gtfs-834.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-buena-vista-ferry-gtfs-834.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/buenavistaferry-or-us/buenavistaferry-or-us.zip",
+        "direct_download": "https://oregon-gtfs.com/gtfs_data/buenavistaferry-or-us/buenavistaferry-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-buena-vista-ferry-gtfs-834.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-buena-vista-ferry-gtfs-834.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-buena-vista-ferry-gtfs-834.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "https://oregon-gtfs.com/gtfs_data/buenavistaferry-or-us/buenavistaferry-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/buenavistaferry-or-us/buenavistaferry-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-buena-vista-ferry-gtfs-834.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-canby-area-transit-cat-gtfs-252.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-canby-area-transit-cat-gtfs-252.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/canbytransit-or-us/canbytransit-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/canbytransit-or-us/canbytransit-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-canby-area-transit-cat-gtfs-252.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-canby-ferry-gtfs-605.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-canby-ferry-gtfs-605.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/canbyferry-or-us/canbyferry-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/canbyferry-or-us/canbyferry-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-canby-ferry-gtfs-605.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-caravan-airport-transportation-gtfs-127.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-caravan-airport-transportation-gtfs-127.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/caravan-or-us/caravan-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/caravan-or-us/caravan-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-caravan-airport-transportation-gtfs-127.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-cascade-point-gtfs-639.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-cascade-point-gtfs-639.json
@@ -6,7 +6,6 @@
     "features": [
         "fares-v1"
     ],
-    "status": "inactive",
     "location": {
         "country_code": "US",
         "subdivision_name": "Oregon",
@@ -20,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/cascadespoint-or-us/cascadespoint-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/cascadespoint-or-us/cascadespoint-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-cascade-point-gtfs-639.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-central-oregon-breeze-gtfs-139.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-central-oregon-breeze-gtfs-139.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/cobreeze-or-us/cobreeze-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/cobreeze-or-us/cobreeze-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-central-oregon-breeze-gtfs-139.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-city-2-city-shuttle-gtfs-129.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-city-2-city-shuttle-gtfs-129.json
@@ -6,7 +6,6 @@
     "features": [
         "fares-v1"
     ],
-    "status": "inactive",
     "location": {
         "country_code": "US",
         "subdivision_name": "Oregon",
@@ -20,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/citytocityshuttle-or-us/citytocityshuttle-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/citytocityshuttle-or-us/citytocityshuttle-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-city-2-city-shuttle-gtfs-129.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-clackamas-community-college-ccc-xpress-gtfs-257.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-clackamas-community-college-ccc-xpress-gtfs-257.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/cccxpress-or-us/cccxpress-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/cccxpress-or-us/cccxpress-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-clackamas-community-college-ccc-xpress-gtfs-257.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-columbia-area-transit-cat-gtfs-260.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-columbia-area-transit-cat-gtfs-260.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/hoodriver-or-us/hoodriver-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/hoodriver-or-us/hoodriver-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-columbia-area-transit-cat-gtfs-260.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-coos-county-area-transit-ccat-gtfs-21.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-coos-county-area-transit-ccat-gtfs-21.json
@@ -19,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/cooscounty-or-us/cooscounty-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/cooscounty-or-us/cooscounty-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-coos-county-area-transit-ccat-gtfs-21.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-diamond-express-gtfs-130.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-diamond-express-gtfs-130.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/diamondexpress-or-us/diamondexpress-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/diamondexpress-or-us/diamondexpress-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-diamond-express-gtfs-130.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-eastern-point-gtfs-632.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-eastern-point-gtfs-632.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/easternpoint-or-us/easternpoint-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/easternpoint-or-us/easternpoint-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-eastern-point-gtfs-632.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-bend-gtfs-140.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-bend-gtfs-140.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/eugenetobend-or-us/eugenetobend-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/eugenetobend-or-us/eugenetobend-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-eugene-to-bend-gtfs-140.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-coos-bay-gtfs-634.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-eugene-to-coos-bay-gtfs-634.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/eugenetocoosbay-or-us/eugenetocoosbay-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/eugenetocoosbay-or-us/eugenetocoosbay-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-eugene-to-coos-bay-gtfs-634.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-harney-county-gtfs-931.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-harney-county-gtfs-931.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/harneycounty-or-us/harneycounty-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/harneycounty-or-us/harneycounty-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-harney-county-gtfs-931.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-josephine-county-transit-jct-gtfs-121.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-josephine-county-transit-jct-gtfs-121.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/josephinecounty-or-us/josephinecounty-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/josephinecounty-or-us/josephinecounty-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-josephine-county-transit-jct-gtfs-121.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-kayak-transit-ctuir-gtfs-272.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-kayak-transit-ctuir-gtfs-272.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/ctuir-or-us/ctuir-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/ctuir-or-us/ctuir-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-kayak-transit-ctuir-gtfs-272.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-klamath-shuttle-crater-lake-trolley-gtfs-124.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-klamath-shuttle-crater-lake-trolley-gtfs-124.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/craterlaketrolley-or-us/craterlaketrolley-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/craterlaketrolley-or-us/craterlaketrolley-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-klamath-shuttle-crater-lake-trolley-gtfs-124.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-leter-bus-gtfs-590.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-leter-bus-gtfs-590.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/pendleton-or-us/pendleton-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/pendleton-or-us/pendleton-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-leter-bus-gtfs-590.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-lincoln-county-transit-lct-gtfs-23.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-lincoln-county-transit-lct-gtfs-23.json
@@ -19,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/lincolncounty-or-us/lincolncounty-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/lincolncounty-or-us/lincolncounty-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-lincoln-county-transit-lct-gtfs-23.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-link-lane-gtfs-932.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-link-lane-gtfs-932.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/lcog-or-us/lcog-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/lcog-or-us/lcog-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-link-lane-gtfs-932.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-linn-shuttle-gtfs-137.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-linn-shuttle-gtfs-137.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/linnshuttle-or-us/linnshuttle-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/linnshuttle-or-us/linnshuttle-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-linn-shuttle-gtfs-137.zip?alt=media",
         "license": "https://oregon-gtfs.trilliumtransit.com"
     }

--- a/catalogs/sources/gtfs/schedule/us-oregon-malheur-council-on-aging-community-services-gtfs-141.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-malheur-council-on-aging-community-services-gtfs-141.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/mcacs-or-us/mcacs-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/mcacs-or-us/mcacs-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-malheur-council-on-aging-community-services-gtfs-141.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-mt-bachelor-gtfs-933.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-mt-bachelor-gtfs-933.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/mtbachelor-or-us/mtbachelor-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/mtbachelor-or-us/mtbachelor-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-mt-bachelor-gtfs-933.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-northwest-point-gtfs-638.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-northwest-point-gtfs-638.json
@@ -19,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/northwestpoint-or-us/northwestpoint-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/northwestpoint-or-us/northwestpoint-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-northwest-point-gtfs-638.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-oregon-express-shuttle-gtfs-132.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-oregon-express-shuttle-gtfs-132.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/oregonexpressshuttle-or-us/oregonexpressshuttle-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/oregonexpressshuttle-or-us/oregonexpressshuttle-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-oregon-express-shuttle-gtfs-132.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-pacific-crest-bus-lines-gtfs-133.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-pacific-crest-bus-lines-gtfs-133.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/pacificcrest-or-us/pacificcrest-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/pacificcrest-or-us/pacificcrest-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-pacific-crest-bus-lines-gtfs-133.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-people-mover-gtfs-112.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-people-mover-gtfs-112.json
@@ -14,7 +14,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/peoplemover-or-us/peoplemover-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/peoplemover-or-us/peoplemover-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-people-mover-gtfs-112.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-rhody-express-gtfs-24.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-rhody-express-gtfs-24.json
@@ -18,7 +18,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/rhodyexpress-or-us/rhodyexpress-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/rhodyexpress-or-us/rhodyexpress-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-rhody-express-gtfs-24.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-ride-connection-gtfs-253.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-ride-connection-gtfs-253.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/rideconnection-or-us/rideconnection-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/rideconnection-or-us/rideconnection-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-ride-connection-gtfs-253.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-sandy-area-metro-sam-gtfs-261.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-sandy-area-metro-sam-gtfs-261.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/sandy-or-us/sandy-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/sandy-or-us/sandy-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-sandy-area-metro-sam-gtfs-261.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-south-clackamas-transportation-district-gtfs-883.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-south-clackamas-transportation-district-gtfs-883.json
@@ -18,7 +18,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/sctd-or-us/sctd-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/sctd-or-us/sctd-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-south-clackamas-transportation-district-gtfs-883.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-south-lane-wheels-gtfs-134.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-south-lane-wheels-gtfs-134.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/southlanewheels-or-us/southlanewheels-or-us.zip",
+        "direct_download": "https://oregon-gtfs-trilliumtransit.com/gtfs_data/southlanewheels-or-us/southlanewheels-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-south-lane-wheels-gtfs-134.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-southwest-point-gtfs-637.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-southwest-point-gtfs-637.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/southwestpoint-or-us/southwestpoint-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/southwestpoint-or-us/southwestpoint-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-southwest-point-gtfs-637.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-sunset-empire-transportation-district-setd-tillamook-county-transportation-district-columbia-county-rider-gtfs-246.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-sunset-empire-transportation-district-setd-tillamook-county-transportation-district-columbia-county-rider-gtfs-246.json
@@ -19,7 +19,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/tillamook-or-us/tillamook-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/tillamookcounty-or-us/tillamookcounty-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-sunset-empire-transportation-district-setd-tillamook-county-transportation-district-columbia-county-rider-gtfs-246.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-swan-island-evening-shuttle-gtfs-255.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-swan-island-evening-shuttle-gtfs-255.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/swanisland-or-us/swanisland-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/swanisland-or-us/swanisland-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-swan-island-evening-shuttle-gtfs-255.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-valley-retriever-busline-gtfs-633.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-valley-retriever-busline-gtfs-633.json
@@ -17,7 +17,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/valleyretriever-or-us/valleyretriever-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/valleyretriever-or-us/valleyretriever-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-valley-retriever-busline-gtfs-633.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-wallowa-community-connection-wcc-gtfs-289.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-wallowa-community-connection-wcc-gtfs-289.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/northeast-or-us/northeast-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/northeast-or-us/northeast-or-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-wallowa-community-connection-wcc-gtfs-289.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-washington-park-shuttle-gtfs-254.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-washington-park-shuttle-gtfs-254.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/washingtonparkshuttle-or-us/washingtonparkshuttle-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/washingtonparkshuttle-or-us/washingtonparkshuttle-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-washington-park-shuttle-gtfs-254.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-water-avenue-shuttle-gtfs-831.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-water-avenue-shuttle-gtfs-831.json
@@ -17,7 +17,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/ceic-or-us/ceic-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/ceic-or-us/ceic-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-water-avenue-shuttle-gtfs-831.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-wheatland-ferry-gtfs-833.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-wheatland-ferry-gtfs-833.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/wheatlandferry-or-us/wheatlandferry-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/wheatlandferry-or-us/wheatlandferry-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-wheatland-ferry-gtfs-833.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-oregon-woodburn-transit-service-wts-gtfs-251.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-woodburn-transit-service-wts-gtfs-251.json
@@ -20,7 +20,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://oregon-gtfs.com/gtfs_data/woodburn-or-us/woodburn-or-us.zip",
+        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/woodburn-or-us/woodburn-or-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-woodburn-transit-service-wts-gtfs-251.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-washington-skamania-county-transit-gtfs-262.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-skamania-county-transit-gtfs-262.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/skamaniacounty-wa-us/skamaniacounty-wa-us.zip",
+        "direct_download": "https://data.trilliumtransit.com/gtfs/skamaniacounty-wa-us/skamaniacounty-wa-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-skamania-county-transit-gtfs-262.zip?alt=media"
     },

--- a/catalogs/sources/gtfs/schedule/us-washington-wahkiakum-ferry-gtfs-2193.json
+++ b/catalogs/sources/gtfs/schedule/us-washington-wahkiakum-ferry-gtfs-2193.json
@@ -16,7 +16,7 @@
         }
     },
     "urls": {
-        "direct_download": "https://oregon-gtfs.trilliumtransit.com/gtfs_data/wahkiakumferry-wa-us/wahkiakumferry-wa-us.zip",
+        "direct_download": "https://data.trilliumtransit.com/gtfs/wahkiakumferry-wa-us/wahkiakumferry-wa-us.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-washington-wahkiakum-ferry-gtfs-2193.zip?alt=media"
     },


### PR DESCRIPTION
Trillium informed us that they've made the switch to HTTPS for Oregon feeds. Updated URLs directly here given there's official confirmation from the data producer these are the same feeds.