### PR TITLE
Fix api endpoints for Transport for NSW realtime feeds

### DIFF
--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-sa-2704.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-sa-2704.json
@@ -4,7 +4,7 @@
     "entity_type": ["sa"],
     "provider": "Transport for New South Wales",
     "urls": {
-        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/alerts",
+        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/alerts/all",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
         "api_key_parameter_name": "apikey"

--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-tu-2702.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-tu-2702.json
@@ -4,7 +4,7 @@
     "entity_type": ["tu"],
     "provider": "Transport for New South Wales",
     "urls": {
-        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/",
+        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/sydneytrains",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
         "api_key_parameter_name": "apikey"

--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-vp-2703.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-vp-2703.json
@@ -4,7 +4,7 @@
     "entity_type": ["vp"],
     "provider": "Transport for New South Wales",
     "urls": {
-        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/vehiclepos/",
+        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/vehiclepos/sydneytrains",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
         "api_key_parameter_name": "apikey"


### PR DESCRIPTION
When I originally submitted these via the form, I missed the last component of the API endpoint.

Note that there are more options for these endpoints.
For example, you can replace `/sydneytrains` with `/metro` to get a different feed.

But I'm settling for just fixing the existing ones for now.