### PR TITLE
Add official Sofia (Bulgaria) static and realtime feeds

### DIFF
--- a/catalogs/sources/gtfs/realtime/bg-sofia-city-gtfs-rt-sa-2845.json
+++ b/catalogs/sources/gtfs/realtime/bg-sofia-city-gtfs-rt-sa-2845.json
@@ -1,0 +1,16 @@
+{
+    "mdb_source_id": 2845,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Urban Mobility Center - Sofia Traffic",
+    "static_reference": [
+        "2451"
+    ],
+    "urls": {
+        "direct_download": "https://gtfs.sofiatraffic.bg/api/v1/alerts",
+        "authentication_type": 0,
+        "license": "https://www.sofiatraffic.bg/bg/info-center/gtfs-danni"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/bg-sofia-city-gtfs-rt-tu-2846.json
+++ b/catalogs/sources/gtfs/realtime/bg-sofia-city-gtfs-rt-tu-2846.json
@@ -1,0 +1,16 @@
+{
+    "mdb_source_id": 2846,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Urban Mobility Center - Sofia Traffic",
+    "static_reference": [
+        "2451"
+    ],
+    "urls": {
+        "direct_download": "https://gtfs.sofiatraffic.bg/api/v1/trip-updates",
+        "authentication_type": 0,
+        "license": "https://www.sofiatraffic.bg/bg/info-center/gtfs-danni"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/bg-sofia-city-gtfs-rt-vp-2847.json
+++ b/catalogs/sources/gtfs/realtime/bg-sofia-city-gtfs-rt-vp-2847.json
@@ -1,0 +1,16 @@
+{
+    "mdb_source_id": 2847,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Urban Mobility Center - Sofia Traffic",
+    "static_reference": [
+        "2451"
+    ],
+    "urls": {
+        "direct_download": "https://gtfs.sofiatraffic.bg/api/v1/vehicle-positions",
+        "authentication_type": 0,
+        "license": "https://www.sofiatraffic.bg/bg/info-center/gtfs-danni"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/bg-sofia-city-gtfs-2451.json
+++ b/catalogs/sources/gtfs/schedule/bg-sofia-city-gtfs-2451.json
@@ -3,7 +3,7 @@
     "data_type": "gtfs",
     "provider": "Urban Mobility Center - Sofia Traffic",
     "status": "active",
-    "is_official": "False", 
+    "is_official": "True", 
     "location": {
         "country_code": "BG",
         "subdivision_name": "Sofia City",
@@ -17,9 +17,9 @@
         }
     },
     "urls": {
-        "direct_download": "https://raw.githubusercontent.com/Dimitar5555/sofiatraffic-gtfs/master/result.zip",
+        "direct_download": "https://gtfs.sofiatraffic.bg/api/v1/static",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/bg-sofia-city-gtfs-2451.zip?alt=media",
-        "license": "https://github.com/Dimitar5555/sofiatraffic-gtfs"
+        "license": "https://www.sofiatraffic.bg/bg/info-center/gtfs-danni"
     },
     "redirect": []
 }


### PR DESCRIPTION
This PR updates the static source for Sofia Traffic (Bulgaria) to the newly released official one and adds realtime feeds. 🚀 