### PR TITLE
[SOURCES] Add Boxcar commuter bus GTFS feed (NJ-NYC)

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3082.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3082.json
@@ -1,0 +1,20 @@
+{
+    "mdb_source_id": 3082,
+    "data_type": "gtfs",
+    "provider": "Boxcar",
+    "name": "Boxcar Commuter Bus",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "New Jersey",
+        "bounding_box": {
+            "minimum_latitude": 40.5700,
+            "maximum_latitude": 41.0200,
+            "minimum_longitude": -74.6500,
+            "maximum_longitude": -73.9600
+        }
+    },
+    "urls": {
+        "direct_download": "https://boxcar-gtfs.vercel.app/api/gtfs"
+    },
+    "feed_contact_url": "https://www.boxcar.com"
+}

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3105.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3105.json
@@ -15,6 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "https://boxcar-gtfs.vercel.app/api/gtfs"
+        "direct_download": "https://boxcar-gtfs.vercel.app/api/gtfs",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-new-jersey-boxcar-gtfs-3105.zip?alt=media"
     }
 }

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3105.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3105.json
@@ -1,5 +1,5 @@
 {
-    "mdb_source_id": 3082,
+    "mdb_source_id": 3105,
     "data_type": "gtfs",
     "provider": "Boxcar",
     "name": "Boxcar Commuter Bus",
@@ -15,6 +15,5 @@
     },
     "urls": {
         "direct_download": "https://boxcar-gtfs.vercel.app/api/gtfs"
-    },
-    "feed_contact_url": "https://www.boxcar.com"
+    }
 }

--- a/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3105.json
+++ b/catalogs/sources/gtfs/schedule/us-new-jersey-boxcar-gtfs-3105.json
@@ -10,7 +10,8 @@
             "minimum_latitude": 40.5700,
             "maximum_latitude": 41.0200,
             "minimum_longitude": -74.6500,
-            "maximum_longitude": -73.9600
+            "maximum_longitude": -73.9600,
+            "extracted_on": "2026-04-10T00:00:00+00:00"
         }
     },
     "urls": {


### PR DESCRIPTION
## New GTFS Schedule Feed: Boxcar

**Provider:** [Boxcar](https://www.boxcar.com)  
**Location:** New Jersey / New York City, USA  
**Feed URL:** https://boxcar-gtfs.vercel.app/api/gtfs

### About Boxcar
Boxcar operates private commuter bus routes between New Jersey suburbs and Midtown/Downtown Manhattan. 13 routes serving towns across Morris, Bergen, Essex, Middlesex, and Raritan counties.

### Feed Details
- **Type:** GTFS Static (schedule only)
- **Routes:** 13
- **Trips:** 91
- **Stops:** 117
- **Stop Times:** 1,051
- **Update frequency:** Daily (auto-generated from live API data)
- **Authentication:** None required (public URL)

### Validation
Feed has been generated and verified with correct structure (7 required GTFS files: agency.txt, stops.txt, routes.txt, trips.txt, stop_times.txt, calendar.txt, feed_info.txt).