### PR TITLE
License change for ZDiTM Szczecin (Poland)

### DIFF
--- a/catalogs/sources/gtfs/realtime/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-rt-sa-1967.json
+++ b/catalogs/sources/gtfs/realtime/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-rt-sa-1967.json
@@ -11,6 +11,6 @@
     "urls": {
         "direct_download": "https://www.zditm.szczecin.pl/storage/gtfs/gtfs-rt-alerts.pb",
         "authentication_type": 0,
-        "license": "https://www.zditm.szczecin.pl/pl/zditm/dla-programistow/gtfs"
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/"
     }
 }

--- a/catalogs/sources/gtfs/realtime/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-rt-tu-1966.json
+++ b/catalogs/sources/gtfs/realtime/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-rt-tu-1966.json
@@ -11,6 +11,6 @@
     "urls": {
         "direct_download": "https://www.zditm.szczecin.pl/storage/gtfs/gtfs-rt-trips.pb",
         "authentication_type": 0,
-        "license": "https://www.zditm.szczecin.pl/pl/zditm/dla-programistow/gtfs"
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/"
     }
 }

--- a/catalogs/sources/gtfs/realtime/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-rt-vp-1968.json
+++ b/catalogs/sources/gtfs/realtime/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-rt-vp-1968.json
@@ -11,6 +11,6 @@
     "urls": {
         "direct_download": "https://www.zditm.szczecin.pl/storage/gtfs/gtfs-rt-vehicles.pb",
         "authentication_type": 0,
-        "license": "https://www.zditm.szczecin.pl/pl/zditm/dla-programistow/gtfs"
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/"
     }
 }

--- a/catalogs/sources/gtfs/schedule/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-981.json
+++ b/catalogs/sources/gtfs/schedule/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-981.json
@@ -19,7 +19,7 @@
         "direct_download": "https://www.zditm.szczecin.pl/storage/gtfs/gtfs.zip",
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-zachodniopomorskie-zarzad-drog-i-transportu-miejskiego-zditm-gtfs-981.zip?alt=media",
-        "license": "https://www.zditm.szczecin.pl/pl/zditm/dla-programistow/gtfs"
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/"
     },
     "redirect": []
 }


### PR DESCRIPTION
GTFS data for ZDiTM Szczecin (Poland) are now [published under the CC0 license](https://www.zditm.szczecin.pl/en/zditm/for-developers/gtfs).