### PR TITLE
ZTP Kraków RT feed update

### DIFF
--- a/catalogs/sources/gtfs/realtime/unknown-unknown-zarzad-transportu-publicznego-w-krakowie-ztp-krakow-gtfs-rt-sa-2338.json
+++ b/catalogs/sources/gtfs/realtime/unknown-unknown-zarzad-transportu-publicznego-w-krakowie-ztp-krakow-gtfs-rt-sa-2338.json
@@ -9,7 +9,7 @@
         "1270"
     ],
     "urls": {
-        "direct_download": "https://gtfs.ztp.krakow.pl/ServiceAlerts_T.pb",
+        "direct_download": "https://gtfs.ztp.krakow.pl/ServiceAlerts.pb",
         "authentication_type": 0
     }
 }

--- a/catalogs/sources/gtfs/realtime/unknown-unknown-zarzad-transportu-publicznego-w-krakowie-ztp-krakow-gtfs-rt-tu-2339.json
+++ b/catalogs/sources/gtfs/realtime/unknown-unknown-zarzad-transportu-publicznego-w-krakowie-ztp-krakow-gtfs-rt-tu-2339.json
@@ -9,7 +9,7 @@
         "1270"
     ],
     "urls": {
-        "direct_download": "https://gtfs.ztp.krakow.pl/TripUpdates_T.pb",
+        "direct_download": "https://gtfs.ztp.krakow.pl/TripUpdates.pb",
         "authentication_type": 0
     }
 }

--- a/catalogs/sources/gtfs/realtime/unknown-unknown-zarzad-transportu-publicznego-w-krakowie-ztp-krakow-gtfs-rt-vp-2340.json
+++ b/catalogs/sources/gtfs/realtime/unknown-unknown-zarzad-transportu-publicznego-w-krakowie-ztp-krakow-gtfs-rt-vp-2340.json
@@ -9,7 +9,7 @@
         "1270"
     ],
     "urls": {
-        "direct_download": "https://gtfs.ztp.krakow.pl/VehiclePositions_T.pb",
+        "direct_download": "https://gtfs.ztp.krakow.pl/VehiclePositions.pb",
         "authentication_type": 0
     }
 }


### PR DESCRIPTION
it seems like ZTP uses also a unified file for all the transport means, so I've updated the links