### PR TITLE
feat: set is_seasonal for 8 seasonal feeds

### DIFF
--- a/catalogs/sources/gtfs/schedule/us-colorado-estes-transit-gtfs-2047.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-estes-transit-gtfs-2047.json
@@ -23,5 +23,6 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-estes-transit-gtfs-2047.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [],
+    "is_seasonal": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-colorado-estes-transit-gtfs-459.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-estes-transit-gtfs-459.json
@@ -19,5 +19,6 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-estes-transit-gtfs-459.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [],
+    "is_seasonal": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "http://data.trilliumtransit.com/gtfs/rockymountainnationalpark-co-us/rockymountainnationalpark-co-us.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-rocky-mountain-national-park-shuttles-gtfs-176.zip?alt=media"
-    }
+    },
+    "is_seasonal": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-3211.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-rocky-mountain-national-park-shuttles-gtfs-3211.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://www.nps.gov/external-resources/gtfs/romo/rocky-mountain-national-park-shuttle.zip",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-rocky-mountain-national-park-shuttles-gtfs-3211.zip?alt=media"
-    }
+    },
+    "is_seasonal": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-colorado-town-of-estes-park-gtfs-177.json
+++ b/catalogs/sources/gtfs/schedule/us-colorado-town-of-estes-park-gtfs-177.json
@@ -21,5 +21,6 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-colorado-town-of-estes-park-gtfs-177.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [],
+    "is_seasonal": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-bay-state-cruise-company-gtfs-435.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-bay-state-cruise-company-gtfs-435.json
@@ -21,5 +21,6 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-bay-state-cruise-company-gtfs-435.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [],
+    "is_seasonal": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-2035.json
+++ b/catalogs/sources/gtfs/schedule/us-missouri-metro-st-louis-gtfs-2035.json
@@ -24,5 +24,6 @@
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-missouri-metro-st-louis-gtfs-2035.zip?alt=media",
         "license": "https://www.looptrolley.com/resources"
     },
-    "redirect": []
+    "redirect": [],
+    "is_seasonal": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-oregon-astoria-riverfront-trolley-gtfs-1254.json
+++ b/catalogs/sources/gtfs/schedule/us-oregon-astoria-riverfront-trolley-gtfs-1254.json
@@ -21,5 +21,6 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-astoria-riverfront-trolley-gtfs-1254.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [],
+    "is_seasonal": "True"
 }


### PR DESCRIPTION
Mark the following GTFS Schedule sources as seasonal:

- mdb-176  Rocky Mountain National Park Shuttles
- mdb-177  Town of Estes Park
- mdb-435  Bay State Cruise Company
- mdb-459  Estes Transit
- mdb-1254 Astoria Riverfront Trolley
- mdb-2035 Metro St. Louis
- mdb-2047 Estes Transit
- mdb-3211 Rocky Mountain National Park Shuttles

Note: this PR doesn't include the tdg and tld series feeds (20 total) that can't be marked seasonal in the catalogs repo

Method can be viewed [here](https://app.notion.com/p/mobilitydata/Seal-of-Reliability-Detect-Seasonality-3ca6e644546a80139118f010be7a612f?source=copy_link)

Feeds can be viewed [here](https://docs.google.com/spreadsheets/d/1Tz-pESNY3_vXOJSWkAOqjTmAoIlQVYQi-5gYTetDWqw/edit?gid=1275456598#gid=1275456598)