### PR TITLE
Add Trafiklab GTFS Regional Feeds

### DIFF
--- a/catalogs/sources/gtfs/realtime/se-blekinge-gtfs-rt-regional-sa-3316.json
+++ b/catalogs/sources/gtfs/realtime/se-blekinge-gtfs-rt-regional-sa-3316.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3316,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Blekingetrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3245"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/blekinge/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-blekinge-gtfs-rt-regional-tu-3315.json
+++ b/catalogs/sources/gtfs/realtime/se-blekinge-gtfs-rt-regional-tu-3315.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3315,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Blekingetrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3245"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/blekinge/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-blekinge-gtfs-rt-regional-vp-3317.json
+++ b/catalogs/sources/gtfs/realtime/se-blekinge-gtfs-rt-regional-vp-3317.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3317,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Blekingetrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3245"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/blekinge/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-dintur-gtfs-rt-regional-sa-3338.json
+++ b/catalogs/sources/gtfs/realtime/se-dintur-gtfs-rt-regional-sa-3338.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3338,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Din Tur - Västernorrland",
+    "is_official": "True",
+    "static_reference": [
+        "3254"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/dintur/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-dintur-gtfs-rt-regional-tu-3337.json
+++ b/catalogs/sources/gtfs/realtime/se-dintur-gtfs-rt-regional-tu-3337.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3337,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Din Tur - Västernorrland",
+    "is_official": "True",
+    "static_reference": [
+        "3254"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/dintur/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-dintur-gtfs-rt-regional-vp-3339.json
+++ b/catalogs/sources/gtfs/realtime/se-dintur-gtfs-rt-regional-vp-3339.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3339,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Din Tur - Västernorrland",
+    "is_official": "True",
+    "static_reference": [
+        "3254"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/dintur/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-dt-gtfs-rt-regional-sa-3332.json
+++ b/catalogs/sources/gtfs/realtime/se-dt-gtfs-rt-regional-sa-3332.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3332,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Dalatrafik",
+    "is_official": "True",
+    "static_reference": [
+        "3252"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/dt/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-dt-gtfs-rt-regional-tu-3331.json
+++ b/catalogs/sources/gtfs/realtime/se-dt-gtfs-rt-regional-tu-3331.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3331,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Dalatrafik",
+    "is_official": "True",
+    "static_reference": [
+        "3252"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/dt/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-dt-gtfs-rt-regional-vp-3333.json
+++ b/catalogs/sources/gtfs/realtime/se-dt-gtfs-rt-regional-vp-3333.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3333,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Dalatrafik",
+    "is_official": "True",
+    "static_reference": [
+        "3252"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/dt/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-gotland-gtfs-rt-regional-sa-3313.json
+++ b/catalogs/sources/gtfs/realtime/se-gotland-gtfs-rt-regional-sa-3313.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3313,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Gotland",
+    "is_official": "True",
+    "static_reference": [
+        "3244"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/gotland/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-gotland-gtfs-rt-regional-tu-3312.json
+++ b/catalogs/sources/gtfs/realtime/se-gotland-gtfs-rt-regional-tu-3312.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3312,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Gotland",
+    "is_official": "True",
+    "static_reference": [
+        "3244"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/gotland/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-gotland-gtfs-rt-regional-vp-3314.json
+++ b/catalogs/sources/gtfs/realtime/se-gotland-gtfs-rt-regional-vp-3314.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3314,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Gotland",
+    "is_official": "True",
+    "static_reference": [
+        "3244"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/gotland/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-halland-gtfs-rt-regional-vp-3321.json
+++ b/catalogs/sources/gtfs/realtime/se-halland-gtfs-rt-regional-vp-3321.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3321,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Hallandstrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3247"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/halland/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-jlt-gtfs-rt-regional-sa-3304.json
+++ b/catalogs/sources/gtfs/realtime/se-jlt-gtfs-rt-regional-sa-3304.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3304,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "JLT",
+    "is_official": "True",
+    "static_reference": [
+        "3241"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/jlt/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-jlt-gtfs-rt-regional-tu-3303.json
+++ b/catalogs/sources/gtfs/realtime/se-jlt-gtfs-rt-regional-tu-3303.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3303,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "JLT",
+    "is_official": "True",
+    "static_reference": [
+        "3241"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/jlt/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-jlt-gtfs-rt-regional-vp-3305.json
+++ b/catalogs/sources/gtfs/realtime/se-jlt-gtfs-rt-regional-vp-3305.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3305,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "JLT",
+    "is_official": "True",
+    "static_reference": [
+        "3241"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/jlt/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-klt-gtfs-rt-regional-sa-3310.json
+++ b/catalogs/sources/gtfs/realtime/se-klt-gtfs-rt-regional-sa-3310.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3310,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "KLT",
+    "is_official": "True",
+    "static_reference": [
+        "3243"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/klt/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-klt-gtfs-rt-regional-tu-3309.json
+++ b/catalogs/sources/gtfs/realtime/se-klt-gtfs-rt-regional-tu-3309.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3309,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "KLT",
+    "is_official": "True",
+    "static_reference": [
+        "3243"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/klt/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-klt-gtfs-rt-regional-vp-3311.json
+++ b/catalogs/sources/gtfs/realtime/se-klt-gtfs-rt-regional-vp-3311.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3311,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "KLT",
+    "is_official": "True",
+    "static_reference": [
+        "3243"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/klt/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-krono-gtfs-rt-regional-sa-3307.json
+++ b/catalogs/sources/gtfs/realtime/se-krono-gtfs-rt-regional-sa-3307.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3307,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Kronoberg",
+    "is_official": "True",
+    "static_reference": [
+        "3242"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/krono/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-krono-gtfs-rt-regional-tu-3306.json
+++ b/catalogs/sources/gtfs/realtime/se-krono-gtfs-rt-regional-tu-3306.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3306,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Kronoberg",
+    "is_official": "True",
+    "static_reference": [
+        "3242"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/krono/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-krono-gtfs-rt-regional-vp-3308.json
+++ b/catalogs/sources/gtfs/realtime/se-krono-gtfs-rt-regional-vp-3308.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3308,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Kronoberg",
+    "is_official": "True",
+    "static_reference": [
+        "3242"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/krono/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-orebro-gtfs-rt-regional-sa-3326.json
+++ b/catalogs/sources/gtfs/realtime/se-orebro-gtfs-rt-regional-sa-3326.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3326,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Örebro",
+    "is_official": "True",
+    "static_reference": [
+        "3250"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/orebro/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-orebro-gtfs-rt-regional-tu-3325.json
+++ b/catalogs/sources/gtfs/realtime/se-orebro-gtfs-rt-regional-tu-3325.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3325,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Örebro",
+    "is_official": "True",
+    "static_reference": [
+        "3250"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/orebro/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-orebro-gtfs-rt-regional-vp-3327.json
+++ b/catalogs/sources/gtfs/realtime/se-orebro-gtfs-rt-regional-vp-3327.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3327,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Örebro",
+    "is_official": "True",
+    "static_reference": [
+        "3250"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/orebro/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-otraf-gtfs-rt-regional-sa-3301.json
+++ b/catalogs/sources/gtfs/realtime/se-otraf-gtfs-rt-regional-sa-3301.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3301,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Östgötatrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3240"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/otraf/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-otraf-gtfs-rt-regional-tu-3300.json
+++ b/catalogs/sources/gtfs/realtime/se-otraf-gtfs-rt-regional-tu-3300.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3300,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Östgötatrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3240"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/otraf/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-otraf-gtfs-rt-regional-vp-3302.json
+++ b/catalogs/sources/gtfs/realtime/se-otraf-gtfs-rt-regional-vp-3302.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3302,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Östgötatrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3240"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/otraf/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-skane-gtfs-rt-regional-sa-3319.json
+++ b/catalogs/sources/gtfs/realtime/se-skane-gtfs-rt-regional-sa-3319.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3319,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Skånetrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3246"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/skane/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-skane-gtfs-rt-regional-tu-3318.json
+++ b/catalogs/sources/gtfs/realtime/se-skane-gtfs-rt-regional-tu-3318.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3318,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Skånetrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3246"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/skane/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-skane-gtfs-rt-regional-vp-3320.json
+++ b/catalogs/sources/gtfs/realtime/se-skane-gtfs-rt-regional-vp-3320.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3320,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Skånetrafiken",
+    "is_official": "True",
+    "static_reference": [
+        "3246"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/skane/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-sl-gtfs-rt-regional-sa-3295.json
+++ b/catalogs/sources/gtfs/realtime/se-sl-gtfs-rt-regional-sa-3295.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3295,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "SL",
+    "is_official": "True",
+    "static_reference": [
+        "3237"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/sl/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-sl-gtfs-rt-regional-tu-3294.json
+++ b/catalogs/sources/gtfs/realtime/se-sl-gtfs-rt-regional-tu-3294.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3294,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "SL",
+    "is_official": "True",
+    "static_reference": [
+        "3237"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/sl/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-sl-gtfs-rt-regional-vp-3296.json
+++ b/catalogs/sources/gtfs/realtime/se-sl-gtfs-rt-regional-vp-3296.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3296,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "SL",
+    "is_official": "True",
+    "static_reference": [
+        "3237"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/sl/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-ul-gtfs-rt-regional-sa-3298.json
+++ b/catalogs/sources/gtfs/realtime/se-ul-gtfs-rt-regional-sa-3298.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3298,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "UL",
+    "is_official": "True",
+    "static_reference": [
+        "3238"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/ul/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-ul-gtfs-rt-regional-tu-3297.json
+++ b/catalogs/sources/gtfs/realtime/se-ul-gtfs-rt-regional-tu-3297.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3297,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "UL",
+    "is_official": "True",
+    "static_reference": [
+        "3238"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/ul/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-ul-gtfs-rt-regional-vp-3299.json
+++ b/catalogs/sources/gtfs/realtime/se-ul-gtfs-rt-regional-vp-3299.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3299,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "UL",
+    "is_official": "True",
+    "static_reference": [
+        "3238"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/ul/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-varm-gtfs-rt-regional-sa-3323.json
+++ b/catalogs/sources/gtfs/realtime/se-varm-gtfs-rt-regional-sa-3323.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3323,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Värmlandstrafik",
+    "is_official": "True",
+    "static_reference": [
+        "3249"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/varm/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-varm-gtfs-rt-regional-tu-3322.json
+++ b/catalogs/sources/gtfs/realtime/se-varm-gtfs-rt-regional-tu-3322.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3322,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Värmlandstrafik",
+    "is_official": "True",
+    "static_reference": [
+        "3249"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/varm/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-varm-gtfs-rt-regional-vp-3324.json
+++ b/catalogs/sources/gtfs/realtime/se-varm-gtfs-rt-regional-vp-3324.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3324,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Värmlandstrafik",
+    "is_official": "True",
+    "static_reference": [
+        "3249"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/varm/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-vastmanland-gtfs-rt-regional-sa-3329.json
+++ b/catalogs/sources/gtfs/realtime/se-vastmanland-gtfs-rt-regional-sa-3329.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3329,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "Västmanland",
+    "is_official": "True",
+    "static_reference": [
+        "3251"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/vastmanland/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-vastmanland-gtfs-rt-regional-tu-3328.json
+++ b/catalogs/sources/gtfs/realtime/se-vastmanland-gtfs-rt-regional-tu-3328.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3328,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "Västmanland",
+    "is_official": "True",
+    "static_reference": [
+        "3251"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/vastmanland/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-vastmanland-gtfs-rt-regional-vp-3330.json
+++ b/catalogs/sources/gtfs/realtime/se-vastmanland-gtfs-rt-regional-vp-3330.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3330,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "Västmanland",
+    "is_official": "True",
+    "static_reference": [
+        "3251"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/vastmanland/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-xt-gtfs-rt-regional-sa-3335.json
+++ b/catalogs/sources/gtfs/realtime/se-xt-gtfs-rt-regional-sa-3335.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3335,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "X-trafik",
+    "is_official": "True",
+    "static_reference": [
+        "3253"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/xt/ServiceAlerts.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-xt-gtfs-rt-regional-tu-3334.json
+++ b/catalogs/sources/gtfs/realtime/se-xt-gtfs-rt-regional-tu-3334.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3334,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "X-trafik",
+    "is_official": "True",
+    "static_reference": [
+        "3253"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/xt/TripUpdates.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/se-xt-gtfs-rt-regional-vp-3336.json
+++ b/catalogs/sources/gtfs/realtime/se-xt-gtfs-rt-regional-vp-3336.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3336,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "X-trafik",
+    "is_official": "True",
+    "static_reference": [
+        "3253"
+    ],
+    "urls": {
+        "direct_download": "https://opendata.samtrafiken.se/gtfs-rt/xt/VehiclePositions.pb",
+        "authentication_type": 1,
+        "authentication_info": "https://developer.trafiklab.se/register",
+        "api_key_parameter_name": "key",
+        "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/se-battaxi-gtfs-regional-3278.json
+++ b/catalogs/sources/gtfs/schedule/se-battaxi-gtfs-regional-3278.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3278,
+  "data_type": "gtfs",
+  "provider": "Stavsnäs båttaxi",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/battaxi/battaxi.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-battaxi-gtfs-3278.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Stavsnäs båttaxi",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-blekinge-gtfs-regional-3245.json
+++ b/catalogs/sources/gtfs/schedule/se-blekinge-gtfs-regional-3245.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3245,
+  "data_type": "gtfs",
+  "provider": "Blekingetrafiken",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/blekinge/blekinge.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-blekinge-gtfs-3245.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Blekingetrafiken",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-btbuss-gtfs-regional-3258.json
+++ b/catalogs/sources/gtfs/schedule/se-btbuss-gtfs-regional-3258.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3258,
+  "data_type": "gtfs",
+  "provider": "BT buss",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/btbuss/btbuss.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-btbuss-gtfs-3258.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional BT buss",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-dg-gtfs-regional-3259.json
+++ b/catalogs/sources/gtfs/schedule/se-dg-gtfs-regional-3259.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3259,
+  "data_type": "gtfs",
+  "provider": "Destination Gotland",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/dg/dg.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-dg-gtfs-3259.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Destination Gotland",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-dintur-gtfs-regional-3254.json
+++ b/catalogs/sources/gtfs/schedule/se-dintur-gtfs-regional-3254.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3254,
+  "data_type": "gtfs",
+  "provider": "Din Tur - Västernorrland",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/dintur/dintur.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-dintur-gtfs-3254.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Din Tur - Västernorrland",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-dt-gtfs-regional-3252.json
+++ b/catalogs/sources/gtfs/schedule/se-dt-gtfs-regional-3252.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3252,
+  "data_type": "gtfs",
+  "provider": "Dalatrafik",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/dt/dt.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-dt-gtfs-3252.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Dalatrafik",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-falcks-gtfs-regional-3260.json
+++ b/catalogs/sources/gtfs/schedule/se-falcks-gtfs-regional-3260.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3260,
+  "data_type": "gtfs",
+  "provider": "Falcks Omnibus AB",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/falcks/falcks.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-falcks-gtfs-3260.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Falcks Omnibus AB",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-flixbus-gtfs-regional-3261.json
+++ b/catalogs/sources/gtfs/schedule/se-flixbus-gtfs-regional-3261.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3261,
+  "data_type": "gtfs",
+  "provider": "Flixbus",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/flixbus/flixbus.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-flixbus-gtfs-3261.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Flixbus",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-flygbussarna-gtfs-regional-3288.json
+++ b/catalogs/sources/gtfs/schedule/se-flygbussarna-gtfs-regional-3288.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3288,
+  "data_type": "gtfs",
+  "provider": "Vy Flygbussarna",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/flygbussarna/flygbussarna.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-flygbussarna-gtfs-3288.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Vy Flygbussarna",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-gotland-gtfs-regional-3244.json
+++ b/catalogs/sources/gtfs/schedule/se-gotland-gtfs-regional-3244.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3244,
+  "data_type": "gtfs",
+  "provider": "Gotland",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/gotland/gotland.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-gotland-gtfs-3244.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Gotland",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-halland-gtfs-regional-3247.json
+++ b/catalogs/sources/gtfs/schedule/se-halland-gtfs-regional-3247.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3247,
+  "data_type": "gtfs",
+  "provider": "Hallandstrafiken",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/halland/halland.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-halland-gtfs-3247.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Hallandstrafiken",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-harje-gtfs-regional-3262.json
+++ b/catalogs/sources/gtfs/schedule/se-harje-gtfs-regional-3262.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3262,
+  "data_type": "gtfs",
+  "provider": "Härjedalingen",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/harje/harje.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-harje-gtfs-3262.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Härjedalingen",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-jamtland-gtfs-regional-3255.json
+++ b/catalogs/sources/gtfs/schedule/se-jamtland-gtfs-regional-3255.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3255,
+  "data_type": "gtfs",
+  "provider": "Jämtland",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/jamtland/jamtland.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-jamtland-gtfs-3255.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Jämtland",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-jlt-gtfs-regional-3241.json
+++ b/catalogs/sources/gtfs/schedule/se-jlt-gtfs-regional-3241.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3241,
+  "data_type": "gtfs",
+  "provider": "JLT",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/jlt/jlt.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-jlt-gtfs-3241.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional JLT",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-kirunabuss-gtfs-regional-3263.json
+++ b/catalogs/sources/gtfs/schedule/se-kirunabuss-gtfs-regional-3263.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3263,
+  "data_type": "gtfs",
+  "provider": "Kiruna Buss",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/kirunabuss/kirunabuss.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-kirunabuss-gtfs-3263.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Kiruna Buss",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-klt-gtfs-regional-3243.json
+++ b/catalogs/sources/gtfs/schedule/se-klt-gtfs-regional-3243.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3243,
+  "data_type": "gtfs",
+  "provider": "KLT",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/klt/klt.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-klt-gtfs-3243.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional KLT",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-kombardo-gtfs-regional-3264.json
+++ b/catalogs/sources/gtfs/schedule/se-kombardo-gtfs-regional-3264.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3264,
+  "data_type": "gtfs",
+  "provider": "Kombardo Expressen",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/kombardo/kombardo.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-kombardo-gtfs-3264.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Kombardo Expressen",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-krono-gtfs-regional-3242.json
+++ b/catalogs/sources/gtfs/schedule/se-krono-gtfs-regional-3242.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3242,
+  "data_type": "gtfs",
+  "provider": "Kronoberg",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/krono/krono.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-krono-gtfs-3242.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Kronoberg",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-lenna-gtfs-regional-3265.json
+++ b/catalogs/sources/gtfs/schedule/se-lenna-gtfs-regional-3265.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3265,
+  "data_type": "gtfs",
+  "provider": "Lennakatten",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/lenna/lenna.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-lenna-gtfs-3265.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Lennakatten",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-lulea-gtfs-regional-3266.json
+++ b/catalogs/sources/gtfs/schedule/se-lulea-gtfs-regional-3266.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3266,
+  "data_type": "gtfs",
+  "provider": "Luleå Lokaltrafik",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/lulea/lulea.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-lulea-gtfs-3266.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Luleå Lokaltrafik",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-malartag-gtfs-regional-3268.json
+++ b/catalogs/sources/gtfs/schedule/se-malartag-gtfs-regional-3268.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3268,
+  "data_type": "gtfs",
+  "provider": "Mälartåg ersättningstrafik",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/malartag/malartag.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-malartag-gtfs-3268.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Mälartåg ersättningstrafik",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-masen-gtfs-regional-3267.json
+++ b/catalogs/sources/gtfs/schedule/se-masen-gtfs-regional-3267.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3267,
+  "data_type": "gtfs",
+  "provider": "Masexpressen",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/masen/masen.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-masen-gtfs-3267.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Masexpressen",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-nikka-gtfs-regional-3269.json
+++ b/catalogs/sources/gtfs/schedule/se-nikka-gtfs-regional-3269.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3269,
+  "data_type": "gtfs",
+  "provider": "Nikkaluoktaexpressen",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/nikka/nikka.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-nikka-gtfs-3269.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Nikkaluoktaexpressen",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-norrbotten-gtfs-regional-3257.json
+++ b/catalogs/sources/gtfs/schedule/se-norrbotten-gtfs-regional-3257.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3257,
+  "data_type": "gtfs",
+  "provider": "Norrbotten",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/norrbotten/norrbotten.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-norrbotten-gtfs-3257.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Norrbotten",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-norrtag-vr-sverige-gtfs-regional-3270.json
+++ b/catalogs/sources/gtfs/schedule/se-norrtag-vr-sverige-gtfs-regional-3270.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3270,
+  "data_type": "gtfs",
+  "provider": "Norrtåg ersättningsstrafik (VR Sverige)",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/norrtag-vr-sverige/norrtag-vr-sverige.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-norrtag-vr-sverige-gtfs-3270.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Norrtåg ersättningsstrafik (VR Sverige)",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-orebro-gtfs-regional-3250.json
+++ b/catalogs/sources/gtfs/schedule/se-orebro-gtfs-regional-3250.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3250,
+  "data_type": "gtfs",
+  "provider": "Örebro",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/orebro/orebro.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-orebro-gtfs-3250.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Örebro",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-otraf-gtfs-regional-3240.json
+++ b/catalogs/sources/gtfs/schedule/se-otraf-gtfs-regional-3240.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3240,
+  "data_type": "gtfs",
+  "provider": "Östgötatrafiken",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/otraf/otraf.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-otraf-gtfs-3240.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Östgötatrafiken",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-ressel-gtfs-regional-3271.json
+++ b/catalogs/sources/gtfs/schedule/se-ressel-gtfs-regional-3271.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3271,
+  "data_type": "gtfs",
+  "provider": "Ressel Rederi",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/ressel/ressel.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-ressel-gtfs-3271.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Ressel Rederi",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-silverlinjen-gtfs-regional-3272.json
+++ b/catalogs/sources/gtfs/schedule/se-silverlinjen-gtfs-regional-3272.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3272,
+  "data_type": "gtfs",
+  "provider": "Silverlinjen",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/silverlinjen/silverlinjen.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-silverlinjen-gtfs-3272.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Silverlinjen",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-sj-gtfs-regional-3273.json
+++ b/catalogs/sources/gtfs/schedule/se-sj-gtfs-regional-3273.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3273,
+  "data_type": "gtfs",
+  "provider": "SJ",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/sj/sj.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-sj-gtfs-3273.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional SJ",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-sjnorge-gtfs-regional-3274.json
+++ b/catalogs/sources/gtfs/schedule/se-sjnorge-gtfs-regional-3274.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3274,
+  "data_type": "gtfs",
+  "provider": "SJ Norge",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/sjnorge/sjnorge.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-sjnorge-gtfs-3274.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional SJ Norge",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-sjostadstrafiken-gtfs-regional-3275.json
+++ b/catalogs/sources/gtfs/schedule/se-sjostadstrafiken-gtfs-regional-3275.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3275,
+  "data_type": "gtfs",
+  "provider": "Sjöstadstrafiken (Stockholm Stad)",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/sjostadstrafiken/sjostadstrafiken.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-sjostadstrafiken-gtfs-3275.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Sjöstadstrafiken (Stockholm Stad)",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-skane-gtfs-regional-3246.json
+++ b/catalogs/sources/gtfs/schedule/se-skane-gtfs-regional-3246.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3246,
+  "data_type": "gtfs",
+  "provider": "Skånetrafiken",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/skane/skane.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-skane-gtfs-3246.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Skånetrafiken",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-skelleftea-gtfs-regional-3276.json
+++ b/catalogs/sources/gtfs/schedule/se-skelleftea-gtfs-regional-3276.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3276,
+  "data_type": "gtfs",
+  "provider": "Skellefteåbuss",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/skelleftea/skelleftea.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-skelleftea-gtfs-3276.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Skellefteåbuss",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-sl-gtfs-regional-3237.json
+++ b/catalogs/sources/gtfs/schedule/se-sl-gtfs-regional-3237.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3237,
+  "data_type": "gtfs",
+  "provider": "SL",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/sl/sl.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-sl-gtfs-3237.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional SL",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-snalltaget-gtfs-regional-3277.json
+++ b/catalogs/sources/gtfs/schedule/se-snalltaget-gtfs-regional-3277.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3277,
+  "data_type": "gtfs",
+  "provider": "Snälltåget",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/snalltaget/snalltaget.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-snalltaget-gtfs-3277.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Snälltåget",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-sormland-gtfs-regional-3239.json
+++ b/catalogs/sources/gtfs/schedule/se-sormland-gtfs-regional-3239.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3239,
+  "data_type": "gtfs",
+  "provider": "Sörmlandstrafiken",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/sormland/sormland.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-sormland-gtfs-3239.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Sörmlandstrafiken",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-stromma-gtfs-regional-3279.json
+++ b/catalogs/sources/gtfs/schedule/se-stromma-gtfs-regional-3279.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3279,
+  "data_type": "gtfs",
+  "provider": "Strömma Turism & Sjöfart AB",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/stromma/stromma.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-stromma-gtfs-3279.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Strömma Turism & Sjöfart AB",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-tagab-gtfs-regional-3284.json
+++ b/catalogs/sources/gtfs/schedule/se-tagab-gtfs-regional-3284.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3284,
+  "data_type": "gtfs",
+  "provider": "Tågab",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/tagab/tagab.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-tagab-gtfs-3284.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Tågab",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-tib-vr-sverige-gtfs-regional-3280.json
+++ b/catalogs/sources/gtfs/schedule/se-tib-vr-sverige-gtfs-regional-3280.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3280,
+  "data_type": "gtfs",
+  "provider": "TiB ersättningstrafik (VR Sverige)",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/tib-vr-sverige/tib-vr-sverige.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-tib-vr-sverige-gtfs-3280.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional TiB ersättningstrafik (VR Sverige)",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-tjf-gtfs-regional-3281.json
+++ b/catalogs/sources/gtfs/schedule/se-tjf-gtfs-regional-3281.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3281,
+  "data_type": "gtfs",
+  "provider": "TJF Smalspåret",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/tjf/tjf.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-tjf-gtfs-3281.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional TJF Smalspåret",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-trosa-gtfs-regional-3283.json
+++ b/catalogs/sources/gtfs/schedule/se-trosa-gtfs-regional-3283.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3283,
+  "data_type": "gtfs",
+  "provider": "Trosabussen",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/trosa/trosa.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-trosa-gtfs-3283.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Trosabussen",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-trv-rdb-gtfs-regional-3282.json
+++ b/catalogs/sources/gtfs/schedule/se-trv-rdb-gtfs-regional-3282.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3282,
+  "data_type": "gtfs",
+  "provider": "Trafikverket RDB",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/trv-rdb/trv-rdb.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-trv-rdb-gtfs-3282.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Trafikverket RDB",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-uddevalla-gtfs-regional-3285.json
+++ b/catalogs/sources/gtfs/schedule/se-uddevalla-gtfs-regional-3285.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3285,
+  "data_type": "gtfs",
+  "provider": "Uddevalla Skärgårdsbåtar AB",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/uddevalla/uddevalla.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-uddevalla-gtfs-3285.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Uddevalla Skärgårdsbåtar AB",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-ul-gtfs-regional-3238.json
+++ b/catalogs/sources/gtfs/schedule/se-ul-gtfs-regional-3238.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3238,
+  "data_type": "gtfs",
+  "provider": "UL",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/ul/ul.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-ul-gtfs-3238.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional UL",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-varm-gtfs-regional-3249.json
+++ b/catalogs/sources/gtfs/schedule/se-varm-gtfs-regional-3249.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3249,
+  "data_type": "gtfs",
+  "provider": "Värmlandstrafik",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/varm/varm.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-varm-gtfs-3249.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Värmlandstrafik",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vasterbotten-gtfs-regional-3256.json
+++ b/catalogs/sources/gtfs/schedule/se-vasterbotten-gtfs-regional-3256.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3256,
+  "data_type": "gtfs",
+  "provider": "Västerbotten",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vasterbotten/vasterbotten.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vasterbotten-gtfs-3256.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Västerbotten",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vastexp-gtfs-regional-3292.json
+++ b/catalogs/sources/gtfs/schedule/se-vastexp-gtfs-regional-3292.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3292,
+  "data_type": "gtfs",
+  "provider": "Västervik Express",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vastexp/vastexp.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vastexp-gtfs-3292.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Västervik Express",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vastmanland-gtfs-regional-3251.json
+++ b/catalogs/sources/gtfs/schedule/se-vastmanland-gtfs-regional-3251.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3251,
+  "data_type": "gtfs",
+  "provider": "Västmanland",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vastmanland/vastmanland.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vastmanland-gtfs-3251.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Västmanland",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vr-gtfs-regional-3286.json
+++ b/catalogs/sources/gtfs/schedule/se-vr-gtfs-regional-3286.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3286,
+  "data_type": "gtfs",
+  "provider": "VR",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vr/vr.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vr-gtfs-3286.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional VR",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vt-gtfs-regional-3248.json
+++ b/catalogs/sources/gtfs/schedule/se-vt-gtfs-regional-3248.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3248,
+  "data_type": "gtfs",
+  "provider": "Västtrafik",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vt/vt.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vt-gtfs-3248.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Västtrafik",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vy-bus4you-gtfs-regional-3287.json
+++ b/catalogs/sources/gtfs/schedule/se-vy-bus4you-gtfs-regional-3287.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3287,
+  "data_type": "gtfs",
+  "provider": "Vy Bus4You",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vy-bus4you/vy-bus4you.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vy-bus4you-gtfs-3287.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Vy Bus4You",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vy-norge-gtfs-regional-3289.json
+++ b/catalogs/sources/gtfs/schedule/se-vy-norge-gtfs-regional-3289.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3289,
+  "data_type": "gtfs",
+  "provider": "Vy Norge",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vy-norge/vy-norge.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vy-norge-gtfs-3289.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Vy Norge",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vy-varmlandnorge-gtfs-regional-3290.json
+++ b/catalogs/sources/gtfs/schedule/se-vy-varmlandnorge-gtfs-regional-3290.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3290,
+  "data_type": "gtfs",
+  "provider": "Vy Tåg AB",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vy-varmlandnorge/vy-varmlandnorge.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vy-varmlandnorge-gtfs-3290.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Vy Tåg AB",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-vy-varmlandstrafik-gtfs-regional-3291.json
+++ b/catalogs/sources/gtfs/schedule/se-vy-varmlandstrafik-gtfs-regional-3291.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3291,
+  "data_type": "gtfs",
+  "provider": "Vy Värmlandstrafik",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/vy-varmlandstrafik/vy-varmlandstrafik.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-vy-varmlandstrafik-gtfs-3291.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Vy Värmlandstrafik",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-xt-gtfs-regional-3253.json
+++ b/catalogs/sources/gtfs/schedule/se-xt-gtfs-regional-3253.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3253,
+  "data_type": "gtfs",
+  "provider": "X-trafik",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/xt/xt.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-xt-gtfs-3253.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional X-trafik",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/se-ybuss-gtfs-regional-3293.json
+++ b/catalogs/sources/gtfs/schedule/se-ybuss-gtfs-regional-3293.json
@@ -1,0 +1,28 @@
+{
+  "mdb_source_id": 3293,
+  "data_type": "gtfs",
+  "provider": "Y-Buss",
+  "location": {
+    "country_code": "SE",
+    "bounding_box": {
+      "minimum_latitude": null,
+      "maximum_latitude": null,
+      "minimum_longitude": null,
+      "maximum_longitude": null,
+      "extracted_on": "2025-12-17 14:34:56.548875+00:00"
+    }
+  },
+  "urls": {
+    "direct_download": "https://opendata.samtrafiken.se/gtfs/ybuss/ybuss.zip",
+    "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/se-ybuss-gtfs-3293.zip?alt=media",
+    "authentication_type": 1,
+    "authentication_info": "https://developer.trafiklab.se/register",
+    "api_key_parameter_name": "key",
+    "license": "https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/#licence"
+  },
+  "name": "GTFS Regional Y-Buss",
+  "features": [],
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/ua-kyiv-gtfs-3230.json
+++ b/catalogs/sources/gtfs/schedule/ua-kyiv-gtfs-3230.json
@@ -1,12 +1,12 @@
 {
     "mdb_source_id": 3230,
     "data_type": "gtfs",
-    "provider": "Kiev",
+    "provider": "Kyiv",
     "is_official": "True",
     "location": {
         "country_code": "UA",
-        "subdivision_name": "Kiev Oblast",
-        "municipality": "Kiev",
+        "subdivision_name": "Kyiv Oblast",
+        "municipality": "Kyiv",
         "bounding_box": {
             "minimum_latitude": null,
             "maximum_latitude": null,
@@ -18,7 +18,7 @@
     "urls": {
         "direct_download": "http://193.23.225.211:8002/export-gtfs-static",
         "authentication_type": 0,
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ua-kiev-gtfs-3230.zip?alt=media",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ua-kyiv-gtfs-3230.zip?alt=media",
         "license": "https://creativecommons.org/licenses/by/4.0/"
     }
 }

--- a/catalogs/sources/gtfs/schedule/ua-kyiv-gtfs-3230.json
+++ b/catalogs/sources/gtfs/schedule/ua-kyiv-gtfs-3230.json
@@ -18,7 +18,7 @@
     "urls": {
         "direct_download": "http://193.23.225.211:8002/export-gtfs-static",
         "authentication_type": 0,
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ua-kyiv-gtfs-3230.zip?alt=media",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ua-kiev-gtfs-3230.zip?alt=media",
         "license": "https://creativecommons.org/licenses/by/4.0/"
     }
 }


### PR DESCRIPTION
Closing loop on https://github.com/MobilityData/mobility-database-catalogs/issues/723#issuecomment-3671329097

https://www.trafiklab.se/api/gtfs-datasets/gtfs-regional/

103 total feeds imported

**Schedule**

57 feeds

**Realtime**

46 feeds

- 15 operators with SA + TU + VP (45 feeds): sl, ul, otraf, jlt, krono, klt, gotland, blekinge, skane, varm, orebro, vastmanland, dt, xt, dintur
- 1 operator with VP only (1 feed): halland