### PR TITLE
feat: Added is_official to the generated sources.csv

### DIFF
--- a/scripts/export_to_csv.py
+++ b/scripts/export_to_csv.py
@@ -13,6 +13,7 @@ CSV_COLUMNS = [
     'location.subdivision_name',
     'location.municipality',
     'provider',
+    'is_official',
     'name',
     'note',
     'feed_contact_email',
@@ -31,7 +32,7 @@ CSV_COLUMNS = [
     'status',
     'features',
     'redirect.id',
-    'redirect.comment'
+    'redirect.comment',
 ]
 
 # tools.constants


### PR DESCRIPTION
Closes #765 

An `is_official` flag was added in https://github.com/MobilityData/mobility-database-catalogs/pull/649
This PR puts this flag in the sources.csv in a an `is_official` column.

Note: I placed the column right after the `provider` column instead of at the end. 
I thought these columns go together, but it may be that some people using the csv file rely on the position of the columns (i.e. not placing `is_official` at the end is not backwards compatible).

![image](https://github.com/user-attachments/assets/d192ca01-dafa-429c-acdf-99a1b05cdd46)
