### PR TITLE
set is_producer_url_unstable for inactive mdb feeds

### DIFF
--- a/catalogs/sources/gtfs/schedule/ar-cordoba-mar-chiquita-srl-gtfs-1146.json
+++ b/catalogs/sources/gtfs/schedule/ar-cordoba-mar-chiquita-srl-gtfs-1146.json
@@ -20,5 +20,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/mar-chiquita-srl/805/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ar-cordoba-mar-chiquita-srl-gtfs-1146.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/au-tasmania-merseylink-gtfs-1251.json
+++ b/catalogs/sources/gtfs/schedule/au-tasmania-merseylink-gtfs-1251.json
@@ -21,5 +21,6 @@
         "direct_download": "https://transitfeeds.com/p/merseylink/1221/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-tasmania-merseylink-gtfs-1251.zip?alt=media",
         "license": "https://www.merseylink.com.au/gtfs-feed/"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/au-victoria-mornington-railway-gtfs-1281.json
+++ b/catalogs/sources/gtfs/schedule/au-victoria-mornington-railway-gtfs-1281.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/mornington-railway/806/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/au-victoria-mornington-railway-gtfs-1281.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/ca-quebec-agence-metropolitaine-de-transport-gtfs-1179.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-agence-metropolitaine-de-transport-gtfs-1179.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/agence-metropolitaine-de-transport/129/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-agence-metropolitaine-de-transport-gtfs-1179.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/ca-quebec-mrc-de-deux-montagnes-gtfs-1182.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-mrc-de-deux-montagnes-gtfs-1182.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/agence-metropolitaine-de-transport/141/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-mrc-de-deux-montagnes-gtfs-1182.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/ca-quebec-mrc-les-moulins-gtfs-1180.json
+++ b/catalogs/sources/gtfs/schedule/ca-quebec-mrc-les-moulins-gtfs-1180.json
@@ -16,5 +16,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/agence-metropolitaine-de-transport/142/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ca-quebec-mrc-les-moulins-gtfs-1180.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-ostalbmobil-verkehrsverbund-gtfs-1202.json
+++ b/catalogs/sources/gtfs/schedule/de-baden-wurttemberg-ostalbmobil-verkehrsverbund-gtfs-1202.json
@@ -19,5 +19,6 @@
         "direct_download": "https://transitfeeds.com/p/ostalbmobil-verkehrsverbund/1236/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-baden-wurttemberg-ostalbmobil-verkehrsverbund-gtfs-1202.zip?alt=media",
         "license": "https://www.nvbw.de/aufgaben/digitale-mobilitaet/lizenz/"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/de-bayern-burgerbus-leupoldsgrun-landkreis-hof-gtfs-1152.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-burgerbus-leupoldsgrun-landkreis-hof-gtfs-1152.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/b-rgerbus-leupoldsgr-n-landkreis-hof/1126/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-burgerbus-leupoldsgrun-landkreis-hof-gtfs-1152.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/de-bayern-hofbus-gtfs-1252.json
+++ b/catalogs/sources/gtfs/schedule/de-bayern-hofbus-gtfs-1252.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/hofbus/1197/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-bayern-hofbus-gtfs-1252.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/de-unknown-db-gtfs-1139.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-db-gtfs-1139.json
@@ -16,5 +16,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/deutsche-bahn/837/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-db-gtfs-1139.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/de-unknown-filsland-verkehrsverbund-gtfs-1183.json
+++ b/catalogs/sources/gtfs/schedule/de-unknown-filsland-verkehrsverbund-gtfs-1183.json
@@ -16,5 +16,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/filsland-verkehrsverbund/1185/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/de-unknown-filsland-verkehrsverbund-gtfs-1183.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/dz-unknown-societe-nationale-des-transports-ferroviaires-sntf-algeria-gtfs-1199.json
+++ b/catalogs/sources/gtfs/schedule/dz-unknown-societe-nationale-des-transports-ferroviaires-sntf-algeria-gtfs-1199.json
@@ -16,5 +16,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/societe-nationale-des-transports-ferroviaires/1084/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/dz-unknown-societe-nationale-des-transports-ferroviaires-sntf-algeria-gtfs-1199.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/fi-etela-pohjanmaa-komia-liikenne-gtfs-1255.json
+++ b/catalogs/sources/gtfs/schedule/fi-etela-pohjanmaa-komia-liikenne-gtfs-1255.json
@@ -19,5 +19,6 @@
         "direct_download": "https://transitfeeds.com/p/komia-liikenne/1225/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-etela-pohjanmaa-komia-liikenne-gtfs-1255.zip?alt=media",
         "license": "https://www.komialiikenne.fi"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-posely-gtfs-1317.json
+++ b/catalogs/sources/gtfs/schedule/fi-pohjois-karjala-posely-gtfs-1317.json
@@ -19,5 +19,6 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fi-pohjois-karjala-posely-gtfs-1317.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [],
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/fr-grand-est-reseau-stan-gtfs-1117.json
+++ b/catalogs/sources/gtfs/schedule/fr-grand-est-reseau-stan-gtfs-1117.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/grand-nancy/1068/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-grand-est-reseau-stan-gtfs-1117.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/fr-ile-de-france-regie-autonome-des-transports-parisiens-gtfs-1291.json
+++ b/catalogs/sources/gtfs/schedule/fr-ile-de-france-regie-autonome-des-transports-parisiens-gtfs-1291.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/regie-autonome-des-transports-parisiens/413/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-ile-de-france-regie-autonome-des-transports-parisiens-gtfs-1291.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-pays-de-la-loire-gtfs-1258.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-pays-de-la-loire-gtfs-1258.json
@@ -17,5 +17,6 @@
         "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/1071/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-pays-de-la-loire-gtfs-1258.zip?alt=media",
         "license": "http://opendatacommons.org/licenses/odbl/"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-tram-train-gtfs-1260.json
+++ b/catalogs/sources/gtfs/schedule/fr-pays-de-la-loire-tram-train-gtfs-1260.json
@@ -19,5 +19,6 @@
         "direct_download": "https://transitfeeds.com/p/region-des-pays-de-la-loire/1074/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/fr-pays-de-la-loire-tram-train-gtfs-1260.zip?alt=media",
         "license": "https://opendatacommons.org/licenses/odbl/"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/gb-unknown-chiltern-railways-gtfs-1311.json
+++ b/catalogs/sources/gtfs/schedule/gb-unknown-chiltern-railways-gtfs-1311.json
@@ -16,5 +16,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/association-of-train-operating-companies/284/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gb-unknown-chiltern-railways-gtfs-1311.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/gr-thessaloniki-trainose-gtfs-1161.json
+++ b/catalogs/sources/gtfs/schedule/gr-thessaloniki-trainose-gtfs-1161.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/trainose/1193/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/gr-thessaloniki-trainose-gtfs-1161.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/it-liguria-atp-esercizio-srl-gtfs-643.json
+++ b/catalogs/sources/gtfs/schedule/it-liguria-atp-esercizio-srl-gtfs-643.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/atp-esercizio-srl/1203/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-liguria-atp-esercizio-srl-gtfs-643.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/it-lombardia-azienda-varesina-trasporti-avt-gtfs-1264.json
+++ b/catalogs/sources/gtfs/schedule/it-lombardia-azienda-varesina-trasporti-avt-gtfs-1264.json
@@ -21,5 +21,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/azienda-varesina-trasporti/525/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-lombardia-azienda-varesina-trasporti-avt-gtfs-1264.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/it-piemonte-bus-company-srl-gtfs-1194.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-bus-company-srl-gtfs-1194.json
@@ -21,5 +21,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/cuneo/622/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-bus-company-srl-gtfs-1194.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/it-piemonte-regione-piemonte-gtfs-1154.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-regione-piemonte-gtfs-1154.json
@@ -18,5 +18,6 @@
         "direct_download": "https://transitfeeds.com/p/regione-piemonte/1192/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-regione-piemonte-gtfs-1154.zip?alt=media",
         "license": "http://www.dati.piemonte.it/catalogodati/dato/100939-.html"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/it-piemonte-trenitalia-piemonte-gtfs-1170.json
+++ b/catalogs/sources/gtfs/schedule/it-piemonte-trenitalia-piemonte-gtfs-1170.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/trenitalia-dtr-piemonte/931/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-piemonte-trenitalia-piemonte-gtfs-1170.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/it-sardegna-collegamenti-marittimi-grandi-navi-veloci-gtfs-1265.json
+++ b/catalogs/sources/gtfs/schedule/it-sardegna-collegamenti-marittimi-grandi-navi-veloci-gtfs-1265.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/collegamenti-marittimi-grandi-navi-veloci/1164/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/it-sardegna-collegamenti-marittimi-grandi-navi-veloci-gtfs-1265.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/nz-unknown-intercity-group-gtfs-1144.json
+++ b/catalogs/sources/gtfs/schedule/nz-unknown-intercity-group-gtfs-1144.json
@@ -16,5 +16,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/intercity-group/744/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/nz-unknown-intercity-group-gtfs-1144.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-bielawa-dzierzoniow-gtfs-1151.json
+++ b/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-bielawa-dzierzoniow-gtfs-1151.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/przyjazdy-pl/1206/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-dolnoslaskie-komunikacja-miejska-bielawa-dzierzoniow-gtfs-1151.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-boleslawiec-gtfs-1271.json
+++ b/catalogs/sources/gtfs/schedule/pl-dolnoslaskie-komunikacja-miejska-boleslawiec-gtfs-1271.json
@@ -18,5 +18,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/przyjazdy-pl-boles-awiec/1209/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-dolnoslaskie-komunikacja-miejska-boleslawiec-gtfs-1271.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-plock-gtfs-1150.json
+++ b/catalogs/sources/gtfs/schedule/pl-mazowieckie-komunikacja-miejska-plock-gtfs-1150.json
@@ -19,5 +19,6 @@
         "direct_download": "https://transitfeeds.com/p/przyjazdy-pl-plock/1211/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-mazowieckie-komunikacja-miejska-plock-gtfs-1150.zip?alt=media",
         "license": "https://gtfs.pl/gtfs/plock"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/pl-rybnik-ztz-rybnik-gtfs-1176.json
+++ b/catalogs/sources/gtfs/schedule/pl-rybnik-ztz-rybnik-gtfs-1176.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/ztz-rybnik/1114/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/pl-rybnik-ztz-rybnik-gtfs-1176.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/rs-sumadijski-okrug-kragujevac-gtfs-1273.json
+++ b/catalogs/sources/gtfs/schedule/rs-sumadijski-okrug-kragujevac-gtfs-1273.json
@@ -25,5 +25,6 @@
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/rs-sumadijski-okrug-kragujevac-gtfs-1273.zip?alt=media",
         "license": "https://www.kgbus.rs/"
     },
-    "redirect": []
+    "redirect": [],
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/ru-sankt-peterburg-peterburgskii-metropoliten-petersburg-metro-gtfs-1186.json
+++ b/catalogs/sources/gtfs/schedule/ru-sankt-peterburg-peterburgskii-metropoliten-petersburg-metro-gtfs-1186.json
@@ -20,5 +20,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/saint-petersburg/826/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/ru-sankt-peterburg-peterburgskii-metropoliten-petersburg-metro-gtfs-1186.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/tn-medenine-srtmedenine-gtfs-1158.json
+++ b/catalogs/sources/gtfs/schedule/tn-medenine-srtmedenine-gtfs-1158.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/srtmedenine/1204/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/tn-medenine-srtmedenine-gtfs-1158.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-biscay-la-burundesa-sa-gtfs-1316.json
+++ b/catalogs/sources/gtfs/schedule/us-biscay-la-burundesa-sa-gtfs-1316.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/la-burundesa/658/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-biscay-la-burundesa-sa-gtfs-1316.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-california-blue-gold-fleet-gtfs-1178.json
+++ b/catalogs/sources/gtfs/schedule/us-california-blue-gold-fleet-gtfs-1178.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/blue-gold-fleet/824/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-california-blue-gold-fleet-gtfs-1178.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-florida-sanford-trolley-gtfs-1157.json
+++ b/catalogs/sources/gtfs/schedule/us-florida-sanford-trolley-gtfs-1157.json
@@ -24,5 +24,6 @@
         "authentication_type": 0,
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-florida-sanford-trolley-gtfs-1157.zip?alt=media"
     },
-    "redirect": []
+    "redirect": [],
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-indiana-indygo-gtfs-1237.json
+++ b/catalogs/sources/gtfs/schedule/us-indiana-indygo-gtfs-1237.json
@@ -19,5 +19,6 @@
         "direct_download": "https://transitfeeds.com/p/indygo/210/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-indiana-indygo-gtfs-1237.zip?alt=media",
         "license": "http://www.indygo.net/about-indygo/indygo-developer-content-area/indygo-gtfs-terms-of-use/"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-ferry-service-gtfs-1309.json
+++ b/catalogs/sources/gtfs/schedule/us-massachusetts-massachusetts-ferry-service-gtfs-1309.json
@@ -17,5 +17,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/massdot/109/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-massachusetts-massachusetts-ferry-service-gtfs-1309.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }

--- a/catalogs/sources/gtfs/schedule/us-minnesota-rochester-city-lines-gtfs-1279.json
+++ b/catalogs/sources/gtfs/schedule/us-minnesota-rochester-city-lines-gtfs-1279.json
@@ -21,5 +21,6 @@
     "urls": {
         "direct_download": "https://transitfeeds.com/p/rochester-city-lines/774/latest/download",
         "latest": "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-minnesota-rochester-city-lines-gtfs-1279.zip?alt=media"
-    }
+    },
+    "is_producer_url_unstable": "True"
 }


### PR DESCRIPTION
Inactive mdb feeds that still need `is_producer_url_unstable` set to True or False

**note:** these are all transitfeed feeds again 

total remaining feeds (including non-mdb feeds): 
[identifying_unstable_url_feeds_____2026-09-11.html](https://github.com/user-attachments/files/32125369/identifying_unstable_url_feeds_____2026-09-11.html)

decision: [unstable_review.csv](https://github.com/user-attachments/files/32125335/unstable_review.csv)
