### PR TITLE
fix: failing pip installation in direct download URLs test

### DIFF
--- a/.github/workflows/direct_download_urls_test_for_sources.yml
+++ b/.github/workflows/direct_download_urls_test_for_sources.yml
@@ -120,7 +120,7 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install "pip<24.1"
           pip install pytest wheel numpy
           sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
           sudo apt-get update


### PR DESCRIPTION
**Problem**

- The `Validate and download` jobs in `direct_download_urls_test_for_sources.yml` fail in `Install dependencies`, before any feed is looked at.
- Error is `no such option: --global-option`, exit code 2.
- Cause: the job runs `python -m pip install --upgrade pip`, and pip 24.1 removed `--global-option`, which the GDAL install two lines later still uses.

**Fix**

- One line: pin `pip<24.1` in the `download-datasets` job.
- This is the same change #1097 made to `unit_tests.yml` and `integration_tests.yml`, and #1101 made to `export_to_csv.yml`. This workflow was missed at the time and is now the only one still on `--upgrade pip` while using `--global-option`.

**Why it went unnoticed**

- This workflow only runs when the PR title contains `[SOURCES]`.
- Across its last 100 runs: 97 skipped, 2 failed, 1 cancelled.
- Both failures are this same error: #1516 on 2026-06-29 and #1572 on 2026-07-25.
- So the job has been broken since pip 24.1 shipped without ever blocking a merge.

**Verification**

- The identical pin is already working in the three sibling workflows.
- #1572 reproduces the failure across 22 jobs today and will exercise this fix once this lands.

**Deliberately left alone**

- The `--upgrade pip` on line 23 in the `get-urls` job. That job does not install GDAL and passes.
- The `--global-option` GDAL line itself, per the existing note in `export_to_csv.yml` to reconsider only once pip supports it again.