### PR TITLE
fix: failing pip installation in export to csv

### DIFF
--- a/.github/workflows/export_to_csv.yml
+++ b/.github/workflows/export_to_csv.yml
@@ -24,6 +24,9 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
+          # Avoid using the latest version (24.1) of pip since they removed support for the
+          # --global-option used during GDAL library installation.
+          # Reconsider later if the problem is corrected. 
           python -m pip install "pip<24.1"
           pip install pytest wheel numpy
           sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable


### PR DESCRIPTION
# Description
Related to #1097 

This PR patches pip to avoid using the latest version (24.1). The latest version of pip removed support for the --global-option used during GDAL library installation.

Working GH action => https://github.com/MobilityData/mobility-database-catalogs/actions/runs/18921585152/job/54018830911