### PR TITLE
Add Minho Access Point static feeds

### DIFF
--- a/catalogs/sources/gtfs/schedule/pt-ave-guimabus-guimaraes-gtfs-2838.json
+++ b/catalogs/sources/gtfs/schedule/pt-ave-guimabus-guimaraes-gtfs-2838.json
@@ -1,0 +1,24 @@
+{
+    "mdb_source_id": 2838,
+    "data_type": "gtfs",
+    "provider": "Guimabus - Transportes de Guimarães",
+    "location": {
+        "country_code": "PT",
+        "subdivision_name": "Ave",
+        "municipality": "Guimarães",
+        "bounding_box": {
+            "minimum_latitude": 41.365302,
+            "maximum_latitude": 41.539364,
+            "minimum_longitude": -8.427469,
+            "maximum_longitude": -8.228296,
+            "extracted_on": "2025-09-03T16:19:30+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://map.mobility.ubiwhere.com/dataset/ee6d46e4-9f19-4f4a-ab93-1a3cd69df349/resource/08f1ee6c-2d3f-4fb3-a861-5d6fb347a6d4/download/gtfs_gui.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-ave-guimabus---transportes-de-guimaraes-gtfs-2838.zip?alt=media",
+        "license": "https://map.mobility.ubiwhere.com/dataset/operador-de-sptp-de-guimaraes"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pt-ave-mobiave-gtfs-2840.json
+++ b/catalogs/sources/gtfs/schedule/pt-ave-mobiave-gtfs-2840.json
@@ -1,0 +1,24 @@
+{
+    "mdb_source_id": 2840,
+    "data_type": "gtfs",
+    "provider": "Mobiave",
+    "location": {
+        "country_code": "PT",
+        "subdivision_name": "Ave,Área Metropolitana do Porto",
+        "municipality": "Famalicão,Santo Tirso,Trofa",
+        "bounding_box": {
+            "minimum_latitude": 41.300434,
+            "maximum_latitude": 41.477368,
+            "minimum_longitude": -8.623817,
+            "maximum_longitude": -8.324232,
+            "extracted_on": "2025-09-03T16:19:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://map.mobility.ubiwhere.com/dataset/fe6015e4-86c7-437a-8d31-10759fe21a1d/resource/7ac67ef8-015c-42e8-9546-f6f0be956270/download/gtfs_vnf.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-ave-mobiave-gtfs-2840.zip?alt=media",
+        "license": "https://map.mobility.ubiwhere.com/dataset/veiculo-de-transporte-de-passageiros-de-vila-nova-de-famalicao"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/pt-cavado-tuba-barcelos-gtfs-2839.json
+++ b/catalogs/sources/gtfs/schedule/pt-cavado-tuba-barcelos-gtfs-2839.json
@@ -1,0 +1,24 @@
+{
+    "mdb_source_id": 2839,
+    "data_type": "gtfs",
+    "provider": "TUBA - Transportes Urbanos de Barcelos",
+    "location": {
+        "country_code": "PT",
+        "subdivision_name": "Cávado",
+        "municipality": "Barcelos",
+        "bounding_box": {
+            "minimum_latitude": 41.4152617727,
+            "maximum_latitude": 41.6537567059,
+            "minimum_longitude": -8.756146,
+            "maximum_longitude": -8.507689,
+            "extracted_on": "2025-09-03T16:19:33+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://map.mobility.ubiwhere.com/dataset/1842a15c-1aec-4f65-8e29-e57c8b4cbd74/resource/a595ee4b-bf86-4323-b1f4-7e3b3eb00e5e/download/gtfs_bar.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pt-cavado-tuba---transportes-urbanos-de-barcelos-gtfs-2839.zip?alt=media",
+        "license": "https://map.mobility.ubiwhere.com/dataset/paragem-de-passageiros-de-barcelos"
+    },
+    "redirect": []
+}


### PR DESCRIPTION
This PR adds three feeds distributed via the [Minho Access Point](https://map.mobility.ubiwhere.com/).

- Guimabus, which is the urban bus service in Guimarães
- TUBA, which is the urban bus service in Barcelos
- Mobiave, which is the bus service that operates in Famalicão, Santo Tirso and Trofa

Thanks :)