### PR TITLE
feat: Add 22 Estonian regional GTFS Schedule sources from peatus.ee [SOURCES]

### DIFF
--- a/catalogs/sources/gtfs/schedule/ee-harjumaa-alukvik-ou-gtfs-3368.json
+++ b/catalogs/sources/gtfs/schedule/ee-harjumaa-alukvik-ou-gtfs-3368.json
@@ -1,0 +1,30 @@
+{
+    "mdb_source_id": 3368,
+    "data_type": "gtfs",
+    "provider": "Alukvik OÜ, Ekspressbussiliinid osaühing, GoBus AS, HANSABUSS AS, SEBE Aktsiaselts",
+    "name": "Harjumaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "features": [
+        "fares-v1"
+    ],
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Harjumaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/harjumaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-harjumaa-alukvik-ou-gtfs-3368.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-hiiumaa-hansabuss-as-gtfs-3381.json
+++ b/catalogs/sources/gtfs/schedule/ee-hiiumaa-hansabuss-as-gtfs-3381.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3381,
+    "data_type": "gtfs",
+    "provider": "HANSABUSS AS",
+    "name": "Hiiumaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Hiiumaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/hiiumaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-hiiumaa-hansabuss-as-gtfs-3381.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-ida-virumaa-gobus-as-gtfs-3365.json
+++ b/catalogs/sources/gtfs/schedule/ee-ida-virumaa-gobus-as-gtfs-3365.json
@@ -1,0 +1,28 @@
+{
+    "mdb_source_id": 3365,
+    "data_type": "gtfs",
+    "provider": "GoBus AS",
+    "name": "Narva linn",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Ida-Virumaa",
+        "municipality": "Narva linn",
+        "bounding_box": {
+            "minimum_latitude": 58.9291564,
+            "maximum_latitude": 59.6162829,
+            "minimum_longitude": 25.6583155,
+            "maximum_longitude": 28.2017595,
+            "extracted_on": "2026-07-25T10:35:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/narva.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-ida-virumaa-gobus-as-gtfs-3365.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-ida-virumaa-gobus-as-gtfs-3366.json
+++ b/catalogs/sources/gtfs/schedule/ee-ida-virumaa-gobus-as-gtfs-3366.json
@@ -1,0 +1,28 @@
+{
+    "mdb_source_id": 3366,
+    "data_type": "gtfs",
+    "provider": "GoBus AS, NAJA OÜ, OSAÜHING FREMANTI, OV Ida-Bus OÜ",
+    "name": "Kohtla-Järve linn",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Ida-Virumaa",
+        "municipality": "Kohtla-Järve linn",
+        "bounding_box": {
+            "minimum_latitude": 58.9843861,
+            "maximum_latitude": 59.4634758,
+            "minimum_longitude": 26.7881726,
+            "maximum_longitude": 28.2024793,
+            "extracted_on": "2026-07-25T10:35:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/kohtla_jarve.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-ida-virumaa-gobus-as-gtfs-3366.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-ida-virumaa-gobus-as-gtfs-3372.json
+++ b/catalogs/sources/gtfs/schedule/ee-ida-virumaa-gobus-as-gtfs-3372.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3372,
+    "data_type": "gtfs",
+    "provider": "GoBus AS, MEELIS HEEK, MK Reis OÜ",
+    "name": "Ida-Virumaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Ida-Virumaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:38+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/ida_viru.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-ida-virumaa-gobus-as-gtfs-3372.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-jarvamaa-atg-bussipark-ou-gtfs-3374.json
+++ b/catalogs/sources/gtfs/schedule/ee-jarvamaa-atg-bussipark-ou-gtfs-3374.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3374,
+    "data_type": "gtfs",
+    "provider": "ATG Bussipark OÜ, GoBus AS",
+    "name": "Järvamaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Järvamaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/jarvamaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-jarvamaa-atg-bussipark-ou-gtfs-3374.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-jogevamaa-eesti-bussiliinid-ou-gtfs-3373.json
+++ b/catalogs/sources/gtfs/schedule/ee-jogevamaa-eesti-bussiliinid-ou-gtfs-3373.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3373,
+    "data_type": "gtfs",
+    "provider": "Eesti Bussiliinid OÜ, GoBus AS",
+    "name": "Jõgevamaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Jõgevamaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:39+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/jogevamaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-jogevamaa-eesti-bussiliinid-ou-gtfs-3373.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-laane-virumaa-hansabuss-as-gtfs-3367.json
+++ b/catalogs/sources/gtfs/schedule/ee-laane-virumaa-hansabuss-as-gtfs-3367.json
@@ -1,0 +1,28 @@
+{
+    "mdb_source_id": 3367,
+    "data_type": "gtfs",
+    "provider": "HANSABUSS AS",
+    "name": "Rakvere linn",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Lääne-Virumaa",
+        "municipality": "Rakvere linn",
+        "bounding_box": {
+            "minimum_latitude": 58.9291564,
+            "maximum_latitude": 59.6162829,
+            "minimum_longitude": 25.6583155,
+            "maximum_longitude": 26.9382895,
+            "extracted_on": "2026-07-25T10:34:10+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/rakvere.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-laane-virumaa-hansabuss-as-gtfs-3367.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-laane-virumaa-hansabuss-as-gtfs-3370.json
+++ b/catalogs/sources/gtfs/schedule/ee-laane-virumaa-hansabuss-as-gtfs-3370.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3370,
+    "data_type": "gtfs",
+    "provider": "HANSABUSS AS",
+    "name": "Lääne-Virumaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Lääne-Virumaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/laane_virumaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-laane-virumaa-hansabuss-as-gtfs-3370.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-laanemaa-gobus-as-gtfs-3369.json
+++ b/catalogs/sources/gtfs/schedule/ee-laanemaa-gobus-as-gtfs-3369.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3369,
+    "data_type": "gtfs",
+    "provider": "GoBus AS, MK Reis OÜ",
+    "name": "Läänemaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Läänemaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:36+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/laanemaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-laanemaa-gobus-as-gtfs-3369.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-parnumaa-aktsiaselts-mk-autobuss-gtfs-3377.json
+++ b/catalogs/sources/gtfs/schedule/ee-parnumaa-aktsiaselts-mk-autobuss-gtfs-3377.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3377,
+    "data_type": "gtfs",
+    "provider": "Aktsiaselts MK Autobuss, Atko Bussiliinid AS, GoBus AS, SEBE Aktsiaselts",
+    "name": "Pärnumaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Pärnumaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/parnumaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-parnumaa-aktsiaselts-mk-autobuss-gtfs-3377.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-parnumaa-osauhing-bristol-takso-gtfs-3364.json
+++ b/catalogs/sources/gtfs/schedule/ee-parnumaa-osauhing-bristol-takso-gtfs-3364.json
@@ -1,0 +1,28 @@
+{
+    "mdb_source_id": 3364,
+    "data_type": "gtfs",
+    "provider": "Osaühing Bristol Takso, Papiniidu Projekt AS, Piiroja Invest OÜ, SEBE Aktsiaselts",
+    "name": "Pärnu linn",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Pärnumaa",
+        "municipality": "Pärnu linn",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:35+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/parnu.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-parnumaa-osauhing-bristol-takso-gtfs-3364.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-polvamaa-gobus-as-gtfs-3375.json
+++ b/catalogs/sources/gtfs/schedule/ee-polvamaa-gobus-as-gtfs-3375.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3375,
+    "data_type": "gtfs",
+    "provider": "GoBus AS",
+    "name": "Põlvamaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Põlvamaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:40+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/polvamaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-polvamaa-gobus-as-gtfs-3375.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-raplamaa-gobus-as-gtfs-3371.json
+++ b/catalogs/sources/gtfs/schedule/ee-raplamaa-gobus-as-gtfs-3371.json
@@ -1,0 +1,30 @@
+{
+    "mdb_source_id": 3371,
+    "data_type": "gtfs",
+    "provider": "GoBus AS, HANSABUSS AS",
+    "name": "Raplamaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "features": [
+        "fares-v1"
+    ],
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Raplamaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:37+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/raplamaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-raplamaa-gobus-as-gtfs-3371.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-saaremaa-gobus-as-gtfs-3382.json
+++ b/catalogs/sources/gtfs/schedule/ee-saaremaa-gobus-as-gtfs-3382.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3382,
+    "data_type": "gtfs",
+    "provider": "GoBus AS, Saaremaa vald",
+    "name": "Saaremaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Saaremaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:45+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/saaremaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-saaremaa-gobus-as-gtfs-3382.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-tartumaa-gobus-as-gtfs-3363.json
+++ b/catalogs/sources/gtfs/schedule/ee-tartumaa-gobus-as-gtfs-3363.json
@@ -1,0 +1,28 @@
+{
+    "mdb_source_id": 3363,
+    "data_type": "gtfs",
+    "provider": "GoBus AS, HANSABUSS AS, SEBE Aktsiaselts",
+    "name": "Tartu linn",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Tartumaa",
+        "municipality": "Tartu linn",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:34+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/tartu.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-tartumaa-gobus-as-gtfs-3363.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-tartumaa-hansabuss-as-gtfs-3378.json
+++ b/catalogs/sources/gtfs/schedule/ee-tartumaa-hansabuss-as-gtfs-3378.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3378,
+    "data_type": "gtfs",
+    "provider": "HANSABUSS AS, Kihnu Veeteed AS",
+    "name": "Tartumaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Tartumaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:42+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/tartumaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-tartumaa-hansabuss-as-gtfs-3378.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-unknown-aktsiaselts-mk-autobuss-gtfs-3383.json
+++ b/catalogs/sources/gtfs/schedule/ee-unknown-aktsiaselts-mk-autobuss-gtfs-3383.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 3383,
+    "data_type": "gtfs",
+    "provider": "Aktsiaselts MK Autobuss, Arilix OÜ, AS ANNISTON, AS Lux Express Estonia, Estonian Lines OÜ, GoBus AS, HANSABUSS AS, Kalle Bussid OÜ, MK Reis OÜ, osaühing Tulisilm, OÜ Baltic Shuttle, Sirel Reisid OÜ, Taisto Express OÜ",
+    "name": "Siseriiklikud kaugbussiliinid",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/kaugliinid.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-unknown-aktsiaselts-mk-autobuss-gtfs-3383.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-unknown-ts-laevad-ou-gtfs-3384.json
+++ b/catalogs/sources/gtfs/schedule/ee-unknown-ts-laevad-ou-gtfs-3384.json
@@ -1,0 +1,26 @@
+{
+    "mdb_source_id": 3384,
+    "data_type": "gtfs",
+    "provider": "TS Laevad OÜ",
+    "name": "TS Laevad OÜ parvlaevaühendused",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "bounding_box": {
+            "minimum_latitude": 58.5731054,
+            "maximum_latitude": 58.9047595,
+            "minimum_longitude": 23.0461342,
+            "maximum_longitude": 23.5084146,
+            "extracted_on": "2026-07-25T10:35:46+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/tslaevad.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-unknown-ts-laevad-ou-gtfs-3384.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-valgamaa-atg-bussiliinid-ou-gtfs-3379.json
+++ b/catalogs/sources/gtfs/schedule/ee-valgamaa-atg-bussiliinid-ou-gtfs-3379.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3379,
+    "data_type": "gtfs",
+    "provider": "ATG Bussiliinid OÜ, GoBus AS",
+    "name": "Valgamaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Valgamaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:43+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/valgamaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-valgamaa-atg-bussiliinid-ou-gtfs-3379.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-viljandimaa-atko-bussiliinid-as-gtfs-3380.json
+++ b/catalogs/sources/gtfs/schedule/ee-viljandimaa-atko-bussiliinid-as-gtfs-3380.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3380,
+    "data_type": "gtfs",
+    "provider": "Atko Bussiliinid AS, Estonian Lines OÜ, GoBus AS",
+    "name": "Viljandimaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Viljandimaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:44+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/viljandimaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-viljandimaa-atko-bussiliinid-as-gtfs-3380.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}

--- a/catalogs/sources/gtfs/schedule/ee-vorumaa-gobus-as-gtfs-3376.json
+++ b/catalogs/sources/gtfs/schedule/ee-vorumaa-gobus-as-gtfs-3376.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3376,
+    "data_type": "gtfs",
+    "provider": "GoBus AS",
+    "name": "Võrumaa",
+    "feed_contact_email": "peatus@agri.ee",
+    "status": "active",
+    "location": {
+        "country_code": "EE",
+        "subdivision_name": "Võrumaa",
+        "bounding_box": {
+            "minimum_latitude": 0.2206108,
+            "maximum_latitude": 59.6539063,
+            "minimum_longitude": 21.8616849,
+            "maximum_longitude": 60.5537851,
+            "extracted_on": "2026-07-25T10:35:41+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://eu-gtfs.remix.com/vorumaa.zip",
+        "authentication_type": 0,
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ee-vorumaa-gobus-as-gtfs-3376.zip?alt=media",
+        "license": "https://www.agri.ee/regionaalareng-uhistransport/uhistransport-ja-reisimine/uhistranspordiregistri-avaandmed"
+    },
+    "redirect": [],
+    "is_official": "True"
+}


### PR DESCRIPTION
**What this is**

- Estonia publishes its public transport open data as 25 GTFS feeds. The catalog has 3, so this adds the other 22.
- Source: Table 1 of [peatus.ee](https://peatus.ee/content/Veebilehest%20ja%20%C3%BChistranspordi%20avaandmetest), the official register listing run by REMITK and the Ministry of Regional Affairs and Agriculture.
- All 22 are `is_official=True` and need no auth.
- Diff is 22 new files. Nothing existing is changed.

**Added, IDs 3363-3384, all under `https://eu-gtfs.remix.com/`**

- Cities: Tartu 3363, Pärnu 3364, Narva 3365, Kohtla-Järve 3366, Rakvere 3367
- Counties: Harjumaa 3368, Läänemaa 3369, Lääne-Virumaa 3370, Raplamaa 3371, Ida-Virumaa 3372, Jõgevamaa 3373, Järvamaa 3374, Põlvamaa 3375, Võrumaa 3376, Pärnumaa 3377, Tartumaa 3378, Valgamaa 3379, Viljandimaa 3380, Hiiumaa 3381, Saaremaa 3382
- Nationwide: domestic long-distance coach 3383, TS Laevad ferries 3384

**Already present, untouched**

- Tallinn 3047, Elron 3153, national aggregate 3235.
- The new feeds are regional slices of 3235, so contents overlap. Deliberate, and consistent with other countries publishing both per-region and aggregate feeds.

**Metadata**

- Created with `add_gtfs_schedule_source`, so bounding boxes, `latest` URLs and filenames are tool-generated.
- `provider` read from each feed's `agency.txt`, since the page names regions rather than companies.
- `name` is the page's own label.
- Counties get `subdivision_name`, cities also get `municipality`, the two nationwide feeds get neither (hence `ee-unknown-...`).
- `fares-v1` on Harjumaa and Raplamaa only, the only two feeds shipping fare files.
- Licence and `feed_contact_email` match existing source 3235.

**IDs are hand-set**

- `Catalog.identify()` counts files to pick the next ID, and overcounts by four here.
- Two files under `catalogs/sources` are not sources: `us-virginia-roanoke-cortran-flex-gtfs-2435` (missing `.json`) and `fr-normandie-hobus-gtfs-2685.zip`.
- Three IDs are used twice: 3204, 2698, 2647.
- That numbered the first feed 3366, failing `test_catalogs_gtfs_source_ids_are_incremental` with `3366 != 3363`.
- Renumbered to a contiguous 3363-3384 using the repo's `create_filename` and `create_latest_url` helpers.
- Stray files and duplicate IDs left alone. Happy to open a separate issue.

**18 feeds have a wrong bounding box, from upstream data**

- Stop `149220`, *Silla (perspektiivne)*, sits at `lat=0.2206108, lon=60.5537851`, far outside Estonia.
- Those 18 feeds each ship the full national stop list of roughly 18,000 stops, so all inherit it.
- The four carrying only local stops (Narva, Kohtla-Järve, Rakvere, TS Laevad) are correct.
- Bbox search will misplace the 18 until it is fixed upstream.
- Left as `extract_gtfs_bounding_box` produced them rather than hand-corrected, matching existing source 1095.
- Worth reporting to `peatus@agri.ee`, since one fix corrects all 18.

**Tests**

- 6 integration passed.
- 85 unit passed, 1 skipped.
- All 22 entries schema-valid.
- All 22 URLs return `HTTP 200` with a non-empty archive.
- No existing files modified.