### PR TITLE
fix: Update Estonia national GTFS feed URL [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ee-unknown-abuss-ou-gtfs-1095.json
+++ b/catalogs/sources/gtfs/schedule/ee-unknown-abuss-ou-gtfs-1095.json
@@ -10,16 +10,19 @@
     "location": {
         "country_code": "EE",
         "bounding_box": {
-            "minimum_latitude": 0.22061077,
-            "maximum_latitude": 69.89999971,
-            "minimum_longitude": 0.14836759,
-            "maximum_longitude": 60.55378507,
-            "extracted_on": "2022-03-17T23:54:38+00:00"
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2026-06-29T15:27:36.999479+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://www.peatus.ee/gtfs/gtfs.zip",
+        "direct_download": "https://eu-gtfs.remix.com/estonia_unified_gtfs.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-unknown-abuss-ou-gtfs-1095.zip?alt=media",
-        "license": "https://www.mnt.ee/eng/public-transportation/public-transport-information-system"
-    }
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed",
+        "authentication_type": 0
+    },
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active"
 }

--- a/catalogs/sources/gtfs/schedule/ee-unknown-abuss-ou-gtfs-3235.json
+++ b/catalogs/sources/gtfs/schedule/ee-unknown-abuss-ou-gtfs-3235.json
@@ -1,32 +1,28 @@
 {
-    "mdb_source_id": 1095,
+    "mdb_source_id": 3235,
     "data_type": "gtfs",
     "provider": "ABuss OÜ, Aktsiaselts Hansa Bussiliinid, Aktsiaselts MK Autobuss, Alukvik OÜ, Arilix OÜ, AS Lux Express Estonia, Asunduse osaühing, ATG Bussiliinid OÜ, Atko Bussiliinid AS, ATKO Liinid OÜ, ATKO Transport OÜ, Ekspress-Auto L Osaühing, Ekspressbussiliinid osaühing, Elmar Purga FIE, ELRON, Estonian Lines OÜ, GoBus AS, HANSABUSS AS, Kalle Bussid OÜ, MEELIS HEEK, MK Reis-X OÜ, NAJA OÜ, Osaühing Bristol Takso, OSAÜHING FREMANTI, osaühing Tulisilm, OV Ida-Bus OÜ, OÜ Baltic Shuttle, PRESTO osaühing, Radix Transport OÜ, Rannu Rukkilill E.S.T. OÜ, Saaremaa vald, SEBE Aktsiaselts, Sirel Reisid OÜ, Taisto Express OÜ, Tallinna Linnatranspordi AS, TS Laevad OÜ, Tõnu Tours OÜ, Valgis osaühing",
     "name": "Ühistranspordiregistri avaandmed",
     "is_official": "True",
-    "status": "deprecated",
     "features": [
         "fares-v1"
     ],
     "location": {
         "country_code": "EE",
         "bounding_box": {
-            "minimum_latitude": 0.22061077,
-            "maximum_latitude": 69.89999971,
-            "minimum_longitude": 0.14836759,
-            "maximum_longitude": 60.55378507,
-            "extracted_on": "2022-03-17T23:54:38+00:00"
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2026-06-29T15:27:36.999479+00:00"
         }
     },
     "urls": {
-        "direct_download": "http://www.peatus.ee/gtfs/gtfs.zip",
+        "direct_download": "https://eu-gtfs.remix.com/estonia_unified_gtfs.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-unknown-abuss-ou-gtfs-1095.zip?alt=media",
-        "license": "https://www.mnt.ee/eng/public-transportation/public-transport-information-system"
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed",
+        "authentication_type": 0
     },
-     "redirect": [
-        {
-            "id": "3235",
-            "comment": " "
-        }
-    ]
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active"
 }

--- a/catalogs/sources/gtfs/schedule/ee-unknown-abuss-ou-gtfs-3235.json
+++ b/catalogs/sources/gtfs/schedule/ee-unknown-abuss-ou-gtfs-3235.json
@@ -19,7 +19,7 @@
     },
     "urls": {
         "direct_download": "https://eu-gtfs.remix.com/estonia_unified_gtfs.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-unknown-abuss-ou-gtfs-1095.zip?alt=media",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-unknown-abuss-ou-gtfs-3235.zip?alt=media",
         "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed",
         "authentication_type": 0
     },


### PR DESCRIPTION
## fix: Update Estonia national GTFS feed URL (mdb-1095) to its new unified URL

### What
Updates the Estonian national GTFS source (`mdb-1095`, "Ühistranspordiregistri avaandmed") to the feed's current download location and refreshes stale metadata.

### Why
Estonia's public transport open data changed hosting in January 2026 and is now published by the Ministry of Regional Affairs and Agriculture. The previous `direct_download` URL (`http://www.peatus.ee/gtfs/gtfs.zip`) is no longer maintained and now resolves to the Digitransit journey planner rather than a feed. The data is now distributed as a single unified national zip.

### Changes
- `direct_download`: `http://www.peatus.ee/gtfs/gtfs.zip` -> `https://eu-gtfs.remix.com/estonia_unified_gtfs.zip`
- `license`: updated from the outdated `mnt.ee` URL to the current open-data page (`https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed`), which states the data is open and freely available to anyone
- Added `feed_contact_email`: `peatus@agri.ee`
- Added `status`: `active`
- `authentication_type`: `0` (no authentication required)
- Bounding box reset to null for re-extraction (the previous values were corrupted by a single placeholder stop)

### Verification
Downloaded and inspected the unified zip (built 2026-06-28): valid GTFS Schedule, 65 agencies, 2,338 routes (bus, tram, rail, ferry), 18,179 stops, ~135k trips. Service calendar covers 2025-01-01 through 2031-07-08. Includes Tallinn (TLT), Elron rail, and all counties.

### Notes
`mdb-3047` (Tallinn) and `mdb-3153` (Elron) already exist as partial per-operator slices of this same national source; this PR fixes the national aggregate entry.