### PR TITLE
Update Sonoma-Marin Area Rail Transit GTFS URLs

### DIFF
--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-1577.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-1577.json
@@ -4,13 +4,17 @@
     "entity_type": [
         "tu"
     ],
-    "provider": "Sonoma-Marin Area Rail Transit (SMART)",
+    "provider": "Sonoma Marin Area Rail Transit (SMART)",
     "static_reference": ["815"],
     "urls": {
-        "direct_download": "https://api.511.org/transit/tripupdates?agency=SA",
-        "authentication_type": 1,
-        "authentication_info": "https://511.org/open-data/token",
-        "api_key_parameter_name": "api_key",
-        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
-    }
+        "direct_download": "http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.zip?alt=media"
+    },
+     "redirect": [
+        {
+            "id": "3223",
+            "comment": " "
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-1577.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-1577.json
@@ -4,13 +4,13 @@
     "entity_type": [
         "tu"
     ],
-    "provider": "Sonoma Marin Area Rail Transit (SMART)",
+    "provider": "Sonoma-Marin Area Rail Transit (SMART)",
     "static_reference": ["815"],
     "urls": {
-        "direct_download": "https://api.goswift.ly/real-time/smart/gtfs-rt-trip-updates",
-        "authentication_type": 2,
-        "authentication_info": "https://goswift.ly/realtime-api-key",
-        "api_key_parameter_name": "authorization",
-        "license": "https://www.goswift.ly/api-license"
+        "direct_download": "https://api.511.org/transit/tripupdates?agency=SA",
+        "authentication_type": 1,
+        "authentication_info": "https://511.org/open-data/token",
+        "api_key_parameter_name": "api_key",
+        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-1577.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-1577.json
@@ -1,15 +1,18 @@
 {
     "mdb_source_id": 1577,
     "data_type": "gtfs-rt",
+    "status": "deprecated",
     "entity_type": [
         "tu"
     ],
     "provider": "Sonoma Marin Area Rail Transit (SMART)",
     "static_reference": ["815"],
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip",
-        "authentication_type": 0,
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.zip?alt=media"
+        "direct_download": "https://api.goswift.ly/real-time/smart/gtfs-rt-trip-updates",
+        "authentication_type": 2,
+        "authentication_info": "https://goswift.ly/realtime-api-key",
+        "api_key_parameter_name": "authorization",
+        "license": "https://www.goswift.ly/api-license"
     },
      "redirect": [
         {

--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-3223.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-tu-3223.json
@@ -1,0 +1,16 @@
+{
+    "mdb_source_id": 3223,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Sonoma-Marin Area Rail Transit (SMART)",
+    "static_reference": ["3222"],
+    "urls": {
+        "direct_download": "https://api.511.org/transit/tripupdates?agency=SA",
+        "authentication_type": 1,
+        "authentication_info": "https://511.org/open-data/token",
+        "api_key_parameter_name": "api_key",
+        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-1576.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-1576.json
@@ -4,13 +4,13 @@
     "entity_type": [
         "vp"
     ],
-    "provider": "Sonoma Marin Area Rail Transit (SMART)",
+    "provider": "Sonoma-Marin Area Rail Transit (SMART)",
     "static_reference": ["815"],
     "urls": {
-        "direct_download": "https://api.goswift.ly/real-time/smart/gtfs-rt-vehicle-positions",
-        "authentication_type": 2,
-        "authentication_info": "https://goswift.ly/realtime-api-key",
-        "api_key_parameter_name": "authorization",
-        "license": "https://www.goswift.ly/api-license"
+        "direct_download": "https://api.511.org/transit/vehiclepositions?agency=SA",
+        "authentication_type": 1,
+        "authentication_info": "https://511.org/open-data/token",
+        "api_key_parameter_name": "api_key",
+        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
     }
 }

--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-1576.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-1576.json
@@ -1,6 +1,7 @@
 {
     "mdb_source_id": 1576,
     "data_type": "gtfs-rt",
+    "status": "deprecated",
     "entity_type": [
         "vp"
     ],

--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-1576.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-1576.json
@@ -4,13 +4,19 @@
     "entity_type": [
         "vp"
     ],
-    "provider": "Sonoma-Marin Area Rail Transit (SMART)",
+    "provider": "Sonoma Marin Area Rail Transit (SMART)",
     "static_reference": ["815"],
     "urls": {
-        "direct_download": "https://api.511.org/transit/vehiclepositions?agency=SA",
-        "authentication_type": 1,
-        "authentication_info": "https://511.org/open-data/token",
-        "api_key_parameter_name": "api_key",
-        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
-    }
+        "direct_download": "https://api.goswift.ly/real-time/smart/gtfs-rt-vehicle-positions",
+        "authentication_type": 2,
+        "authentication_info": "https://goswift.ly/realtime-api-key",
+        "api_key_parameter_name": "authorization",
+        "license": "https://www.goswift.ly/api-license"
+    },
+     "redirect": [
+        {
+            "id": "3224",
+            "comment": " "
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-3224.json
+++ b/catalogs/sources/gtfs/realtime/us-california-sonoma-marin-area-rail-transit-smart-gtfs-rt-vp-3224.json
@@ -1,0 +1,16 @@
+{
+    "mdb_source_id": 3224,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Sonoma-Marin Area Rail Transit (SMART)",
+    "static_reference": ["3222"],
+    "urls": {
+        "direct_download": "https://api.511.org/transit/vehiclepositions?agency=SA",
+        "authentication_type": 1,
+        "authentication_info": "https://511.org/open-data/token",
+        "api_key_parameter_name": "api_key",
+        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-3222.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-3222.json
@@ -1,0 +1,28 @@
+{
+    "mdb_source_id": 3222,
+    "data_type": "gtfs",
+    "provider": "Sonoma Marin Area Rail Transit (SMART)",
+    "is_official": "True",
+    "location": {
+        "country_code": "US",
+        "subdivision_name": "California",
+        "municipality": "Santa Rosa",
+        "bounding_box": {
+            "minimum_latitude": 37.94781,
+            "maximum_latitude": 38.5098222070014,
+            "minimum_longitude": -122.784085789652,
+            "maximum_longitude": -122.51248,
+            "extracted_on": "2022-03-17T15:22:11+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "http://api.511.org/transit/datafeeds?operator_id=SA",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-3222.zip?alt=media",
+        "authentication_type": 1,
+        "authentication_info": "https://511.org/open-data/token",
+        "api_key_parameter_name": "api_key",
+        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
+    },
+    "redirect": [],
+    "feed_contact_email": "gtfs@sonomamarintrain.org"
+}

--- a/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
@@ -16,13 +16,14 @@
         }
     },
     "urls": {
-        "direct_download": "http://api.511.org/transit/datafeeds?operator_id=SA",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.zip?alt=media",
-        "authentication_type": 1,
-        "authentication_info": "https://511.org/open-data/token",
-        "api_key_parameter_name": "api_key",
-        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
+        "direct_download": "http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.zip?alt=media"
     },
-    "redirect": [],
-    "feed_contact_email": "gtfs@sonomamarintrain.org"
+     "redirect": [
+        {
+            "id": "3222",
+            "comment": " "
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
@@ -16,9 +16,13 @@
         }
     },
     "urls": {
-        "direct_download": "http://data.trilliumtransit.com/gtfs/smart-ca-us/smart-ca-us.zip",
-        "authentication_type": 0,
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.zip?alt=media"
+        "direct_download": "http://api.511.org/transit/datafeeds?operator_id=SA",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.zip?alt=media",
+        "authentication_type": 1,
+        "authentication_info": "https://511.org/open-data/token",
+        "api_key_parameter_name": "api_key",
+        "license": "https://511.org/sites/default/files/pdfs/511_Data_Agreement_Final.pdf"
     },
-    "redirect": []
+    "redirect": [],
+    "feed_contact_email": "gtfs@sonomamarintrain.org"
 }

--- a/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
+++ b/catalogs/sources/gtfs/schedule/us-california-sonoma-marin-area-rail-transit-smart-gtfs-815.json
@@ -3,6 +3,7 @@
     "data_type": "gtfs",
     "provider": "Sonoma-Marin Area Rail Transit (SMART)",
     "is_official": "True",
+    "status": "deprecated",
     "location": {
         "country_code": "US",
         "subdivision_name": "California",


### PR DESCRIPTION
* Update static and GTFS-realtime URLs to use 511.org
* Standardize agency name as "Sonoma-Marin Area Rail Transit (SMART)"