### PR TITLE
Feed updates

### DIFF
--- a/catalogs/sources/gtfs/schedule/se-trafiklab-gtfs-sverige-2-gtfs-2661.json
+++ b/catalogs/sources/gtfs/schedule/se-trafiklab-gtfs-sverige-2-gtfs-2661.json
@@ -1,0 +1,24 @@
+{
+    "mdb_source_id": 2661,
+    "data_type": "gtfs",
+    "provider": "TrafikLab",
+    "name": "GTFS Sverige 2",
+    "location": {
+        "country_code": "SE",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2022-04-04T18:47:32+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://api.resrobot.se/gtfs/sweden.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-trafiklab-gtfs-sverige-2-gtfs-2661.zip?alt=media",
+        "authentication_type": 1,
+        "authentication_info": "https://www.trafiklab.se/api",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-sverige-2/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/se-unknown-samtrafiken-gtfs-1321.json
+++ b/catalogs/sources/gtfs/schedule/se-unknown-samtrafiken-gtfs-1321.json
@@ -3,6 +3,7 @@
     "data_type": "gtfs",
     "provider": "Samtrafiken, SJ, NSB, NSB/SJ, Visingsöleden, UL, Sörmlandstrafiken, ÖstgötaTrafiken, JLT, Länstrafiken Kronoberg, KLT, Region Gotland, Blekingetrafiken, Gällivare Stadstrafik, Hallandstrafiken, Värmlandstrafik, VL, Dalatrafik, X-trafik, Din Tur, Destination Gotland, Länstrafiken Jämtland, Länstrafiken Västerbotten, Länstrafiken Norrbotten, SL, Skånetrafiken, Flygbussarna, Västtrafik, Ventrafiken, Arlanda Express, Länstrafiken Örebro, Öresundståg, BT Buss, Mälartåg, Vy Tåg, Värmlandstrafik, Waxholmsbolaget, FlixTrain, Bus4You, Nettbuss Express, Skelleftebuss, Y-buss, MasExpressen, Silverlinjen, Härjedalingen, Merresor Express, ForSea, Snälltåget, Nikkaluoktaexpressen, Trafikverket Färjerederiet, Bergkvarabuss, Vy Nattåg, Vy Norrtåg, Krösatågen, Tågab, Karlstadsbuss, Luleå Lokaltrafik, Trosabussen, Ressels Rederi, Haparanda lokaltrafik, Roslagens Sjötrafik, Piteå Lokaltrafik, Strömma, Boden Stadstrafik, Snötåget, Kiruna Stadstrafik, Stadsbussarna Östersund, Krösatågen, SJ NORGE, Skärgårdsbåtarna i Uddevalla, MTRX, Stavsnäs Båttaxi, Söne Buss, Kalix stadstrafik, Flixbus, Stockholms stad",
     "name": "TrafikLab",
+    "status": "deprecated",
     "location": {
         "country_code": "SE",
         "bounding_box": {
@@ -17,5 +18,11 @@
         "direct_download": "https://transitfeeds.com/p/trafiklab/50/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-unknown-samtrafiken-gtfs-1321.zip?alt=media",
         "license": "http://www.trafiklab.se/api"
-    }
+    },
+    "redirect": [
+        {
+            "id": "2661",
+            "comment": " "
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/schedule/us-california-city-of-glendale-gtfs-1245.json
+++ b/catalogs/sources/gtfs/schedule/us-california-city-of-glendale-gtfs-1245.json
@@ -2,6 +2,7 @@
     "mdb_source_id": 1245,
     "data_type": "gtfs",
     "provider": "City of Glendale",
+    "status": "deprecated",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",
@@ -17,5 +18,11 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/city-of-glendale/628/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-city-of-glendale-gtfs-1245.zip?alt=media"
-    }
+    },
+    "redirect": [
+        {
+            "id": "tld-471",
+            "comment": " "
+        }
+    ]
 }


### PR DESCRIPTION
Updating Glendale and the overall aggregate feed for Sweden as a test before adding all Trafiklab data: https://www.trafiklab.se/