### PR TITLE
Update GTFS sources for Via Mobility [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/realtime/us-colorado-via-mobility-gtfs-rt-sa-1731.json
+++ b/catalogs/sources/gtfs/realtime/us-colorado-via-mobility-gtfs-rt-sa-1731.json
@@ -9,10 +9,7 @@
         "180"
     ],
     "urls": {
-        "direct_download": "https://api.goswift.ly/real-time/via/gtfs-rt-alerts",
-        "authentication_type": 2,
-        "authentication_info": "https://goswift.ly/realtime-api-key",
-        "api_key_parameter_name": "authorization",
-        "license": "https://www.goswift.ly/api-license"
+        "direct_download": "https://passio3.com/viaboulder/passioTransit/gtfs/realtime/serviceAlerts",
+        "authentication_type": 0
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-colorado-via-mobility-gtfs-rt-tu-1730.json
+++ b/catalogs/sources/gtfs/realtime/us-colorado-via-mobility-gtfs-rt-tu-1730.json
@@ -9,10 +9,7 @@
         "180"
     ],
     "urls": {
-        "direct_download": "https://api.goswift.ly/real-time/via/gtfs-rt-trip-updates",
-        "authentication_type": 2,
-        "authentication_info": "https://goswift.ly/realtime-api-key",
-        "api_key_parameter_name": "authorization",
-        "license": "https://www.goswift.ly/api-license"
+        "direct_download": "https://passio3.com/viaboulder/passioTransit/gtfs/realtime/tripUpdates",
+        "authentication_type": 0
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-colorado-via-mobility-gtfs-rt-vp-1732.json
+++ b/catalogs/sources/gtfs/realtime/us-colorado-via-mobility-gtfs-rt-vp-1732.json
@@ -9,10 +9,7 @@
         "180"
     ],
     "urls": {
-        "direct_download": "https://api.goswift.ly/real-time/via/gtfs-rt-vehicle-positions",
-        "authentication_type": 2,
-        "authentication_info": "https://goswift.ly/realtime-api-key",
-        "api_key_parameter_name": "authorization",
-        "license": "https://www.goswift.ly/api-license"
+        "direct_download": "https://passio3.com/viaboulder/passioTransit/gtfs/realtime/vehiclePositions",
+        "authentication_type": 0
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-colorado-via-mobility-gtfs-180.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-via-mobility-gtfs-180.json
@@ -2,7 +2,6 @@
     "mdb_source_id": 180,
     "data_type": "gtfs",
     "provider": "Via Mobility",
-    "feed_contact_email": "support+test+viamobilityservices-co-us@trilliumtransit.com",
     "location": {
         "country_code": "US",
         "subdivision_name": "Colorado",
@@ -16,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/viamobilityservices-co-us/viamobilityservices-co-us.zip",
+        "direct_download": "https://passio3.com/viaboulder/passioTransit/gtfs/google_transit.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-via-mobility-gtfs-180.zip?alt=media"
     },


### PR DESCRIPTION
Via Mobility moved to Passio, and the previous sources were outdated. Update URLs.