### PR TITLE
Import/na

### DIFF
--- a/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-sa-1706.json
+++ b/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-sa-1706.json
@@ -8,11 +8,18 @@
     "static_reference": [
         "696"
     ],
+    "status": "deprecated",
     "urls": {
         "direct_download": "https://gtfs.translink.ca/v2/gtfsalerts",
         "authentication_type": 1,
         "authentication_info": "https://www.translink.ca/about-us/doing-business-with-translink/app-developer-resources/register",
         "api_key_parameter_name": "apikey",
         "license": "https://developer.translink.ca/Home/TermsOfUse"
-    }
+    },
+    "redirect": [
+        {
+            "id": "3348",
+            "comment": " "
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-sa-3348.json
+++ b/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-sa-3348.json
@@ -1,5 +1,5 @@
 {
-    "mdb_source_id": 1706,
+    "mdb_source_id": 3348,
     "data_type": "gtfs-rt",
     "entity_type": [
         "sa"

--- a/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-sa-3348.json
+++ b/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-sa-3348.json
@@ -1,25 +1,18 @@
 {
-    "mdb_source_id": 1705,
+    "mdb_source_id": 1706,
     "data_type": "gtfs-rt",
     "entity_type": [
-        "vp"
+        "sa"
     ],
     "provider": "TransLink Vancouver",
     "static_reference": [
         "696"
     ],
-    "status": "deprecated",
     "urls": {
-        "direct_download": "https://gtfs.translink.ca/v2/gtfsposition",
+        "direct_download": "https://gtfsapi.translink.ca/v3/gtfsalerts",
         "authentication_type": 1,
         "authentication_info": "https://www.translink.ca/about-us/doing-business-with-translink/app-developer-resources/register",
         "api_key_parameter_name": "apikey",
         "license": "https://developer.translink.ca/Home/TermsOfUse"
-    },
-    "redirect": [
-        {
-            "id": "3350",
-            "comment": " "
-        }
-    ]
+    }
 }

--- a/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-tu-1707.json
+++ b/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-tu-1707.json
@@ -8,11 +8,18 @@
     "static_reference": [
         "696"
     ],
+    "status": "deprecated",
     "urls": {
         "direct_download": "https://gtfs.translink.ca/v2/gtfsrealtime",
         "authentication_type": 1,
         "authentication_info": "https://www.translink.ca/about-us/doing-business-with-translink/app-developer-resources/register",
         "api_key_parameter_name": "apikey",
         "license": "https://developer.translink.ca/Home/TermsOfUse"
-    }
+    },
+    "redirect": [
+        {
+            "id": "3349",
+            "comment": " "
+        }
+    ]
 }

--- a/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-tu-3349.json
+++ b/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-tu-3349.json
@@ -1,25 +1,18 @@
 {
-    "mdb_source_id": 1705,
+    "mdb_source_id": 1707,
     "data_type": "gtfs-rt",
     "entity_type": [
-        "vp"
+        "tu"
     ],
     "provider": "TransLink Vancouver",
     "static_reference": [
         "696"
     ],
-    "status": "deprecated",
     "urls": {
-        "direct_download": "https://gtfs.translink.ca/v2/gtfsposition",
+        "direct_download": "https://gtfsapi.translink.ca/v3/gtfsrealtime",
         "authentication_type": 1,
         "authentication_info": "https://www.translink.ca/about-us/doing-business-with-translink/app-developer-resources/register",
         "api_key_parameter_name": "apikey",
         "license": "https://developer.translink.ca/Home/TermsOfUse"
-    },
-    "redirect": [
-        {
-            "id": "3350",
-            "comment": " "
-        }
-    ]
+    }
 }

--- a/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-tu-3349.json
+++ b/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-tu-3349.json
@@ -1,5 +1,5 @@
 {
-    "mdb_source_id": 1707,
+    "mdb_source_id": 3349,
     "data_type": "gtfs-rt",
     "entity_type": [
         "tu"

--- a/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-vp-3350.json
+++ b/catalogs/sources/gtfs/realtime/ca-british-columbia-translink-vancouver-gtfs-rt-vp-3350.json
@@ -1,5 +1,5 @@
 {
-    "mdb_source_id": 1705,
+    "mdb_source_id": 3350,
     "data_type": "gtfs-rt",
     "entity_type": [
         "vp"
@@ -8,18 +8,11 @@
     "static_reference": [
         "696"
     ],
-    "status": "deprecated",
     "urls": {
-        "direct_download": "https://gtfs.translink.ca/v2/gtfsposition",
+        "direct_download": "https://gtfsapi.translink.ca/v3/gtfsposition",
         "authentication_type": 1,
         "authentication_info": "https://www.translink.ca/about-us/doing-business-with-translink/app-developer-resources/register",
         "api_key_parameter_name": "apikey",
         "license": "https://developer.translink.ca/Home/TermsOfUse"
-    },
-    "redirect": [
-        {
-            "id": "3350",
-            "comment": " "
-        }
-    ]
+    }
 }

--- a/catalogs/sources/gtfs/realtime/ca-quebec-stm-gtfs-rt-sa-3345.json
+++ b/catalogs/sources/gtfs/realtime/ca-quebec-stm-gtfs-rt-sa-3345.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3345,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "sa"
+    ],
+    "provider": "STM",
+    "is_official": "True",
+    "static_reference": [
+        "2126"
+    ],
+    "urls": {
+        "direct_download": "https://api.stm.info/pub/od/i3/v2/messages/etatservice",
+        "authentication_type": 2,
+        "authentication_info": "https://portail.developpeurs.stm.info/apihub/#/",
+        "api_key_parameter_name": "apiKey",
+        "license": "https://www.stm.info/en/about/developers/terms-use"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/ca-quebec-stm-gtfs-rt-tu-3346.json
+++ b/catalogs/sources/gtfs/realtime/ca-quebec-stm-gtfs-rt-tu-3346.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3346,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "tu"
+    ],
+    "provider": "STM",
+    "is_official": "True",
+    "static_reference": [
+        "2126"
+    ],
+    "urls": {
+        "direct_download": "https://api.stm.info/pub/od/gtfs-rt/ic/v2/tripUpdates",
+        "authentication_type": 2,
+        "authentication_info": "https://portail.developpeurs.stm.info/apihub/#/",
+        "api_key_parameter_name": "apiKey",
+        "license": "https://www.stm.info/en/about/developers/terms-use"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/ca-quebec-stm-gtfs-rt-vp-3347.json
+++ b/catalogs/sources/gtfs/realtime/ca-quebec-stm-gtfs-rt-vp-3347.json
@@ -1,0 +1,19 @@
+{
+    "mdb_source_id": 3347,
+    "data_type": "gtfs-rt",
+    "entity_type": [
+        "vp"
+    ],
+    "provider": "STM",
+    "is_official": "True",
+    "static_reference": [
+        "2126"
+    ],
+    "urls": {
+        "direct_download": "https://api.stm.info/pub/od/gtfs-rt/ic/v2/vehiclePositions",
+        "authentication_type": 2,
+        "authentication_info": "https://portail.developpeurs.stm.info/apihub/#/",
+        "api_key_parameter_name": "apiKey",
+        "license": "https://www.stm.info/en/about/developers/terms-use"
+    }
+}

--- a/catalogs/sources/gtfs/realtime/us-illinois-chicago-metra-gtfs-rt-sa-3351.json
+++ b/catalogs/sources/gtfs/realtime/us-illinois-chicago-metra-gtfs-rt-sa-3351.json
@@ -1,0 +1,24 @@
+{
+  "mdb_source_id": 3351,
+  "data_type": "gtfs-rt",
+  "entity_type": [
+    "sa"
+  ],
+  "provider": "Metra",
+  "urls": {
+    "direct_download": "https://gtfspublic.metrarr.com/gtfs/public/alerts",
+    "authentication_type": 1,
+    "authentication_info": "https://metra.com/developers",
+    "api_key_parameter_name": "api_token",
+    "license": "https://metra.com/developers"
+  },
+  "feed_contact_email": "FOIA@metrarr.com",
+  "static_reference": [
+      "2854"
+  ],
+  "features": [],
+  "note": "",
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/realtime/us-illinois-chicago-metra-gtfs-rt-tu-3352.json
+++ b/catalogs/sources/gtfs/realtime/us-illinois-chicago-metra-gtfs-rt-tu-3352.json
@@ -1,0 +1,24 @@
+{
+  "mdb_source_id": 3352,
+  "data_type": "gtfs-rt",
+  "entity_type": [
+    "tu"
+  ],
+  "provider": "Metra",
+  "urls": {
+    "direct_download": "https://gtfspublic.metrarr.com/gtfs/public/tripupdates",
+    "authentication_type": 1,
+    "authentication_info": "https://metra.com/developers",
+    "api_key_parameter_name": "api_token",
+    "license": "https://metra.com/developers"
+  },
+  "feed_contact_email": "FOIA@metrarr.com",
+  "static_reference": [
+      "2854"
+  ],
+  "features": [],
+  "note": "",
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/realtime/us-illinois-chicago-metra-gtfs-rt-vp-3353.json
+++ b/catalogs/sources/gtfs/realtime/us-illinois-chicago-metra-gtfs-rt-vp-3353.json
@@ -1,0 +1,24 @@
+{
+  "mdb_source_id": 3353,
+  "data_type": "gtfs-rt",
+  "entity_type": [
+    "vp"
+  ],
+  "provider": "Metra",
+  "urls": {
+    "direct_download": "https://gtfspublic.metrarr.com/gtfs/public/positions",
+    "authentication_type": 1,
+    "authentication_info": "https://metra.com/developers",
+    "api_key_parameter_name": "api_token",
+    "license": "https://metra.com/developers"
+  },
+  "feed_contact_email": "FOIA@metrarr.com",
+  "static_reference": [
+    "2854"
+  ],
+  "features": [],
+  "note": "",
+  "status": "active",
+  "is_official": "True",
+  "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/us-illinois-chicago-transit-authority-cta-gtfs-389.json
+++ b/catalogs/sources/gtfs/schedule/us-illinois-chicago-transit-authority-cta-gtfs-389.json
@@ -15,7 +15,7 @@
         }
     },
     "urls": {
-        "direct_download": "http://www.transitchicago.com/downloads/sch_data/google_transit.zip",
+        "direct_download": "https://www.transitchicago.com/downloads/sch_data/google_transit.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-illinois-chicago-transit-authority-cta-gtfs-389.zip?alt=media"
     }
 }


### PR DESCRIPTION
Adds: 
- STM Montreal realtime feeds,
- Metra Chicago realtime feeds*,

*Metra realtime feed URLs are **still** not accessible despite receiving an api key for authorization. Also, there is no contact email to reach out for clarification. The realtime feeds will be included regardless so that we have coverage. #1149

Updates:
- Translink Vancouver realtime feeds in accordance with new api v3