### PR TITLE
Update es-barcelona-autos-castellbisbal-gtfs-892.json

### DIFF
--- a/catalogs/sources/gtfs/schedule/es-barcelona-autos-castellbisbal-gtfs-892.json
+++ b/catalogs/sources/gtfs/schedule/es-barcelona-autos-castellbisbal-gtfs-892.json
@@ -2,7 +2,7 @@
     "mdb_source_id": 892,
     "data_type": "gtfs",
     "provider": "Autos Castellbisbal, Mohn, Oliveras, Rosanbus, Soler i Sauret, Tusgsal, Barcelona City Tour, Monbus, Avanza",
-    "name": "AMB Bus",
+    "name": "AMB Mobilitat Bus",
     "location": {
         "country_code": "ES",
         "subdivision_name": "Barcelona",


### PR DESCRIPTION
Updating to full name of AMB Mobilitat for search. This is a case where the actual data provider doesn't appear in the agency.txt file. 

cc @davidgamez as an example of why just extracting the agency list directly gets messy for search purposes and why we need a transit provider display name 