### PR TITLE
Oceania Coverage

### DIFF
--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-vp-2703.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-gtfs-rt-vp-2703.json
@@ -2,14 +2,14 @@
     "mdb_source_id": 2703,
     "data_type": "gtfs-rt",
     "entity_type": ["vp"],
-    "provider": "Transport for New South Wales",
+    "provider": "Transport for New South Wales - Sydney Trains",
     "urls": {
         "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/vehiclepos/sydneytrains",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
-        "api_key_parameter_name": "apikey"
+        "api_key_parameter_name": "Authorization"
     },
-    "license": "https://opendata.transport.nsw.gov.au/datalicence",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
     "is_official": "True",
     "static_reference": ["2449"]
 }

--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-lightrail-gtfs-rt-tu-3343.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-lightrail-gtfs-rt-tu-3343.json
@@ -1,17 +1,15 @@
 {
-    "mdb_source_id": 2702,
+    "mdb_source_id": 3343,
     "data_type": "gtfs-rt",
     "entity_type": ["tu"],
-    "provider": "Transport for New South Wales - Sydney Trains",
+    "provider": "Transport for New South Wales - Light Rail",
     "urls": {
-        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/sydneytrains",
+        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/lightrail/innerwest",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
         "api_key_parameter_name": "Authorization"
     },
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "is_official": "True",
-    "static_reference": [
-        "2449"
-    ]
+    "static_reference": ["2449"]
 }

--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-lightrail-gtfs-rt-vp-3344.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-lightrail-gtfs-rt-vp-3344.json
@@ -1,17 +1,15 @@
 {
-    "mdb_source_id": 2702,
+    "mdb_source_id": 3344,
     "data_type": "gtfs-rt",
-    "entity_type": ["tu"],
-    "provider": "Transport for New South Wales - Sydney Trains",
+    "entity_type": ["vp"],
+    "provider": "Transport for New South Wales - Light Rail",
     "urls": {
-        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/sydneytrains",
+        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/lightrail/innerwest",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
         "api_key_parameter_name": "Authorization"
     },
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "is_official": "True",
-    "static_reference": [
-        "2449"
-    ]
+    "static_reference": ["2449"]
 }

--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-metro-gtfs-rt-tu-3341.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-metro-gtfs-rt-tu-3341.json
@@ -1,17 +1,15 @@
 {
-    "mdb_source_id": 2702,
+    "mdb_source_id": 3341,
     "data_type": "gtfs-rt",
     "entity_type": ["tu"],
-    "provider": "Transport for New South Wales - Sydney Trains",
+    "provider": "Transport for New South Wales - Metro",
     "urls": {
-        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/sydneytrains",
+        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/metro",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
         "api_key_parameter_name": "Authorization"
     },
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "is_official": "True",
-    "static_reference": [
-        "2449"
-    ]
+    "static_reference": ["2449"]
 }

--- a/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-metro-gtfs-rt-vp-3342.json
+++ b/catalogs/sources/gtfs/realtime/au-new-south-wales-transport-for-new-south-wales-metro-gtfs-rt-vp-3342.json
@@ -1,17 +1,15 @@
 {
-    "mdb_source_id": 2702,
+    "mdb_source_id": 3342,
     "data_type": "gtfs-rt",
-    "entity_type": ["tu"],
-    "provider": "Transport for New South Wales - Sydney Trains",
+    "entity_type": ["vp"],
+    "provider": "Transport for New South Wales - Metro",
     "urls": {
-        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/realtime/sydneytrains",
+        "direct_download": "https://api.transport.nsw.gov.au/v2/gtfs/vehiclepos/metro",
         "authentication_type": 2,
         "authentication_info": "https://opendata.transport.nsw.gov.au/data/user/register",
         "api_key_parameter_name": "Authorization"
     },
     "license": "https://creativecommons.org/licenses/by/4.0/",
     "is_official": "True",
-    "static_reference": [
-        "2449"
-    ]
+    "static_reference": ["2449"]
 }

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-bus-gtfs-rt-tu-2654.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-bus-gtfs-rt-tu-2654.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Metro Bus",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/bus/trip-updates",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-bus-gtfs-rt-vp-2872.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-bus-gtfs-rt-vp-2872.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Metro Bus",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/bus/vehicle-positions",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-train-gtfs-rt-sa-2655.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-train-gtfs-rt-sa-2655.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Metro Train",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/metro/service-alerts",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-train-gtfs-rt-tu-2656.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-train-gtfs-rt-tu-2656.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Metro Train",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/metro/trip-updates",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-train-gtfs-rt-vp-2657.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-metro-train-gtfs-rt-vp-2657.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Metro Train",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/metro/vehicle-positions",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-regional-train-gtfs-rt-tu-2873.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-regional-train-gtfs-rt-tu-2873.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) V/Line Regional Train",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/vline/trip-updates",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-regional-train-gtfs-rt-vp-2874.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-regional-train-gtfs-rt-vp-2874.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) V/Line Regional Train",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/vline/vehicle-positions",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-yarra-trams-gtfs-rt-sa-2658.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-yarra-trams-gtfs-rt-sa-2658.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Yarra Trams",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/tram/service-alerts",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-yarra-trams-gtfs-rt-tu-2659.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-yarra-trams-gtfs-rt-tu-2659.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Yarra Trams",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/tram/trip-updates",

--- a/catalogs/sources/gtfs/realtime/au-victoria-ptv-yarra-trams-gtfs-rt-vp-2660.json
+++ b/catalogs/sources/gtfs/realtime/au-victoria-ptv-yarra-trams-gtfs-rt-vp-2660.json
@@ -7,7 +7,7 @@
     "provider": "Public Transport Victoria (PTV) Yarra Trams",
     "is_official": "True",
     "static_reference": [
-        "657"
+        "3340"
     ],
     "urls": {
         "direct_download": "https://api.opendata.transport.vic.gov.au/opendata/public-transport/gtfs/realtime/v1/tram/vehicle-positions",

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-3340.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-3340.json
@@ -1,0 +1,23 @@
+{
+    "mdb_source_id": 3340,
+    "data_type": "gtfs",
+    "provider": "Public Transport Victoria (PTV)",
+    "is_official": "True",
+    "location": {
+        "country_code": "AU",
+        "subdivision_name": "Victoria",
+        "municipality": "Melbourne",
+        "bounding_box": {
+            "minimum_latitude": null,
+            "maximum_latitude": null,
+            "minimum_longitude": null,
+            "maximum_longitude": null,
+            "extracted_on": "2026-07-06T18:51:23+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://opendata.transport.vic.gov.au/dataset/3f4e292e-7f8a-4ffe-831f-1953be0fe448/resource/fb152201-859f-4882-9206-b768060b50ad/download/gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-3340.zip?alt=media",
+        "license": "https://creativecommons.org/licenses/by/4.0/"
+    }
+}

--- a/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-657.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-public-transport-victoria-ptv-gtfs-657.json
@@ -2,6 +2,7 @@
     "mdb_source_id": 657,
     "data_type": "gtfs",
     "provider": "Public Transport Victoria (PTV)",
+    "status": "deprecated",
     "location": {
         "country_code": "AU",
         "subdivision_name": "Victoria",
@@ -18,5 +19,11 @@
         "direct_download": "http://data.ptv.vic.gov.au/downloads/gtfs.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-public-transport-victoria-ptv-gtfs-657.zip?alt=media",
         "license": "https://www.data.vic.gov.au/data/dataset/ptv-timetable-and-geographic-information-2015-gtfs"
-    }
+    },
+     "redirect": [
+        {
+            "id": "3340",
+            "comment": " "
+        }
+    ]
 }


### PR DESCRIPTION
**PR consists of Melbourne and Sdyney updates.** 

The current Melbourne feed we have https://mobilitydatabase.org/feeds/gtfs/mdb-657 seems to be the old legacy URL: http://data.ptv.vic.gov.au/downloads/gtfs.zip

The portal https://opendata.transport.vic.gov.au/dataset/gtfs-schedule provides a new URL: 

https://opendata.transport.vic.gov.au/dataset/3f4e292e-7f8a-4ffe-831f-1953be0fe448/resource/fb152201-859f-4882-9206-b768060b50ad/download/gtfs.zip

Neither the old or new URLs are able to validated because the zip files contain all 8 operating branches in sub folders.

The Sydney realtime feed updates add the Metro and Lightrail feeds