### PR TITLE
Fix: NYC MTA feeds no longer require auth

### DIFF
--- a/catalogs/sources/gtfs/realtime/us-new-york-bus-gtfs-rt-sa-1628.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-bus-gtfs-rt-sa-1628.json
@@ -11,9 +11,7 @@
     ],
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fbus-alerts",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-long-island-rail-road-gtfs-rt-sa-1625.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-long-island-rail-road-gtfs-rt-sa-1625.json
@@ -11,9 +11,7 @@
     ],
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Flirr-alerts",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-long-island-rail-road-gtfs-rt-vp-tu-1624.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-long-island-rail-road-gtfs-rt-vp-tu-1624.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/lirr%2Fgtfs-lirr",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-metro-north-railroad-gtfs-rt-sa-1626.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-metro-north-railroad-gtfs-rt-sa-1626.json
@@ -11,9 +11,7 @@
     ],
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fmnr-alerts",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-metro-north-railroad-gtfs-rt-tu-1627.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-metro-north-railroad-gtfs-rt-tu-1627.json
@@ -11,9 +11,7 @@
     ],
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/mnr%2Fgtfs-mnr",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-1-gtfs-rt-vp-tu-1635.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-1-gtfs-rt-vp-tu-1635.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-ace-lines-gtfs-rt-vp-tu-1630.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-ace-lines-gtfs-rt-vp-tu-1630.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-bdfm-lines-gtfs-rt-vp-tu-1631.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-bdfm-lines-gtfs-rt-vp-tu-1631.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-g-line-gtfs-rt-vp-tu-1632.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-g-line-gtfs-rt-vp-tu-1632.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-g",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-gtfs-rt-sa-1629.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-gtfs-rt-sa-1629.json
@@ -11,9 +11,7 @@
     ],
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-jz-lines-gtfs-rt-vp-tu-1633.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-jz-lines-gtfs-rt-vp-tu-1633.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-jz",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-l-train-gtfs-rt-vp-tu-1636.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-l-train-gtfs-rt-vp-tu-1636.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-l",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-nqrw-lines-gtfs-rt-vp-tu-1634.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-nyc-subway-nqrw-lines-gtfs-rt-vp-tu-1634.json
@@ -13,9 +13,7 @@
     "note": "This source includes Vehicle Position and Trip Updates entities under the same feed.",
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-nqrw",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-new-york-staten-island-railway-gtfs-rt-vp-tu-1637.json
+++ b/catalogs/sources/gtfs/realtime/us-new-york-staten-island-railway-gtfs-rt-vp-tu-1637.json
@@ -12,9 +12,7 @@
     ],
     "urls": {
         "direct_download": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-si",
-        "authentication_type": 2,
-        "authentication_info": "https://api.mta.info/#/signup",
-        "api_key_parameter_name": "x-api-key",
+        "authentication_type": 0,
         "license": "https://api.mta.info/#/DataFeedAgreement"
     }
 }


### PR DESCRIPTION
Update New York City's MTA feeds to remove auth. The earliest record I can find of this change is 2024 but it could have happened earlier. 

**Source**: It's confirmed on their [API web page](https://api.mta.info/) and the signup link in `authentication_info` is dead: "Accounts and API keys are no longer required to access these feeds."