### PR TITLE
Add Cochabamba, Bolivia

### DIFF
--- a/catalogs/sources/gtfs/schedule/bo-c-trufi-association-gtfs-3503.json
+++ b/catalogs/sources/gtfs/schedule/bo-c-trufi-association-gtfs-3503.json
@@ -1,0 +1,27 @@
+{
+    "mdb_source_id": 3503,
+    "data_type": "gtfs",
+    "provider": "Trufi Association",
+    "name": "Agregación de datos de transporte público en Cochabamba (tren metropolitano, micros, minibuses, y trufis) desde OpenStreetMap",
+    "feed_contact_email": "idaasannmvgd@gmail.com",
+    "features": [],
+    "status": "active",
+    "location": {
+        "country_code": "BO",
+        "subdivision_name": "C",
+        "municipality": "Cochabamba",
+        "bounding_box": {
+            "minimum_latitude": -17.576720100000003,
+            "maximum_latitude": -17.287615000000002,
+            "minimum_longitude": -66.3885041,
+            "maximum_longitude": -65.84141430000001,
+            "extracted_on": "2026-08-26T14:55:17+00:00"
+        }
+    },
+    "urls": {
+        "direct_download": "https://raw.githubusercontent.com/trufi-association/trufi-gtfs-builder/refs/heads/main/examples/Bolivia-Cochabamba/out/cochabamba.gtfs.zip",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/bo-c-trufi-association-gtfs-3503.zip?alt=media",
+        "license": "https://www.openstreetmap.org/copyright"
+    },
+    "redirect": []
+}

--- a/catalogs/sources/gtfs/schedule/bo-c-trufi-association-gtfs-3507.json
+++ b/catalogs/sources/gtfs/schedule/bo-c-trufi-association-gtfs-3507.json
@@ -1,9 +1,10 @@
 {
-    "mdb_source_id": 3503,
+    "mdb_source_id": 3507,
     "data_type": "gtfs",
     "provider": "Trufi Association",
     "name": "Agregación de datos de transporte público en Cochabamba (tren metropolitano, micros, minibuses, y trufis) desde OpenStreetMap",
     "feed_contact_email": "idaasannmvgd@gmail.com",
+    "is_official": "False",
     "features": [],
     "status": "active",
     "location": {
@@ -20,7 +21,7 @@
     },
     "urls": {
         "direct_download": "https://raw.githubusercontent.com/trufi-association/trufi-gtfs-builder/refs/heads/main/examples/Bolivia-Cochabamba/out/cochabamba.gtfs.zip",
-        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/bo-c-trufi-association-gtfs-3503.zip?alt=media",
+        "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/bo-c-trufi-association-gtfs-3507.zip?alt=media",
         "license": "https://www.openstreetmap.org/copyright"
     },
     "redirect": []


### PR DESCRIPTION
cc @IsmaDavidAA (I put your email address, as mentioned in our chat)

For the license, I linked to https://www.openstreetmap.org/copyright, as the GTFS is derived from OSM.

For reference, I created the file with

```python
from tools.operations import add_gtfs_schedule_source
add_gtfs_schedule_source(
        provider="Trufi Association",
        country_code="BO",
        direct_download_url="https://raw.githubusercontent.com/trufi-association/trufi-gtfs-builder/refs/heads/main/examples/Bolivia-Cochabamba/out/cochabamba.gtfs.zip",
        subdivision_name="C",
        municipality="Cochabamba",
        license_url="https://www.openstreetmap.org/copyright",
        name="Agregación de datos de transporte público en Cochabamba (tren metropolitano, micros, minibuses, y trufis) desde OpenStreetMap",
        features=[],
        status="active",
        feed_contact_email="idaasannmvgd@gmail.com"
    )
```

following instructions in the README